### PR TITLE
Add a way to show the history of team data updates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -884,6 +884,13 @@ function App() {
     return result;
   }
 
+  // This function reads the team data update history gatool Cloud.
+  async function getTeamHistory(teamNumber) {
+    var result = await httpClient.get(`team/${teamNumber}/updates/history/`);
+    var history = await result.json();
+    return history;
+  }
+
   const nextMatch = () => {
     if (!_.isNull(practiceSchedule) && (currentMatch < practiceSchedule?.schedule?.length)) {
       setCurrentMatch(currentMatch + 1);
@@ -1157,7 +1164,7 @@ function App() {
 
               <Route path="/schedule" element={<SchedulePage selectedEvent={selectedEvent} playoffSchedule={playoffSchedule} qualSchedule={qualSchedule} practiceSchedule={practiceSchedule} setPracticeSchedule={setPracticeSchedule} />} />
 
-              <Route path="/teamdata" element={<TeamDataPage selectedEvent={selectedEvent} selectedYear={selectedYear} teamList={teamList} rankings={rankings} teamSort={teamSort} setTeamSort={setTeamSort} communityUpdates={communityUpdates} setCommunityUpdates={setCommunityUpdates} allianceCount={allianceCount} lastVisit={lastVisit} setLastVisit={setLastVisit} putTeamData={putTeamData} localUpdates={localUpdates} setLocalUpdates={setLocalUpdates} qualSchedule={qualSchedule} playoffSchedule={playoffSchedule} originalAndSustaining={originalAndSustaining} monthsWarning={monthsWarning} user={user}/>} />
+              <Route path="/teamdata" element={<TeamDataPage selectedEvent={selectedEvent} selectedYear={selectedYear} teamList={teamList} rankings={rankings} teamSort={teamSort} setTeamSort={setTeamSort} communityUpdates={communityUpdates} setCommunityUpdates={setCommunityUpdates} allianceCount={allianceCount} lastVisit={lastVisit} setLastVisit={setLastVisit} putTeamData={putTeamData} localUpdates={localUpdates} setLocalUpdates={setLocalUpdates} qualSchedule={qualSchedule} playoffSchedule={playoffSchedule} originalAndSustaining={originalAndSustaining} monthsWarning={monthsWarning} user={user} getTeamHistory={getTeamHistory} timeFormat={timeFormat}/>} />
 
               <Route path='/ranks' element={<RanksPage selectedEvent={selectedEvent} teamList={teamList} rankings={rankings} rankSort={rankSort} setRankSort={setRankSort} allianceCount={allianceCount} rankingsOverride={rankingsOverride} setRankingsOverride={setRankingsOverride} allianceSelection={allianceSelection} getRanks={getRanks} setRankings={setRankings} setAllianceSelectionArrays={setAllianceSelectionArrays} playoffs={playoffs} districtRankings={districtRankings} />} />
 

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -86,7 +86,7 @@ const monthsWarningMenu = [
 
 
 
-function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedYear, eventList, teamList, qualSchedule, playoffSchedule, rankings, eventFilters, setEventFilters, timeFilter, setTimeFilter, timeFormat, setTimeFormat, showSponsors, setShowSponsors, showAwards, setShowAwards, showNotes, setShowNotes, showMottoes, setShowMottoes, showChampsStats, setShowChampsStats, swapScreen, setSwapScreen, autoAdvance, setAutoAdvance, getSchedule, awardsMenu, setAwardsMenu, showQualsStats, setShowQualsStats, showQualsStatsQuals, setShowQualsStatsQuals,teamReduction, setTeamReduction, playoffCountOverride, setPlayoffCountOverride, allianceCount, localUpdates, setLocalUpdates, putTeamData, getCommunityUpdates, reverseEmcee, setReverseEmcee, showDistrictChampsStats, setShowDistrictChampsStats, monthsWarning, setMonthsWarning, user }) {
+function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedYear, eventList, teamList, qualSchedule, playoffSchedule, rankings, eventFilters, setEventFilters, timeFilter, setTimeFilter, timeFormat, setTimeFormat, showSponsors, setShowSponsors, showAwards, setShowAwards, showNotes, setShowNotes, showMottoes, setShowMottoes, showChampsStats, setShowChampsStats, swapScreen, setSwapScreen, autoAdvance, setAutoAdvance, getSchedule, awardsMenu, setAwardsMenu, showQualsStats, setShowQualsStats, showQualsStatsQuals, setShowQualsStatsQuals, teamReduction, setTeamReduction, playoffCountOverride, setPlayoffCountOverride, allianceCount, localUpdates, setLocalUpdates, putTeamData, getCommunityUpdates, reverseEmcee, setReverseEmcee, showDistrictChampsStats, setShowDistrictChampsStats, monthsWarning, setMonthsWarning, user }) {
     const isOnline = useOnlineStatus();
 
     const [deleteSavedModal, setDeleteSavedModal] = useState(null);
@@ -237,7 +237,7 @@ function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedY
                         {playoffSchedule?.matchesLastModified && <p><b>Playoff Results last updated: </b><br />{moment(playoffSchedule?.matchesLastModified).format("ddd, MMM Do YYYY, " + timeFormat.value)}</p>}
                         {teamList?.lastUpdate && <p><b>Team List last updated: </b><br />{moment(teamList?.lastUpdate).format("ddd, MMM Do YYYY, " + timeFormat.value)}</p>}
                         {rankings?.lastModified && <p><b>Rankings last updated: </b><br />{moment(rankings?.lastModified).format("ddd, MMM Do YYYY, " + timeFormat.value)}</p>}
-                        {localUpdates.length > 0 && <Alert><p><b>You have {localUpdates.length === 1 ? "an update for team" : "updates for teams"} {_.sortBy(updatedTeamList).join(", ")} that can be uploaded to gatool Cloud.</b></p><span><Button disabled={!isOnline} onClick={uploadLocalUpdates}>Upload to gatool Cloud now</Button>  <Button disabled={!isOnline} variant={"warning"} onClick={deleteLocalUpdates}>Delete stored updates</Button></span></Alert>}
+                        {((user["https://gatool.org/roles"].indexOf("user") >= 0) && localUpdates.length > 0) && <Alert><p><b>You have {localUpdates.length === 1 ? "an update for team" : "updates for teams"} {_.sortBy(updatedTeamList).join(", ")} that can be uploaded to gatool Cloud.</b></p><span><Button disabled={!isOnline} onClick={uploadLocalUpdates}>Upload to gatool Cloud now</Button>  <Button disabled={!isOnline} variant={"warning"} onClick={deleteLocalUpdates}>Delete stored updates</Button></span></Alert>}
                         <Alert variant={"warning"}><p><b>Update Team Data</b><br />You can refresh your team data if it has changed on another device. <i><b>Know that we fetch all team data automatically when you load an event</b></i>, so you should not need this very often.</p><Button variant={"warning"} disabled={!isOnline} onClick={(e) => { getCommunityUpdates(true, e) }}>Update now</Button></Alert>
                     </Col>
                     <Col sm={4}>
@@ -334,7 +334,7 @@ function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedY
                                 </tr>
                                 <tr>
                                     <td colSpan={2}>
-                                    <label><b>How many months before we consider a team's data to be stale? The default is 6 months.</b><Select options={monthsWarningMenu} value={monthsWarning ? monthsWarning : monthsWarningMenu[2]} onChange={setMonthsWarning} /></label>
+                                        <label><b>How many months before we consider a team's data to be stale? The default is 6 months.</b><Select options={monthsWarningMenu} value={monthsWarning ? monthsWarning : monthsWarningMenu[2]} onChange={setMonthsWarning} /></label>
                                     </td>
                                 </tr>
                                 <tr>

--- a/src/pages/TeamDataPage.jsx
+++ b/src/pages/TeamDataPage.jsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Container, Form, InputGroup, Modal, Table } from "react-bootstrap";
+import { Alert, Button, Col, Container, Form, InputGroup, Modal, Row, Table } from "react-bootstrap";
 import { SortAlphaDown, SortAlphaUp, SortNumericDown, SortNumericUp } from 'react-bootstrap-icons';
 import { merge, orderBy, find } from "lodash";
 import { rankHighlight } from "../components/HelperFunctions";
@@ -14,7 +14,7 @@ import PizZipUtils from "pizzip/utils/index.js";
 import { saveAs } from "file-saver";
 import { useHotkeysContext } from "react-hotkeys-hook";
 
-function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSort, setTeamSort, communityUpdates, setCommunityUpdates, allianceCount, lastVisit, setLastVisit, putTeamData, localUpdates, setLocalUpdates, qualSchedule, playoffSchedule, originalAndSustaining, monthsWarning, user }) {
+function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSort, setTeamSort, communityUpdates, setCommunityUpdates, allianceCount, lastVisit, setLastVisit, putTeamData, localUpdates, setLocalUpdates, qualSchedule, playoffSchedule, originalAndSustaining, monthsWarning, user, getTeamHistory, timeFormat }) {
     const [currentTime, setCurrentTime] = useState(moment());
     const { disableScope, enableScope } = useHotkeysContext();
 
@@ -58,6 +58,8 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
     const [updateTeam, setUpdateTeam] = useState(null);
     const [formValue, setFormValue] = useState(null);
     const [gaName, setGaName] = useState("");
+    const [showHistory, setShowHistory] = useState(false);
+    const [teamHistory, setTeamHistory] = useState(null);
 
     const handleClose = () => {
         setUpdateTeam(null);
@@ -138,6 +140,21 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
             setShow(true);
             disableScope('tabNavigation');
         }
+    }
+
+    const handleHistory = async (team, e) => {
+        if (user["https://gatool.org/roles"].indexOf("user") >= 0) {
+            var history = await getTeamHistory(team.teamNumber);
+            setShowHistory(true);
+            setTeamHistory(_.orderBy(history, ['modifiedDate'], ['desc']));
+            disableScope('tabNavigation');
+        }
+    }
+
+    const handleCloseHistory = () => {
+        setShowHistory(false);
+        setTeamHistory(null);
+        enableScope('tabNavigation');
     }
 
     const clearVisits = (single, e) => {
@@ -551,8 +568,9 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
                 </Modal.Header>
                 <Modal.Body>
                     <p>Use this form to update team information for <b>Team {updateTeam.teamNumber}.</b> Editable fields are shown below. Your changes will be stored locally on your machine and should not be erased if you close your browser. We do recommend using the Save to Home Screen feature on Android and iOS, and the Save App feature from Chrome on desktop, if you are offline.</p>
-                    <p>Tap on each item to update its value. Tap <b>DONE</b> when you're finished editing, or browse to another tab to cancel editing. Items <span className={"teamTableHighlight"}><b>highlighted in green</b></span> have local changes. Motto and Notes do not exist in TIMS, so they are always local. To reset any value to the TIMS value, simply delete it here and tap DONE.</p>
-                    <p>You can load changes to Team Data from gatool Cloud, or you can sync your local values with gatool Cloud using the buttons at the bottom of this screen.</p>
+                    <p>Tap on each item to update its value. Tap <b>DONE</b> when you're finished editing, or browse to another tab to cancel editing. Items <span className={"teamTableHighlight"}><b>highlighted in green</b></span> have local changes. <b>Motto</b> and <b>Notes</b> do not exist in TIMS, so they are always local. To reset any value to the TIMS value, simply delete it here and tap DONE.</p>
+                    <p>You can upload your local values to gatool Cloud using the buttons at the bottom of this screen.</p>
+                    <p onClick={(e) => handleHistory(updateTeam, e)}><b>Tap here to see prior team data updates.</b></p>
                     <div className={updateClass(updateTeam?.lastUpdate)}><p>Last updated in gatool Cloud: {moment(updateTeam?.lastUpdate).fromNow()}</p></div>
                     <Form>
                         <Form.Group controlId="teamName">
@@ -629,6 +647,67 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
                     <br />
                 </Modal.Footer>
             </Modal>}
