### PR TITLE
Fixing EI Team bug for District Champs events

### DIFF
--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -1,6 +1,12 @@
 
 export const appUpdates = [
     {
+        date: "March 26, 2024",
+        message: <ul>
+            <li>Fixed bug that prevented District Champs EI teams' community updates from loading</li>
+            <li>Added Restore option to Team update History</li>
+        </ul>
+    },{
         date: "March 25, 2024",
         message: <ul>
             <li>Added contextual warning to Reload cached gatool code if browser doesn't support PWA</li>

--- a/src/components/Constants.jsx
+++ b/src/components/Constants.jsx
@@ -1079,6 +1079,26 @@ export const specialAwards = [
     }]
 }
 ]
+
+export const communityUpdateTemplate = {
+    "nameShortLocal": "",
+    "cityStateLocal": "",
+    "topSponsorsLocal": "",
+    "sponsorsLocal": "",
+    "organizationLocal": "",
+    "robotNameLocal": "",
+    "awardsLocal": "",
+    "teamMottoLocal": "",
+    "teamNotesLocal": "",
+    "teamYearsNoCompeteLocal": "",
+    "showRobotName": "",
+    "teamNotes": "",
+    "sayNumber": "",
+    "awardsTextLocal":"",
+    "lastUpdate": "",
+    "source": ""
+  }
+
 export const originalAndSustaining = ["20", "45", "126", "148", "151", "157", "190", "191", "250"];
 
 //Championship events receive special treatment. We define the Championship events here, including Michigan.

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -84,10 +84,6 @@ const monthsWarningMenu = [
 function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedYear, eventList, teamList, qualSchedule, playoffSchedule, rankings, eventFilters, setEventFilters, timeFilter, setTimeFilter, timeFormat, setTimeFormat, showSponsors, setShowSponsors, showAwards, setShowAwards, showNotes, setShowNotes, showNotesAnnounce, setShowNotesAnnounce, showMottoes, setShowMottoes, showChampsStats, setShowChampsStats, swapScreen, setSwapScreen, autoAdvance, setAutoAdvance, autoUpdate, setAutoUpdate, getSchedule, awardsMenu, setAwardsMenu, showQualsStats, setShowQualsStats, showQualsStatsQuals, setShowQualsStatsQuals, teamReduction, setTeamReduction, playoffCountOverride, setPlayoffCountOverride, allianceCount, localUpdates, setLocalUpdates, putTeamData, getCommunityUpdates, reverseEmcee, setReverseEmcee, showDistrictChampsStats, setShowDistrictChampsStats, monthsWarning, setMonthsWarning, user, adHocMode, setAdHocMode, supportedYears, reloadPage, autoHideSponsors, setAutoHideSponsors, setLoadingCommunityUpdates }) {
     const isOnline = useOnlineStatus();
     const PWASupported = (isChrome && Number(browserVersion) >= 76) || (isSafari && Number(browserVersion) >= 15 && Number(fullBrowserVersion.split(".")[1]) >= 4);
-    console.log("Safari: " + isSafari);
-    console.log("Chrome: " + isChrome);
-    console.log("BrowserVersion: " + browserVersion);
-    console.log("FullBrowserVersion: " + fullBrowserVersion);
 
     const [deleteSavedModal, setDeleteSavedModal] = useState(null);
 

--- a/src/pages/TeamDataPage.jsx
+++ b/src/pages/TeamDataPage.jsx
@@ -17,7 +17,7 @@ import ReactQuill from "react-quill";
 import 'react-quill/dist/quill.snow.css';
 import { useInterval } from 'react-interval-hook';
 
-function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSort, setTeamSort, communityUpdates, setCommunityUpdates, allianceCount, lastVisit, setLastVisit, putTeamData, localUpdates, setLocalUpdates, qualSchedule, playoffSchedule, originalAndSustaining, monthsWarning, user, getTeamHistory, timeFormat }) {
+function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSort, setTeamSort, communityUpdates, setCommunityUpdates, allianceCount, lastVisit, setLastVisit, putTeamData, localUpdates, setLocalUpdates, qualSchedule, playoffSchedule, originalAndSustaining, monthsWarning, user, getTeamHistory, timeFormat, getCommunityUpdates }) {
     const [currentTime, setCurrentTime] = useState(moment());
     const { disableScope, enableScope } = useHotkeysContext();
 
@@ -215,6 +215,23 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
         setShow(false);
         enableScope('tabNavigation');
     }
