### PR TITLE
District High Scores

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -450,21 +450,23 @@ td {
   text-align: center;
   padding: 0px;
   margin: 0px;
-  background-image: -webkit-linear-gradient(top, #f2dede 0, #e7c3c3 100%);
-  background-image: -o-linear-gradient(top, #f2dede 0, #e7c3c3 100%);
-  background-image: -webkit-gradient(
-    linear,
-    left top,
-    left bottom,
-    from(#f2dede),
-    to(#e7c3c3)
-  );
-  background-image: linear-gradient(to bottom, #f2dede 0, #e7c3c3 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff2dede', endColorstr='#ffe7c3c3', GradientType=0);
-  background-repeat: repeat-x;
   border-color: #dca7a7;
   color: #a94442;
   background-color: #f2dede;
+  border: 3px solid;
+  border-collapse: collapse;
+  margin-bottom: 10px;
+}
+
+.gatool-districtHighScores {
+  font-size: 14px;
+  font-weight: bold;
+  text-align: center;
+  padding: 0px;
+  margin: 0px;
+  border-color: #bc9b15;
+  color: #ad8b03;
+  background-color: #fff5ce;
   border: 3px solid;
   border-collapse: collapse;
   margin-bottom: 10px;
@@ -476,18 +478,7 @@ td {
   text-align: center;
   padding: 0px;
   margin: 0px;
-  background-image: -webkit-linear-gradient(top, #d9edf7 0, #b9def0 100%);
-  background-image: -o-linear-gradient(top, #d9edf7 0, #b9def0 100%);
-  background-image: -webkit-gradient(
-    linear,
-    left top,
-    left bottom,
-    from(#d9edf7),
-    to(#b9def0)
-  );
-  background-image: linear-gradient(to bottom, #d9edf7 0, #b9def0 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffd9edf7', endColorstr='#ffb9def0', GradientType=0);
-  background-repeat: repeat-x;
+ background-repeat: repeat-x;
   border-color: #9acfea;
   color: #31708f;
   background-color: #d9edf7;

--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -1,5 +1,14 @@
 export const appUpdates = [
   {
+    date: "March 19, 2025",
+    message: (
+      <ul>
+        <li>Added District High Scores to Stats Page</li>
+        <li>Added new high score to Stats page to align with TBA</li>
+      </ul>
+    ),
+  },
+  {
     date: "March 16, 2025",
     message: (
       <ul>
@@ -7,26 +16,23 @@ export const appUpdates = [
           Restored Practice Matches to Schedule, Announce and Play by Play pages
         </li>
         <li>
-          Added switch to control Inspection/Alliance Selection alert on Setup screen
+          Added switch to control Inspection/Alliance Selection alert on Setup
+          screen
         </li>
-        <li>
-          Changed Top Sponsors form field to text area for easier editing
-        </li>
-        <li>
-          Added Ranking Points Achieved to match results on Schedule page
-        </li>
+        <li>Changed Top Sponsors form field to text area for easier editing</li>
+        <li>Added Ranking Points Achieved to match results on Schedule page</li>
       </ul>
     ),
-  },{
+  },
+  {
     date: "March 4, 2025",
     message: (
       <ul>
         <li>
-          Alliance Captains are now removed from the list of available teams during Alliance Selection.
+          Alliance Captains are now removed from the list of available teams
+          during Alliance Selection.
         </li>
-        <li>
-          Declined teams who become Alliance Captains can now be skipped.
-        </li>
+        <li>Declined teams who become Alliance Captains can now be skipped.</li>
       </ul>
     ),
   },

--- a/src/components/BottomButtons.jsx
+++ b/src/components/BottomButtons.jsx
@@ -6,9 +6,9 @@ import PlayoffDetails from "../components/PlayoffDetails";
 
 function BottomButtons({ previousMatch, nextMatch, matchDetails, playoffSchedule, eventHighScores, alliances, selectedEvent, adHocMode, playoffCountOverride }) {
     var matches = playoffSchedule?.schedule;
-    var eventHighScore = eventHighScores?.overallqual;
-    if (eventHighScores?.overallqual?.score < eventHighScores?.overallplayoff?.score) {
-        eventHighScore = eventHighScores?.overallplayoff;
+    var eventHighScore = eventHighScores?.highscores?.overallqual;
+    if (eventHighScores?.highscores?.overallqual?.score < eventHighScores?.highscores?.overallplayoff?.score) {
+        eventHighScore = eventHighScores?.highscores?.overallplayoff;
     }
 
 

--- a/src/components/MainNavigation.jsx
+++ b/src/components/MainNavigation.jsx
@@ -170,7 +170,7 @@ function MainNavigation({ selectedEvent, practiceSchedule, qualSchedule, playoff
     // YELLOW: Event Selected, World High Scores Available, no matches complete for selected event
     // RED: Event Selected, no world high scores available
 
-    if (selectedEvent && (eventHighScores?.overallqual || eventHighScores?.overallplayoff) && worldHighScores) {
+    if (selectedEvent && (eventHighScores?.highscores?.overallqual || eventHighScores?.highscores?.overallplayoff) && worldHighScores) {
       setStatsTabReady(TabStates.Ready)
     } else if (selectedEvent && worldHighScores) {
       setStatsTabReady(TabStates.Stale)

--- a/src/components/StatsMatch.jsx
+++ b/src/components/StatsMatch.jsx
@@ -1,7 +1,7 @@
 import _ from "lodash";
 
 function StatsMatch({ highScores, matchType, matchName, eventNamesCY, tableType }) {
-    const style = tableType === "world" ? {backgroundColor: "#f2dede"} : {backgroundColor: "#d9edf7"}
+    const style = tableType === "world" ? {backgroundColor: "#f2dede"} : tableType === "event"? {backgroundColor: "#d9edf7"} : {backgroundColor: "#fff5ce"} 
     return (
         <>
             {highScores && (_.keys(highScores[matchType])?.length > 0) && <td style={style}>{matchName}<br />

--- a/src/pages/StatsPage.jsx
+++ b/src/pages/StatsPage.jsx
@@ -1,9 +1,10 @@
 
 import { Alert, Container, Row, Col } from "react-bootstrap";
 import StatsMatch from "../components/StatsMatch";
+import _ from "lodash";
 
-function StatsPage({ worldStats, selectedEvent, eventHighScores, eventNamesCY, eventLabel }) {
-
+function StatsPage({ worldStats, selectedEvent, eventHighScores, eventNamesCY, eventLabel, districts }) {
+    const eventDistrict = _.filter(districts, { value: selectedEvent?.value?.districtCode })[0];
     return (
         <Container fluid>
             {!selectedEvent && <div>
@@ -15,8 +16,8 @@ function StatsPage({ worldStats, selectedEvent, eventHighScores, eventNamesCY, e
             {selectedEvent && worldStats &&
                 <Container fluid>
                     <Row>
-                        <Col xs={"12"} sm={"6"}>
-                            <table className="table table-condensed gatool-worldHighScores" style={{backgroundColor: "#f2dede"}}>
+                        <Col xs={"12"} sm={selectedEvent?.value?.districtCode?"4":"6"}>
+                            <table className="table table-condensed gatool-worldHighScores" >
                                 <thead>
                                     <tr>
                                         <td style={{backgroundColor: "#f2dede"}} colSpan={2}>World High Scores {worldStats?.year}</td>
@@ -24,8 +25,12 @@ function StatsPage({ worldStats, selectedEvent, eventHighScores, eventNamesCY, e
                                 </thead>
                                 <tbody>
                                     <tr >
-                                        <StatsMatch highScores={worldStats?.highscores} matchType={"penaltyFreequal"} matchName={"Qual (no penalties)"} eventNamesCY={eventNamesCY} tableType={"world"}/>
-                                        <StatsMatch highScores={worldStats?.highscores} matchType={"penaltyFreeplayoff"} matchName={"Playoff (no penalties)"} eventNamesCY={eventNamesCY} tableType={"world"}/>
+                                        <StatsMatch highScores={worldStats?.highscores} matchType={"penaltyFreequal"} matchName={"Qual (no penalties in match)"} eventNamesCY={eventNamesCY} tableType={"world"}/>
+                                        <StatsMatch highScores={worldStats?.highscores} matchType={"penaltyFreeplayoff"} matchName={"Playoff (no penalties in match)"} eventNamesCY={eventNamesCY} tableType={"world"}/>
+                                    </tr>
+                                    <tr >
+                                        <StatsMatch highScores={worldStats?.highscores} matchType={"TBAPenaltyFreequal"} matchName={"Qual (no penalties to winner)"} eventNamesCY={eventNamesCY} tableType={"world"}/>
+                                        <StatsMatch highScores={worldStats?.highscores} matchType={"TBAPenaltyFreeplayoff"} matchName={"Playoff (no penalties to winner)"} eventNamesCY={eventNamesCY} tableType={"world"}/>
                                     </tr>
                                     <tr>
                                         <StatsMatch highScores={worldStats?.highscores} matchType={"offsettingqual"} matchName={"Qual (offsetting penalties)"} eventNamesCY={eventNamesCY} tableType={"world"}/>
@@ -37,9 +42,35 @@ function StatsPage({ worldStats, selectedEvent, eventHighScores, eventNamesCY, e
                                     </tr>
                                 </tbody>
                             </table>
-                            NOTE: The penalty free calculation considers the penalties for <b><i>both Alliance members in the match</i></b>. This is not how The Blue Alliance calculates high score, as they consider only the high scoring Alliance member. We are aware of this discrepancy and will consider adding additional results here.
                         </Col>
-                        <Col xs={"12"} sm={"6"}>
+                        {selectedEvent?.value?.districtCode && <Col xs={"12"} sm={"4"}>
+                            <table className="table table-condensed gatool-districtHighScores" >
+                                <thead>
+                                    <tr >
+                                        <td  colSpan={2} style={{backgroundColor: "#fff5ce"}}>{eventDistrict?.label} High Scores {worldStats?.year}</td>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr >
+                                        <StatsMatch highScores={worldStats?.highscores} matchType={`District${selectedEvent?.value?.districtCode}PenaltyFreequal`} matchName={"Qual (no penalties in match)"} eventNamesCY={eventNamesCY} tableType={"district"}/>
+                                        <StatsMatch highScores={worldStats?.highscores} matchType={`District${selectedEvent?.value?.districtCode}PenaltyFreeplayoff`} matchName={"Playoff (no penalties in match)"} eventNamesCY={eventNamesCY} tableType={"district"}/>
+                                    </tr>
+                                    <tr >
+                                        <StatsMatch highScores={worldStats?.highscores} matchType={`District${selectedEvent?.value?.districtCode}TBAPenaltyFreequal`} matchName={"Qual (no penalties to winner)"} eventNamesCY={eventNamesCY} tableType={"district"}/>
+                                        <StatsMatch highScores={worldStats?.highscores} matchType={`District${selectedEvent?.value?.districtCode}TBAPenaltyFreeplayoff`} matchName={"Playoff (no penalties to winner)"} eventNamesCY={eventNamesCY} tableType={"district"}/>
+                                    </tr>
+                                    <tr >
+                                        <StatsMatch highScores={worldStats?.highscores} matchType={`District${selectedEvent?.value?.districtCode}offsettingqual`} matchName={"Qual (offsetting penalties)"} eventNamesCY={eventNamesCY} tableType={"district"}/>
+                                        <StatsMatch highScores={worldStats?.highscores} matchType={`District${selectedEvent?.value?.districtCode}offsettingplayoff`} matchName={"Playoff (offsetting penalties)"} eventNamesCY={eventNamesCY} tableType={"district"}/>
+                                    </tr>
+                                    <tr >
+                                        <StatsMatch highScores={worldStats?.highscores} matchType={`District${selectedEvent?.value?.districtCode}Overallqual`} matchName={"Qual (incl. penalties)"} eventNamesCY={eventNamesCY} tableType={"district"}/>
+                                        <StatsMatch highScores={worldStats?.highscores} matchType={`District${selectedEvent?.value?.districtCode}Overallplayoff`} matchName={"Playoff (incl. penalties)"} eventNamesCY={eventNamesCY} tableType={"district"}/>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </Col>}
+                        <Col xs={"12"} sm={selectedEvent?.value?.districtCode?"4":"6"}>
                             <table className="table table-condensed gatool-eventHighScores">
                                 <thead>
                                     <tr>
@@ -48,16 +79,20 @@ function StatsPage({ worldStats, selectedEvent, eventHighScores, eventNamesCY, e
                                 </thead>
                                 <tbody>
                                     <tr>
-                                        <StatsMatch highScores={eventHighScores} matchType={"penaltyFreequal"} matchName={"Qual (no penalties)"} eventNamesCY={eventNamesCY} tableType={"event"}/>
-                                        <StatsMatch highScores={eventHighScores} matchType={"penaltyFreeplayoff"} matchName={"Playoff (no penalties)"} eventNamesCY={eventNamesCY}  tableType={"event"}/>
+                                        <StatsMatch highScores={eventHighScores?.highscores} matchType={"penaltyFreequal"} matchName={"Qual (no penalties in match)"} eventNamesCY={eventNamesCY} tableType={"event"}/>
+                                        <StatsMatch highScores={eventHighScores?.highscores} matchType={"penaltyFreeplayoff"} matchName={"Playoff (no penalties in match)"} eventNamesCY={eventNamesCY}  tableType={"event"}/>
                                     </tr>
                                     <tr>
-                                        <StatsMatch highScores={eventHighScores} matchType={"offsettingqual"} matchName={"Qual (offsetting penalties)"} eventNamesCY={eventNamesCY}  tableType={"event"}/>
-                                        <StatsMatch highScores={eventHighScores} matchType={"offsettingplayoff"} matchName={"Playoff (offsetting penalties)"} eventNamesCY={eventNamesCY}  tableType={"event"}/>
+                                        <StatsMatch highScores={eventHighScores?.highscores} matchType={"TBAPenaltyFreequal"} matchName={"Qual (no penalties to winner)"} eventNamesCY={eventNamesCY} tableType={"event"}/>
+                                        <StatsMatch highScores={eventHighScores?.highscores} matchType={"TBAPenaltyFreeplayoff"} matchName={"Playoff (no penalties to winner)"} eventNamesCY={eventNamesCY}  tableType={"event"}/>
                                     </tr>
                                     <tr>
-                                        <StatsMatch highScores={eventHighScores} matchType={"overallqual"} matchName={"Qual (incl. penalties)"} eventNamesCY={eventNamesCY}  tableType={"event"}/>
-                                        <StatsMatch highScores={eventHighScores} matchType={"overallplayoff"} matchName={"Playoff (incl. penalties)"} eventNamesCY={eventNamesCY}  tableType={"event"}/>
+                                        <StatsMatch highScores={eventHighScores?.highscores} matchType={"offsettingqual"} matchName={"Qual (offsetting penalties)"} eventNamesCY={eventNamesCY}  tableType={"event"}/>
+                                        <StatsMatch highScores={eventHighScores?.highscores} matchType={"offsettingplayoff"} matchName={"Playoff (offsetting penalties)"} eventNamesCY={eventNamesCY}  tableType={"event"}/>
+                                    </tr>
+                                    <tr>
+                                        <StatsMatch highScores={eventHighScores?.highscores} matchType={"overallqual"} matchName={"Qual (incl. penalties)"} eventNamesCY={eventNamesCY}  tableType={"event"}/>
+                                        <StatsMatch highScores={eventHighScores?.highscores} matchType={"overallplayoff"} matchName={"Playoff (incl. penalties)"} eventNamesCY={eventNamesCY}  tableType={"event"}/>
                                     </tr>
                                 </tbody>
                             </table>


### PR DESCRIPTION
This adds District High Scores to gatool. It also adds a new High Score category to highlight a match where the winning Alliance did not benefit from penalty points, but they may have given penalty points to their opponent. This is to align with how TBA reports world high scores.

<img width="1308" alt="Screenshot_3_19_25__11_34 AM" src="https://github.com/user-attachments/assets/7718604a-b779-4cc6-b9f0-1db0e9bde934" />


Closes #500 