+
+            <Modal fullscreen={true} centered={true} show={showHistory} onHide={handleCloseHistory}>
+                <Modal.Header className={"allianceChoice"} closeVariant={"white"} closeButton>
+                    <Modal.Title >Team Update History</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <p>The table below shows the recorded values for each of the customizable fields we record in gatool Cloud.</p>
+                    <Table bordered striped size="sm">
+                        <thead><tr>
+                            <td>Date modified</td>
+                            <td>Team Name</td>
+                            <td>Org Name</td>
+                            <td>Robot Name</td>
+                            <td>Motto</td>
+                            <td>City/State</td>
+                            <td>Top Sponsors</td>
+                            <td>Awards text</td>
+                            <td>Team Table Notes</td>
+                            <td>Announce Screen Notes</td>
+                            {(user["https://gatool.org/roles"].indexOf("admin") >= 0) && <td>
+                                Source</td>}
+                        </tr>
+                        </thead>
+                        <tbody>
+                            <tr key={updateTeam?.lastUpdate}>
+                                <td>{moment(updateTeam?.lastUpdate).format("MMM Do YYYY, " + timeFormat.value)}</td>
+                                <td>{updateTeam?.nameShortLocal}</td>
+                                <td>{updateTeam?.organizationLocal}</td>
+                                <td>{updateTeam?.robotNameLocal}</td>
+                                <td>{updateTeam?.teamMottoLocal}</td>
+                                <td>{updateTeam?.cityStateLocal}</td>
+                                <td>{updateTeam?.topSponsorsLocal}</td>
+                                <td>{updateTeam?.awardsTextLocal}</td>
+                                <td>{updateTeam?.teamNotes}</td>
+                                <td>{updateTeam?.teamNotesLocal}</td>
+                                {(user["https://gatool.org/roles"].indexOf("admin") >= 0) && <td>
+                                    {updateTeam?.source}</td>}
+                            </tr>
+                            {teamHistory && teamHistory.map((team) => {
+                                return <tr key={team?.lastUpdate}>
+                                    <td>{moment(team?.lastUpdate).format("MMM Do YYYY, " + timeFormat.value)}</td>
+                                    <td>{team?.nameShortLocal}</td>
+                                    <td>{team?.organizationLocal}</td>
+                                    <td>{team?.robotNameLocal}</td>
+                                    <td>{team?.teamMottoLocal}</td>
+                                    <td>{team?.cityStateLocal}</td>
+                                    <td>{team?.topSponsorsLocal}</td>
+                                    <td>{team?.awardsTextLocal}</td>
+                                    <td>{team?.teamNotes}</td>
+                                    <td>{team?.teamNotesLocal}</td>
+                                    {(user["https://gatool.org/roles"].indexOf("admin") >= 0) && <td>
+                                        {team?.source}</td>}
+                                </tr>
+                            })}</tbody>
+                    </Table>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button variant="success" size="sm" onClick={handleCloseHistory}>close</Button>
+                </Modal.Footer>
+            </Modal>
+
         </Container>
     )
 }

--- a/src/pages/TeamDataPage.jsx
+++ b/src/pages/TeamDataPage.jsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Col, Container, Form, InputGroup, Modal, Row, Table } from "react-bootstrap";
+import { Alert, Button, Container, Form, InputGroup, Modal, Table } from "react-bootstrap";
 import { SortAlphaDown, SortAlphaUp, SortNumericDown, SortNumericUp } from 'react-bootstrap-icons';
 import { merge, orderBy, find } from "lodash";
 import { rankHighlight } from "../components/HelperFunctions";


### PR DESCRIPTION
Added tap area to Team Info page that opens a new modal. The modal contains a table showing the historical changes to the team's data. Closes #171