### PR TITLE
Add support and documentation for running locally with custom Auth0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+REACT_APP_AUTH0_DOMAIN=abc123.us.auth0.com
+REACT_APP_AUTH0_LOGIN_DOMAIN=abc123.us.auth0.com
+REACT_APP_AUTH0_CONNECTION=google-oauth2 # or another connection if you have configured one in auth0
+REACT_APP_AUTH0_CLIENTID=def456
+REACT_APP_API_BASE=http://localhost:3001/v3/

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.env

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Note that when running as a PWA, debugging will not be available.
 #### Testing with a local `gatool-api` and custom Auth0:
 
 Create a new Auth0 Application, selecting the "Single Page Web Application" option
-On the settings tab set the "Allowed Callback URLs", "Allowed Logout URLs" and "Allowed Web Origins" to `http://localhost:3000` and save. If you Record the Client ID and domain. The Client Secret is not needed for GATool.
+On the settings tab set the "Allowed Callback URLs", "Allowed Logout URLs" and "Allowed Web Origins" to `http://localhost:3000` and save. Record the Client ID and domain. The Client Secret is not needed for GATool.
 
 In Auth0, go to Actions -> Triggers. Select "Post Login". On the post-login page, add a custom trigger named "Add Roles". Replace the content with
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,33 @@ npm run build && serve -s build
 
 Note that when running as a PWA, debugging will not be available.
 
