### PR TITLE
Fix Visit tracking

### DIFF
--- a/src/pages/SchedulePage.jsx
+++ b/src/pages/SchedulePage.jsx
@@ -159,7 +159,7 @@ function SchedulePage({ selectedEvent, playoffSchedule, qualSchedule, practiceSc
                         <Row style={{ cursor: "pointer", color: "darkblue" }} onClick={clickRemovePractice}>
                             <Col xs={2}></Col>
                             <Col xs={1}><img style={{ float: "left" }} width="50" src="images/excelicon.png" alt="Excel Logo" /></Col>
-                            <Col xs={7} className={"leftTable"}><b>You have uploaded a Practice Schedule.<br />Tap here to remove it.</b>
+                            <Col xs={7} className={"leftTable"}><b>You have uploaded a Practice Schedule.<br />Tap here to remove it. Know that we will automatically remove it when we get a Qualification Matches Schedule.</b>
                             </Col><Col xs={2}></Col>
                         </Row>
                     </Container>

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -140,6 +140,10 @@ function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedY
         setSelectedYear(supportedYears[0]);
     }
 
+    var updatedTeamList = localUpdates.map((update) => {
+        return update.teamNumber
+    })
+
     return (
         <Container fluid>
             {!isOnline && <Row>
@@ -208,7 +212,7 @@ function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedY
                         {playoffSchedule?.lastUpdate && <p><b>Playoff Schedule last updated: </b><br />{moment(playoffSchedule?.lastUpdate).format("ddd, MMM Do YYYY, " + timeFormat.value)}</p>}
                         {teamList?.lastUpdate && <p><b>Team List last updated: </b><br />{moment(teamList?.lastUpdate).format("ddd, MMM Do YYYY, " + timeFormat.value)}</p>}
                         {rankings?.lastUpdate && <p><b>Rankings last updated: </b><br />{moment(rankings?.lastUpdate).format("ddd, MMM Do YYYY, " + timeFormat.value)}</p>}
-                        {localUpdates.length > 0 && <Alert><p><b>You have updates that can be uploaded to gatool Cloud.</b></p><Button disabled={!isOnline} onClick={uploadLocalUpdates}>Upload to gatool Cloud now</Button></Alert>}
+                        {localUpdates.length > 0 && <Alert><p><b>You have {localUpdates.length === 1 ? "an update for team" : "updates for teams"} {updatedTeamList.join(", ")} that can be uploaded to gatool Cloud.</b></p><Button disabled={!isOnline} onClick={uploadLocalUpdates}>Upload to gatool Cloud now</Button></Alert>}
                         <Alert variant={"warning"}><p><b>Update Team Data</b><br />You can refresh your team data if it has changed on another device. <i><b>Know that we fetch all team data automatically when you load an event</b></i>, so you should not need this very often.</p><Button variant={"warning"} disabled={!isOnline} onClick={(e) => { getCommunityUpdates(true, e) }}>Update now</Button></Alert>
                     </Col>
                     <Col sm={4}>

--- a/src/pages/TeamDataPage.jsx
+++ b/src/pages/TeamDataPage.jsx
@@ -55,7 +55,7 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
     }
 
     const handleTrack = () => {
-        var visits = lastVisit;
+        var visits = _.cloneDeep(lastVisit);
         visits[`${updateTeam.teamNumber}`] = moment();
         setLastVisit(visits);
         setUpdateTeam(null);
@@ -70,7 +70,7 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
     }
 
     const handleSubmit = (mode, e) => {
-        var visits = lastVisit;
+        var visits = _.cloneDeep(lastVisit);
         visits[`${updateTeam.teamNumber}`] = moment();
         var communityUpdatesTemp = _.cloneDeep(communityUpdates);
         var update = _.filter(communityUpdatesTemp, { "teamNumber": updateTeam.teamNumber })[0];
@@ -127,8 +127,9 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
 
     const clearVisits = (single, e) => {
         if (single) {
-            var visits = lastVisit;
-            delete visits[`${updateTeam.teamNumber}`]
+            var visits = _.cloneDeep(lastVisit);
+            delete visits[`${updateTeam.teamNumber}`];
+            setLastVisit(visits);
         } else {
             setLastVisit({});
         }


### PR DESCRIPTION
Visit tracking was not persistent when a user reloaded the site. It is now persistent.

Also adding guidance about which teams have pending updates. Todo: discuss whether to load updates from the cache when reloading the site.

Closes #49 