+
+    const handleRestoreData = async (data) => {
+        console.log(data);
+        var resp = await putTeamData(data.team.teamNumber, data.update);
+        if (resp.status !== 204) {
+            var errorText = `Your update for team ${data.team.teamNumber} was not successful.`;
+            toast.error(errorText);
+            throw new Error(errorText);
+        } else {
+            toast.success(`You restored data for team ${data.team.teamNumber}.`);
+        }
+        handleCloseHistory();
+        handleClose();
+        await getCommunityUpdates(false, null);
+    }
+
+
 
     /**
      * Opens the team data screen so that a user can view and edit the team details 
@@ -569,7 +586,6 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
         }
     }
 
-
     return (
         <Container fluid>
             {!selectedEvent && !teamList && <div>
@@ -769,6 +785,8 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
                             <td>Awards text</td>
                             <td>Team Table Notes</td>
                             <td>Announce Screen Notes</td>
+                            <td>Sponsors</td>
+                            <td>How to pronounce #</td>
                             {(user["https://gatool.org/roles"].indexOf("admin") >= 0) && <td>
                                 Source</td>}
                         </tr>
@@ -785,11 +803,14 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
                                 <td>{updateTeam?.awardsTextLocal}</td>
                                 <td>{updateTeam?.teamNotes}</td>
                                 <td>{updateTeam?.teamNotesLocal}</td>
+                                <td>{updateTeam?.sponsorsLocal}</td>
+                                <td><td>{updateTeam?.sayNumber}</td></td>
                                 {(user["https://gatool.org/roles"].indexOf("admin") >= 0) && <td>
                                     {updateTeam?.source}</td>}
+                                <td>Current Value</td>
                             </tr>
-                            {teamHistory && teamHistory.map((team) => {
-                                return <tr key={team?.lastUpdate}>
+                            {teamHistory && teamHistory.map((team, index) => {
+                                return <tr key={`history${index}`}>
                                     <td>{moment(team?.lastUpdate).format("MMM Do YYYY, " + timeFormat.value)}</td>
                                     <td>{team?.nameShortLocal}</td>
                                     <td>{team?.organizationLocal}</td>
@@ -800,8 +821,11 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
                                     <td>{team?.awardsTextLocal}</td>
                                     <td>{team?.teamNotes}</td>
                                     <td>{team?.teamNotesLocal}</td>
+                                    <td>{team?.sponsordLocal}</td>
+                                    <td>{team?.sayNumber}</td>
                                     {(user["https://gatool.org/roles"].indexOf("admin") >= 0) && <td>
                                         {team?.source}</td>}
+                                    <td><Button onClick={() => { handleRestoreData({ "team": updateTeam, "update": team }) }}>Restore</Button></td>
                                 </tr>
                             })}</tbody>
                     </Table>

--- a/src/pages/TeamDataPage.jsx
+++ b/src/pages/TeamDataPage.jsx
@@ -789,6 +789,7 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
                             <td>How to pronounce #</td>
                             {(user["https://gatool.org/roles"].indexOf("admin") >= 0) && <td>
                                 Source</td>}
+                            <td></td>
                         </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
When user loads District Champs event, we load EI teams that are not competing with their robot. We had neglected to load the community updates for these teams. This is now fixed.
We also added the capability to load prior updates from the update history.
![FIRST_Game_Announcer_Tool](https://github.com/arthurlockman/gatool-ui/assets/2659225/87d33834-6c2a-4318-af23-12dbacf51049)