+#### Testing with a local `gatool-api` and custom Auth0:
+
+Create a new Auth0 Application, selecting the "Single Page Web Application" option
+On the settings tab set the "Allowed Callback URLs", "Allowed Logout URLs" and "Allowed Web Origins" to `http://localhost:3000` and save. If you Record the Client ID and domain. The Client Secret is not needed for GATool.
+
+In Auth0, go to Actions -> Triggers. Select "Post Login". On the post-login page, add a custom trigger named "Add Roles". Replace the content with
+```
+exports.onExecutePostLogin = async (event, api) => {
+  if (event.authorization) {
+    api.idToken.setCustomClaim("https://gatool.org/roles", event.authorization.roles);
+  }
+};
+```
+After creating the action, go back to the trigger and drag the newly created "Add Roles" action into the flow, and apply.
+
+In Auth0, go to User Management -> Roles, and create two roles, one with an name of "admin" and the other with the name of "user". After a user has first logged in with oauth, you can assign either/both roles to the user from the User Mangement -> Users page. Any updates to roles may require a log out and back in to the app.
+
+Copy `.env.example` to `.env`
+Fill in the following variables:
+- `REACT_APP_AUTH0_DOMAIN` and `REACT_APP_AUTH0_LOGIN_DOMAIN`: the domain recorded above (they could be different if you were using a custom login domain)
+- `REACT_APP_AUTH0_CLIENTID`: the client ID recorded above
+- `REACT_APP_AUTH0_CONNECTION`: Can be left on `google-oauth2` or changed to a different connection if you have configured one
+
+Configure `gatool-api` according to the local development instructions in that repository.
+
+Start the app using the directions above
+
 ### Deploying
 
 GATool has two main active deployments: [beta](https://beta.gatool.org) and [production](https://gatool.org). Both are hosted on Azure web services and deployed automatically from GitHub.

--- a/src/contextProviders/AuthClientContext.jsx
+++ b/src/contextProviders/AuthClientContext.jsx
@@ -3,7 +3,7 @@ import { createContext, useContext, useEffect, useMemo, useState } from "react"
 import { toast } from 'react-toastify';
 import { useOnlineStatus } from "./OnlineContext";
 
-const apiBaseUrl = "https://api.gatool.org/v3/";
+export const apiBaseUrl = process.env.REACT_APP_API_BASE || "https://api.gatool.org/v3/";
 
 class AuthClient {
     setOperationsInProgress = null;
@@ -156,7 +156,7 @@ class AuthClient {
 
     async getToken() {
         var tokenResponse = await this.tokenGetter({
-            audience: 'https://gatool.auth0.com/userinfo',
+            audience: `https://${process.env.REACT_APP_AUTH0_DOMAIN || 'gatool.auth0.com'}/userinfo`,
             scope: 'openid email profile offline_access',
             detailedResponse: true
         });

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -21,12 +21,12 @@ root.render(
     <HotkeysProvider initiallyActiveScopes={['matchNavigation', 'tabNavigation', 'none']}>
       <OnlineStatusProvider>
         <Auth0Provider
-          domain="auth.gatool.org"
-          clientId="afsE1dlAGS609U32NjmvNMaYSQmtO3NT"
+          domain={process.env.REACT_APP_AUTH0_LOGIN_DOMAIN || 'auth.gatool.org'}
+          clientId={process.env.REACT_APP_AUTH0_CLIENTID || 'afsE1dlAGS609U32NjmvNMaYSQmtO3NT'}
           redirectUri={window.location.origin}
           useRefreshTokens={true}
           cacheLocation='localstorage'
-          connection='email'
+          connection={process.env.REACT_APP_AUTH0_CONNECTION || 'email'}
           sessionCheckExpiryDays={7}
         >
           <AuthClientContextProvider>

--- a/src/pages/CheatsheetPage.jsx
+++ b/src/pages/CheatsheetPage.jsx
@@ -2,6 +2,7 @@ import { Container, Row } from "react-bootstrap";
 import { FlashcardArray } from "react-quizlet-flashcard";
 import { saveAs } from "file-saver";
 import _ from "lodash";
+import { apiBaseUrl } from "../contextProviders/AuthClientContext";
 
 function CheatsheetPage({
   teamList,
@@ -25,7 +26,7 @@ function CheatsheetPage({
       backHTML: "",
       style: { width: "500px", height: "300px" },
     };
-    var avatar = `<img src="https://api.gatool.org/v3/${selectedYear.value}/avatars/team/${team?.teamNumber}/avatar.png" onerror="this.style.display='none'">&nbsp`;
+    var avatar = `<img src="${apiBaseUrl}${selectedYear.value}/avatars/team/${team?.teamNumber}/avatar.png" onerror="this.style.display='none'">&nbsp`;
     var robotImage = _.filter(robotImages, { teamNumber: team?.teamNumber })[0]
       ?.imageURL
       ? `<img height="225px" src="${

--- a/src/pages/Developer.jsx
+++ b/src/pages/Developer.jsx
@@ -54,7 +54,7 @@ function Developer({
   useEffect(() => {
     async function getToken() {
       const tokenResponse = await getAccessTokenSilently({
-        audience: "https://gatool.auth0.com/userinfo",
+        audience: `https://${process.env.REACT_APP_AUTH0_DOMAIN || 'gatool.auth0.com'}/userinfo`,
         scope: "openid email profile",
         detailedResponse: true,
       });

--- a/src/pages/TeamDataPage.jsx
+++ b/src/pages/TeamDataPage.jsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from "react";
 import moment from "moment";
 import _ from "lodash";
 import { toast } from "react-toastify";
+import { apiBaseUrl } from "../contextProviders/AuthClientContext";
 import { useOnlineStatus } from "../contextProviders/OnlineContext";
 import { utils, read, write, writeFile } from "xlsx";
 import Docxtemplater from "docxtemplater";
@@ -724,7 +725,7 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
                     <tbody>
                         {teamList && teamList?.teams && teamListExtended.map((team) => {
                             var cityState = `${team?.city}, ${team?.stateProv}${(team?.country !== "USA") ? ", " + team?.country : ""}`;
-                            var avatar = `<img src='https://api.gatool.org/v3/${selectedYear.value}/avatars/team/${team?.teamNumber}/avatar.png' onerror="this.style.display='none'">&nbsp`;
+                            var avatar = `<img src='${apiBaseUrl}${selectedYear.value}/avatars/team/${team?.teamNumber}/avatar.png' onerror="this.style.display='none'">&nbsp`;
                             var teamNameWithAvatar = team?.updates?.nameShortLocal ? team?.updates?.nameShortLocal : team?.nameShort;
                             teamNameWithAvatar = avatar + "<br />" + teamNameWithAvatar;
 


### PR DESCRIPTION
This PR makes it easier to run and develop gatool-ui against a local server and without requiring access to production Auth0. I don't know if this is actually desired, but I did this work locally to be able to poke around the software and I figured it wouldn't hurt to make a PR out of it.
