### PR TITLE
Fix crasher in Playoffs and add support for Overtime 3

### DIFF
--- a/src/components/AllianceSelection.jsx
+++ b/src/components/AllianceSelection.jsx
@@ -322,10 +322,10 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
                             <InputGroup className="mb-3" >
                                 <InputGroup.Text>Filter the teams</InputGroup.Text>
                                 <Form.Control id={"filterControl"} type="number" placeholder="Enter a number" aria-label="Team Number" onChange={filterTeams} />
-                                {(_.filter(asArrays.availableTeams, { 'teamNumber': Number(teamFilter) }).length === 1) && <Button variant="primary" type="submit">Select this team</Button>}
+                                {(_.filter(asArrays?.availableTeams, { 'teamNumber': Number(teamFilter) }).length === 1) && <Button variant="primary" type="submit">Select this team</Button>}
                                 <span>    </span>
-                                {(asArrays.undo.length > 0) && <Button size="sm" onClick={handleUndo} active >Undo Previous Choice</Button>}
-                                {(asArrays.undo.length === 0) && <Button size="sm" onClick={handleUndo} disabled >Undo Previous Choice</Button>}
+                                {(asArrays?.undo?.length > 0) && <Button size="sm" onClick={handleUndo} active >Undo Previous Choice</Button>}
+                                {(asArrays?.undo?.length === 0) && <Button size="sm" onClick={handleUndo} disabled >Undo Previous Choice</Button>}
                                 <span>    </span><Button size="sm" variant="warning" onClick={handleReset} active>Restart Alliance Selection</Button>
                             </InputGroup>
                         </Form>
@@ -342,14 +342,14 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
                                                     {availColumns.map((column, index) => {
                                                         return (<td key={`availableTableColumn${index}`}>
                                                             {column.map((team) => {
-                                                                var declined = asArrays.declined.includes(team?.teamNumber);
+                                                                var declined = asArrays?.declined.includes(team?.teamNumber);
                                                                 return (
                                                                     <>
-                                                                        {(asArrays.nextChoice < allianceSelectionOrder.length && team.rank !== 1) &&
-                                                                            (String(team.teamNumber).startsWith(teamFilter) || teamFilter === "") && <div key={"availableButton" + team.teamNumber} className={declined ? "allianceDecline" : "allianceTeam"} onClick={(e) => handleShow(team, declined ? "declined" : "show", e)}><b>{team.teamNumber}</b></div>}
+                                                                        {(asArrays?.nextChoice < allianceSelectionOrder?.length && team.rank !== 1) &&
+                                                                            (String(team?.teamNumber).startsWith(teamFilter) || teamFilter === "") && <div key={"availableButton" + team?.teamNumber} className={declined ? "allianceDecline" : "allianceTeam"} onClick={(e) => handleShow(team, declined ? "declined" : "show", e)}><b>{team.teamNumber}</b></div>}
 
-                                                                        {(asArrays.nextChoice >= allianceSelectionOrder.length || team.rank === 1) &&
-                                                                            (String(team.teamNumber).startsWith(teamFilter) || teamFilter === "") && <div key={"availableButtonDisabled" + team.teamNumber} className={declined ? "allianceDecline" : "allianceTeam"} ><b>{team.teamNumber}</b></div>}
+                                                                        {(asArrays?.nextChoice >= allianceSelectionOrder?.length || team.rank === 1) &&
+                                                                            (String(team?.teamNumber).startsWith(teamFilter) || teamFilter === "") && <div key={"availableButtonDisabled" + team?.teamNumber} className={declined ? "allianceDecline" : "allianceTeam"} ><b>{team?.teamNumber}</b></div>}
                                                                     </>
                                                                 )
                                                             })}
@@ -372,10 +372,10 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
                                                         {backupTeams.map((team) => {
                                                             var declined = asArrays.declined.includes(team.teamNumber);
                                                             return (
-                                                                <>{(asArrays.nextChoice < allianceSelectionOrder.length) &&
-                                                                    <div key={"backupButton" + team.teamNumber} className={declined ? "allianceDecline" : "allianceTeam"} onClick={(e) => handleShow(team, declined ? "declined" : "show", e)}><b>{team.teamNumber}</b></div>}
-                                                                    {(asArrays.nextChoice >= allianceSelectionOrder.length) &&
-                                                                        <div key={"backupButtonDisabled" + team.teamNumber} className={declined ? "allianceDecline" : "allianceTeam"} ><b>{team.teamNumber}</b></div>}
+                                                                <>{(asArrays?.nextChoice < allianceSelectionOrder?.length) &&
+                                                                    <div key={"backupButton" + team?.teamNumber} className={declined ? "allianceDecline" : "allianceTeam"} onClick={(e) => handleShow(team, declined ? "declined" : "show", e)}><b>{team?.teamNumber}</b></div>}
+                                                                    {(asArrays?.nextChoice >= allianceSelectionOrder?.length) &&
+                                                                        <div key={"backupButtonDisabled" + team?.teamNumber} className={declined ? "allianceDecline" : "allianceTeam"} ><b>{team.teamNumber}</b></div>}
                                                                 </>
                                                             )
                                                         })}
@@ -393,7 +393,7 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
                                                         <tr key={`allianceDisplay${row[0]}`}>
                                                             {row.map((allianceNumber) => {
                                                                 var alliance = _.filter(alliances, { "number": allianceNumber })
-                                                                var allianceName = alliance[0].name;
+                                                                var allianceName = alliance[0]?.name;
                                                                 var captain = alliance[0]?.captain;
                                                                 if (captain) { captain.declined = asArrays?.declined?.includes(captain?.teamNumber); }
                                                                 var round1 = alliance[0]?.round1;
@@ -403,20 +403,20 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
                                                                 var round3 = alliance[0]?.round3;
                                                                 if (round3) { round3.declined = asArrays?.declined?.includes(round3?.teamNumber); }
                                                                 return (
-                                                                    (allianceNumber <= allianceCount?.count) ? <td className={allianceSelectionOrder[asArrays.nextChoice]?.number === allianceNumber ? "dropzone" : ""} key={`AllianceTable${allianceName}`}>
+                                                                    (allianceNumber <= allianceCount?.count) ? <td className={allianceSelectionOrder[asArrays?.nextChoice]?.number === allianceNumber ? "dropzone" : ""} key={`AllianceTable${allianceName}`}>
                                                                         <div><b>{allianceName}</b></div>
 
-                                                                        {(allianceNumber === asArrays.nextChoice + 1) && <div className={"alliancedrop allianceCaptain"} >Captain<div key={`${allianceName}captainAvailable`} className={captain?.declined ? "allianceDecline" : "allianceTeam"} onClick={(e) => handleShow(captain, allianceNumber === 1 ? "a1captain" : allianceNumber > 1 ? "captain" : captain.declined ? "declined" : "show", e)}>{captain?.teamNumber ? captain?.teamNumber : ""}</div></div>}
+                                                                        {(allianceNumber === asArrays?.nextChoice + 1) && <div className={"alliancedrop allianceCaptain"} >Captain<div key={`${allianceName}captainAvailable`} className={captain?.declined ? "allianceDecline" : "allianceTeam"} onClick={(e) => handleShow(captain, allianceNumber === 1 ? "a1captain" : allianceNumber > 1 ? "captain" : captain?.declined ? "declined" : "show", e)}>{captain?.teamNumber ? captain?.teamNumber : ""}</div></div>}
 
-                                                                        {(allianceNumber > asArrays.nextChoice + 1) && <div className={"alliancedrop allianceCaptain"} >Captain<div key={`${allianceName}captainAvailable`} className={captain?.declined ? "allianceDecline" : "allianceTeam"} onClick={(e) => handleShow(captain, captain.declined ? "declined" : "show", e)}>{captain?.teamNumber ? captain?.teamNumber : ""}</div></div>}
+                                                                        {(allianceNumber > asArrays.nextChoice + 1) && <div className={"alliancedrop allianceCaptain"} >Captain<div key={`${allianceName}captainAvailable`} className={captain?.declined ? "allianceDecline" : "allianceTeam"} onClick={(e) => handleShow(captain, captain?.declined ? "declined" : "show", e)}>{captain?.teamNumber ? captain?.teamNumber : ""}</div></div>}
 
-                                                                        {(allianceNumber < asArrays.nextChoice + 1) && <div className={"alliancedrop allianceCaptain"} >Captain<div key={`${allianceName}captainunavailable`} className={captain?.declined ? "allianceDecline" : "allianceTeam"} >{captain?.teamNumber ? captain?.teamNumber : ""}</div></div>}
+                                                                        {(allianceNumber < asArrays?.nextChoice + 1) && <div className={"alliancedrop allianceCaptain"} >Captain<div key={`${allianceName}captainunavailable`} className={captain?.declined ? "allianceDecline" : "allianceTeam"} >{captain?.teamNumber ? captain?.teamNumber : ""}</div></div>}
 
-                                                                        <div className={(allianceSelectionOrder[asArrays.nextChoice]?.number === allianceNumber) && (allianceSelectionOrder[asArrays.nextChoice]?.round === 1) ? "alliancedrop nextAllianceChoice" : "alliancedrop"}>1st choice{round1?.teamNumber ? <div key={`${allianceName}round1`} className={round1?.declined ? "allianceDecline" : "allianceTeam"}>{round1?.teamNumber}</div> : ""}</div>
+                                                                        <div className={(allianceSelectionOrder[asArrays?.nextChoice]?.number === allianceNumber) && (allianceSelectionOrder[asArrays?.nextChoice]?.round === 1) ? "alliancedrop nextAllianceChoice" : "alliancedrop"}>1st choice{round1?.teamNumber ? <div key={`${allianceName}round1`} className={round1?.declined ? "allianceDecline" : "allianceTeam"}>{round1?.teamNumber}</div> : ""}</div>
 
-                                                                        <div className={(allianceSelectionOrder[asArrays.nextChoice]?.number === allianceNumber) && (allianceSelectionOrder[asArrays.nextChoice]?.round === 2) ? "alliancedrop nextAllianceChoice" : "alliancedrop"}>2nd choice{round2?.teamNumber ? <div key={`${allianceName}round2`} className={"allianceTeam"}>{round2?.teamNumber}</div> : ""}</div>
+                                                                        <div className={(allianceSelectionOrder[asArrays?.nextChoice]?.number === allianceNumber) && (allianceSelectionOrder[asArrays?.nextChoice]?.round === 2) ? "alliancedrop nextAllianceChoice" : "alliancedrop"}>2nd choice{round2?.teamNumber ? <div key={`${allianceName}round2`} className={"allianceTeam"}>{round2?.teamNumber}</div> : ""}</div>
 
-                                                                        {inChamps && <div className={(allianceSelectionOrder[asArrays.nextChoice]?.number === allianceNumber) && (allianceSelectionOrder[asArrays.nextChoice]?.round === 3) ? "alliancedrop nextAllianceChoice" : "alliancedrop"}>3rd choice{round3?.teamNumber ? <div key={`${allianceName}round3`} className={"allianceTeam"}>{round3?.teamNumber}</div> : ""}</div>}
+                                                                        {inChamps && <div className={(allianceSelectionOrder[asArrays?.nextChoice]?.number === allianceNumber) && (allianceSelectionOrder[asArrays?.nextChoice]?.round === 3) ? "alliancedrop nextAllianceChoice" : "alliancedrop"}>3rd choice{round3?.teamNumber ? <div key={`${allianceName}round3`} className={"allianceTeam"}>{round3?.teamNumber}</div> : ""}</div>}
                                                                     </td> : <td></td>
                                                                 )
                                                             })}
@@ -434,18 +434,18 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
                         <Modal.Title >{allianceMode === "decline" ? "Team declines the offer" : allianceMode === "accept" ? "Are you sure they want to accept?" : allianceMode === "a1captaion" ? "Top Seeded Alliance" : "Alliance Choice"}</Modal.Title>
                     </Modal.Header>
                     <Modal.Body>
-                        {(allianceMode === "show" || allianceMode === "a1captain") && <span className={"allianceAnnounceDialog"}>Team {allianceTeam?.teamNumber} {allianceTeam?.updates?.nameShortLocal ? allianceTeam.updates.nameShortLocal : allianceTeam?.nameShort}<br />
+                        {(allianceMode === "show" || allianceMode === "a1captain") && <span className={"allianceAnnounceDialog"}>Team {allianceTeam?.teamNumber} {allianceTeam?.updates?.nameShortLocal ? allianceTeam?.updates.nameShortLocal : allianceTeam?.nameShort}<br />
                             is {(originalAndSustaining.indexOf(String(allianceTeam?.teamNumber)) >= 0) ? "an Original and Sustaining Team " : ""}from<br />
                             {allianceTeam?.updates?.organizationLocal ? allianceTeam?.updates?.organizationLocal : allianceTeam?.organization}<br />
                             in {allianceTeam?.updates?.cityStateLocal ? allianceTeam?.updates?.cityStateLocal : `${allianceTeam?.city}, ${allianceTeam?.stateProv}`}{allianceTeam?.country !== "USA" ? `, ${allianceTeam?.country}` : ""}<br /></span>}
-                        {allianceMode === "accept" && <span className={"allianceAnnounceDialog"}>Team {allianceTeam?.teamNumber} {allianceTeam?.updates?.nameShortLocal ? allianceTeam.updates.nameShortLocal : allianceTeam?.nameShort}<br />
+                        {allianceMode === "accept" && <span className={"allianceAnnounceDialog"}>Team {allianceTeam?.teamNumber} {allianceTeam?.updates?.nameShortLocal ? allianceTeam?.updates?.nameShortLocal : allianceTeam?.nameShort}<br />
                             has been asked to join Alliance {allianceSelectionOrder[asArrays.nextChoice]?.number}.<br />Do they accept?</span>}
                         {allianceMode === "decline" && <span className={"allianceAnnounceDialog"}>Team {allianceTeam?.teamNumber} {allianceTeam?.updates?.nameShortLocal ? allianceTeam?.updates?.nameShortLocal : allianceTeam?.nameShort}<br />
-                            has declined the offer from Alliance {allianceSelectionOrder[asArrays.nextChoice]?.number}.<br />They will become inelegible to be selected by another team or to continue as a backup team in the playoffs. Do they decline?</span>}
-                        {allianceMode === "declined" && <span className={"allianceAnnounceDialog"}>Team {allianceTeam?.teamNumber} {allianceTeam?.updates?.nameShortLocal ? allianceTeam.updates.nameShortLocal : allianceTeam?.nameShort}<br />
+                            has declined the offer from Alliance {allianceSelectionOrder[asArrays?.nextChoice]?.number}.<br />They will become inelegible to be selected by another team or to continue as a backup team in the playoffs. Do they decline?</span>}
+                        {allianceMode === "declined" && <span className={"allianceAnnounceDialog"}>Team {allianceTeam?.teamNumber} {allianceTeam?.updates?.nameShortLocal ? allianceTeam?.updates?.nameShortLocal : allianceTeam?.nameShort}<br />
                             has previously declined an offer. They are inelegible to be selected by another alliance.</span>}
                         {allianceMode === "a1captain" && <span className={"allianceAnnounceDialog"}><br />Team {allianceTeam?.teamNumber} is our top seeded Alliance. They are inelegible to be selected by another alliance.</span>}
-                        {allianceMode === "captain" && <span className={"allianceAnnounceDialog"}>Team {allianceTeam?.teamNumber} {allianceTeam?.updates?.nameShortLocal ? allianceTeam.updates.nameShortLocal : allianceTeam?.nameShort}<br />
+                        {allianceMode === "captain" && <span className={"allianceAnnounceDialog"}>Team {allianceTeam?.teamNumber} {allianceTeam?.updates?.nameShortLocal ? allianceTeam?.updates?.nameShortLocal : allianceTeam?.nameShort}<br />
                             is an Alliance Captain. They are inelegible to be selected by another alliance.</span>}
 
                     </Modal.Body>

--- a/src/components/Bracket.jsx
+++ b/src/components/Bracket.jsx
@@ -38,23 +38,59 @@ function Bracket({ selectedEvent, playoffSchedule, alliances }) {
 		var allianceName = "";
 		if (matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.teams[0]?.teamNumber) {
 			allianceName = alliances?.Lookup[`${matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.teams[0]?.teamNumber}`]?.alliance;
-			if (matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.winner.tieWinner === "red") {
-				allianceName += ` (L${matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.winner.level})`;
-			}
-			if (allianceColor === "blue") {
-				allianceName = alliances?.Lookup[`${matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.teams[3]?.teamNumber}`]?.alliance
-				if (matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.winner.tieWinner === "blue") {
-					allianceName += ` (L${matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.winner.level} WIN)`;
+			if (matchNumber <= 13 || matchNumber === 19) {
+				if (matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.winner.tieWinner === "red") {
+					allianceName += ` (L${matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.winner.level})`;
 				}
 			}
+			if (allianceColor === "blue") {
+				allianceName = alliances?.Lookup[`${matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.teams[3]?.teamNumber}`]?.alliance;
+				if (matchNumber <= 13 || matchNumber === 19) {
+					if (matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.winner.tieWinner === "blue") {
+						allianceName += ` (L${matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.winner.level} WIN)`;
+					}
+				}
+
+			}
+
+
 		}
 		return allianceName;
 	}
 	var overtimeOffset = 0;
-	if (matches[17]?.postResultTime) {
+	var tournamentWinner = {
+		"red": 0,
+		"blue": 0,
+		"winner": "",
+		"level": 0
+	}
+	if (matches[18]?.postResultTime) {
+		overtimeOffset = 45;
+
+	} else if (matches[17]?.postResultTime) {
 		overtimeOffset = 30;
 	} else if (matches[16]?.postResultTime) {
 		overtimeOffset = 15;
+	}
+
+	for (var finalsMatches = 14; finalsMatches < 19; finalsMatches++) {
+		if (matches[_.findIndex(matches, { "matchNumber": finalsMatches })]?.winner.winner === "red") {
+			tournamentWinner.red += 1
+		}
+		if (matches[_.findIndex(matches, { "matchNumber": finalsMatches })]?.winner.winner === "blue") {
+			tournamentWinner.blue += 1
+		}
+	}
+	if (tournamentWinner.red === 2) {
+		tournamentWinner.winner = "red";
+	} else if (tournamentWinner.blue === 2) {
+		tournamentWinner.winner = "blue";
+	} else if (matches[18]?.winner.tieWinner === "red") {
+		tournamentWinner.winner = "red";
+		tournamentWinner.level = matches[18]?.winner.level;
+	} else if (matches[18]?.winner.tieWinner === "blue") {
+		tournamentWinner.winner = "blue";
+		tournamentWinner.level = matches[18]?.winner.level;
 	}
 
 	return (
@@ -97,12 +133,12 @@ function Bracket({ selectedEvent, playoffSchedule, alliances }) {
 				</g>
 				<g id="finals">
 					<g id="finalsContainer">
-					<path id="finalsBackground" fill="#C1C1C1" stroke="#000000" strokeWidth="2" strokeMiterlimit="10" d="M1254.5,511.6H1024c-5.5,0-10-4.5-10-10V343.4c0-5.5,4.5-10,10-10h230.5
+						<path id="finalsBackground" fill="#C1C1C1" stroke="#000000" strokeWidth="2" strokeMiterlimit="10" d="M1254.5,511.6H1024c-5.5,0-10-4.5-10-10V343.4c0-5.5,4.5-10,10-10h230.5
 		c5.5,0,10,4.5,10,10v158.1C1264.5,507.1,1260,511.6,1254.5,511.6z"/>
-						<polygon fill={RED} points="1164.7,389.6 1048.4,389.6 1048.4,353.5 1164.7,353.5 1177.6,371.6" />
-						<polygon fill={BLUE} points="1164.7,426 1048.4,426 1048.4,390 1164.7,390 1177.6,408" />
+						<polygon fill={RED} points="1164.7,389.6 1048.4,389.6 1048.4,353.5 1164.7,353.5 1177.6,371.6" stroke={(tournamentWinner?.winner === "red") ? GOLD : "none"} strokeWidth="5" />
+						<polygon fill={BLUE} points="1164.7,426 1048.4,426 1048.4,390 1164.7,390 1177.6,408" stroke={(tournamentWinner?.winner === "blue") ? GOLD : "none"} strokeWidth="5" />
 						<line fill="none" stroke="#FFFFFF" strokeMiterlimit="10" x1="1164.7" y1="389.7" x2="1026" y2="389.7" />
-						<rect x="1026" y="353.5" width="22.4" height="72.5"/>
+						<rect x="1026" y="353.5" width="22.4" height="72.5" />
 						<text transform="matrix(0 -1.0059 1 0 1041.7773 418.6328)" fill="#FFFFFF" fontFamily="'myriad-pro'" fontWeight={bold} fontStyle={"normal"} fontSize="12.076px">BEST 2 of 3</text>
 						<text transform="matrix(0.9941 0 0 1 1106 367)" textAnchor="middle">
 							<tspan x="0" y="0" fill="#FFFFFF" fontFamily="'myriad-pro'" fontWeight={bold} fontStyle={"normal"} fontSize="12.1471px">{allianceName(14, "red") ? allianceName(14, "red") : "Winner of M11"}</tspan>
@@ -130,9 +166,9 @@ function Bracket({ selectedEvent, playoffSchedule, alliances }) {
 						<path fill="#FFA200" d="M1225.08,362.82c0,15.56-3.34,28.17-7.46,28.17c8.24,0,14.91-12.61,14.91-28.17H1225.08z" />
 						<path fill="#FEE79B" d="M1208.61,362.82h-2.18c0,15.56,5.01,28.17,11.19,28.17C1212.64,390.99,1208.61,378.38,1208.61,362.82z" />
 					</g>
-					
-					<circle id="winnerMatch1Dot" fill={(matches[13]?.winner.winner === "red") ? RED : (matches[13]?.winner.winner === "blue") ? BLUE : (matches[13]?.winner.winner === "tie") ? GREEN : "none"} cx={`${1110-overtimeOffset}`} cy="451" r="8" />
-					<text id="finalsM1Scores" transform={`matrix(1 0 0 1 ${1110-overtimeOffset} 477.5537)`}>
+
+					<circle id="winnerMatch1Dot" fill={(matches[13]?.winner.winner === "red") ? RED : (matches[13]?.winner.winner === "blue") ? BLUE : (matches[13]?.winner.winner === "tie") ? GREEN : "none"} cx={`${1110 - overtimeOffset}`} cy="451" r="8" />
+					<text id="finalsM1Scores" transform={`matrix(1 0 0 1 ${1110 - overtimeOffset} 477.5537)`}>
 						<tspan x="0" y="0" fill={RED} fontFamily="'myriad-pro'"
 							fontWeight={(matches[13]?.winner.winner === "red") ? black : semibold}
 							fontStyle={"normal"}
@@ -143,8 +179,8 @@ function Bracket({ selectedEvent, playoffSchedule, alliances }) {
 							fontSize="14px" textAnchor="middle">{matches[13]?.scoreBlueFinal}</tspan>
 					</text>
 
-					<circle id="winnerMatch2Dot" fill={(matches[14]?.winner.winner === "red") ? RED : (matches[14]?.winner.winner === "blue") ? BLUE : (matches[14]?.winner.winner === "tie") ? GREEN : "none"} cx={`${1140-overtimeOffset}`}cy="451" r="8" />
-					<text id="finalsM2Scores" transform={`matrix(1 0 0 1 ${1140-overtimeOffset} 477.5537)`}>
+					<circle id="winnerMatch2Dot" fill={(matches[14]?.winner.winner === "red") ? RED : (matches[14]?.winner.winner === "blue") ? BLUE : (matches[14]?.winner.winner === "tie") ? GREEN : "none"} cx={`${1140 - overtimeOffset}`} cy="451" r="8" />
+					<text id="finalsM2Scores" transform={`matrix(1 0 0 1 ${1140 - overtimeOffset} 477.5537)`}>
 						<tspan x="0" y="0"
 							fill={RED}
 							fontFamily="'myriad-pro'"
@@ -158,9 +194,9 @@ function Bracket({ selectedEvent, playoffSchedule, alliances }) {
 							fontSize="14px" textAnchor="middle">{matches[14]?.scoreBlueFinal}</tspan>
 					</text>
 
-					<circle id="winnerMatch3Dot" fill={(matches[15]?.winner.winner === "red") ? RED : (matches[15]?.winner.winner === "blue") ? BLUE : (matches[15]?.winner.winner === "tie") ? GREEN : "none"} cx={`${1170-overtimeOffset}`}cy="451" r="8" />
+					<circle id="winnerMatch3Dot" fill={(matches[15]?.winner.winner === "red") ? RED : (matches[15]?.winner.winner === "blue") ? BLUE : (matches[15]?.winner.winner === "tie") ? GREEN : "none"} cx={`${1170 - overtimeOffset}`} cy="451" r="8" />
 					<text id="finalsM3Scores"
-						transform={`matrix(1 0 0 1 ${1170-overtimeOffset} 477.5537)`}>
+						transform={`matrix(1 0 0 1 ${1170 - overtimeOffset} 477.5537)`}>
 						<tspan x="0" y="0"
 							fill={RED}
 							fontFamily="'myriad-pro'"
@@ -174,9 +210,9 @@ function Bracket({ selectedEvent, playoffSchedule, alliances }) {
 							fontSize="14px" textAnchor="middle">{matches[15]?.scoreBlueFinal}</tspan>
 					</text>
 
-					<circle id="winnerMatch4Dot" fill={(matches[16]?.winner.winner === "red") ? RED : (matches[16]?.winner.winner === "blue") ? BLUE : (matches[16]?.winner.winner === "tie") ? GREEN : "none"} cx={`${1170+overtimeOffset}`}cy="451" r="8" />
+					<circle id="winnerMatch4Dot" fill={(matches[16]?.winner.winner === "red") ? RED : (matches[16]?.winner.winner === "blue") ? BLUE : (matches[16]?.winner.winner === "tie") ? GREEN : "none"} cx={`${1170 + overtimeOffset}`} cy="451" r="8" />
 					<text id="finalsM4Scores"
-						transform={`matrix(1 0 0 1 ${1170+overtimeOffset} 477.5537)`}>
+						transform={`matrix(1 0 0 1 ${1170 + overtimeOffset} 477.5537)`}>
 						<tspan x="0" y="0"
 							fill={RED}
 							fontFamily="'myriad-pro'"
@@ -205,8 +241,24 @@ function Bracket({ selectedEvent, playoffSchedule, alliances }) {
 							fontStyle={"normal"}
 							fontSize="14px" textAnchor="middle">{matches[17]?.scoreBlueFinal}</tspan>
 					</text>
+
+					<circle id="winnerMatch6Dot" fill={(matches[18]?.winner.winner === "red") ? RED : (matches[18]?.winner.winner === "blue") ? BLUE : (matches[18]?.winner.winner === "tie") ? GREEN : "none"} cx={`${1200 + overtimeOffset}`} cy="451" r="8" />
+					<text id="finalsM5Scores"
+						transform={`matrix(1 0 0 1 ${1200 + overtimeOffset} 477.5537)`}>
+						<tspan x="0" y="0"
+							fill={RED}
+							fontFamily="'myriad-pro'"
+							fontWeight={(matches[18]?.winner.winner === "red") ? black : semibold}
+							fontStyle={"normal"}
+							fontSize="14px" textAnchor="middle">{matches[18]?.scoreRedFinal}</tspan>
+						<tspan x="0" y="14" fill={BLUE}
+							fontFamily="'myriad-pro'"
+							fontWeight={(matches[18]?.winner.winner === "blue") ? black : semibold}
+							fontStyle={"normal"}
+							fontSize="14px" textAnchor="middle">{matches[18]?.scoreBlueFinal}</tspan>
+					</text>
 				</g>
-				
+
 
 				<g id="match13">
 					<g>

--- a/src/pages/AllianceSelectionPage.jsx
+++ b/src/pages/AllianceSelectionPage.jsx
@@ -31,7 +31,7 @@ function AllianceSelectionPage({ selectedYear, selectedEvent, qualSchedule, play
                     <p>When it's time for Alliance Selection, simply tap a team when their number is called. If they accept, tap <b>Gratefully Accept.</b> If they decline, tap <b>Respectfully Decline.</b></p>
                     {!allianceSelection && <Alert variant="danger" ><div onClick={getRanks}><b>Do not proceed with Alliance Selection until you confirm that the rank order below agrees with the rank order in FMS. Check the Alliance leaders and the teams in the Backup Teams box. Tap this alert to see if we can get a more current schedule and rankings.</b></div>
                         <Container fluid><Row className="align-items-center"><Col xs={10}>If you believe that your ranks are correct, and you need to proceed with Alliance Selection even though our confidence is low, you can do so by enabling this option:</Col>
-                            <Col xs={2} AlignMiddle><Switch
+                            <Col xs={2}><Switch
                                 checked={overrideAllianceSelection}
                                 onChange={setOverrideAllianceSelection}
                                 height={20}


### PR DESCRIPTION
User identified a crasher on Playoff page, caused when reloading event when on the /allianceselection route. This is now fixed. Closes #72
Users do not see which Alliance won the event. This is now indicated with a gold outline for the Finals matches. Closes #73
Playoffs did not support 3 overtime matches, which are indicted in the rules. We have added another Finals match to support, and we are testing for the winner based on match 18 tiebreaker in the event of repeated ties. Closes #71