### PR TITLE
Unauthenticated Mode

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,6 @@ import EmceePage from "./pages/EmceePage";
 import { useEffect, useState } from "react";
 import { UseAuthClient } from "./contextProviders/AuthClientContext";
 import { useAuth0 } from "@auth0/auth0-react";
-import AnonymousUserPage from "./pages/AnonymousUserPage";
 import { Blocks } from "react-loader-spinner";
 import { Button, Container } from "react-bootstrap";
 import { usePersistentState } from "./hooks/UsePersistentState";
@@ -116,7 +115,7 @@ var halloffame = _.cloneDeep(hallOfFame);
 const timezones = _.cloneDeep(timeZones);
 
 function App() {
-  const { isAuthenticated, isLoading, user } = useAuth0();
+  const { isLoading, user, isAuthenticated } = useAuth0();
 
   // eslint-disable-next-line no-unused-vars
   const [httpClient] = UseAuthClient();
@@ -394,11 +393,6 @@ function App() {
     }
   }, [showReloaded, setShowReloaded, enqueueSnackbar, closeSnackbar]);
 
-  // Handle if users are offline. If they're offline but have an event and year selected, let them in.
-  const canAccessApp = () => {
-    return isOnline ? isAuthenticated : selectedEvent && selectedYear;
-  };
-
   /**
    * Trim all values in an array
    * @function trimArray
@@ -488,7 +482,7 @@ function App() {
       //do something
       practiceschedule = { schedule: { schedule: [] } };
     } else if (!selectedEvent?.value?.code.includes("PRACTICE")) {
-      const practiceResult = await httpClient.get(
+      const practiceResult = await httpClient.getNoAuth(
         `${selectedYear?.value}/schedule/hybrid/${selectedEvent?.value.code}/practice`
       );
       practiceschedule = await practiceResult.json();
@@ -522,12 +516,12 @@ function App() {
       //do something
       qualschedule = { schedule: { schedule: [] } };
     } else if (!selectedEvent?.value?.code.includes("PRACTICE")) {
-      const qualsResult = await httpClient.get(
+      const qualsResult = await httpClient.getNoAuth(
         `${selectedYear?.value}/schedule/hybrid/${selectedEvent?.value.code}/qual`
       );
       qualschedule = await qualsResult.json();
 
-      const qualsScoresResult = await httpClient.get(
+      const qualsScoresResult = await httpClient.getNoAuth(
         `${selectedYear?.value}/scores/${selectedEvent?.value.code}/qual`
       );
 
@@ -613,7 +607,7 @@ function App() {
       //set playoffschedule to be empty
       playoffschedule = { schedule: { schedule: [] } };
     } else if (!selectedEvent?.value?.code.includes("PRACTICE")) {
-      const playoffResult = await httpClient.get(
+      const playoffResult = await httpClient.getNoAuth(
         `${selectedYear?.value}/schedule/hybrid/${selectedEvent?.value.code}/playoff`
       );
       playoffschedule = await playoffResult.json();
@@ -663,7 +657,7 @@ function App() {
     // })]?.matchNumber;
 
     if (!selectedEvent?.value?.code.includes("PRACTICE")) {
-      const playoffScoresResult = await httpClient.get(
+      const playoffScoresResult = await httpClient.getNoAuth(
         `${selectedYear?.value}/scores/${selectedEvent?.value.code}/playoff`
       );
       var playoffScores = await playoffScoresResult.json();
@@ -821,7 +815,7 @@ function App() {
           //https://api.gatool.org/v3/2023/teams?teamNumber=172
 
           var adHocTeams = adHocTeamList.map(async (team) => {
-            var request = await httpClient.get(
+            var request = await httpClient.getNoAuth(
               `${selectedYear?.value}/teams?teamNumber=${team}`
             );
             var teamDetails = await request.json();
@@ -839,7 +833,7 @@ function App() {
           });
         }
       } else if (!selectedEvent?.value?.code.includes("PRACTICE")) {
-        result = await httpClient.get(
+        result = await httpClient.getNoAuth(
           `${selectedYear?.value}/teams?eventCode=${selectedEvent?.value?.code}`
         );
         teams = await result.json();
@@ -865,7 +859,7 @@ function App() {
         });
         // get awards for those filtered events
         var districtEITeams = districtEvents.map(async (event) => {
-          var request = await httpClient.get(
+          var request = await httpClient.getNoAuth(
             `${selectedYear?.value}/awards/event/${event?.value?.code}`
           );
           var eventDetails = await request.json();
@@ -892,7 +886,7 @@ function App() {
           // get team details for those teams not in this event
           if (tempTeams.length > 0) {
             var EITeamData = tempTeams.map(async (teamNumber) => {
-              var request = await httpClient.get(
+              var request = await httpClient.getNoAuth(
                 `${selectedYear?.value}/teams?teamNumber=${teamNumber}`
               );
               var teamDetails = await request.json();
@@ -1013,7 +1007,7 @@ function App() {
 
       //fetch awards for the current teams
       var newTeams = teams.teams.map(async (team) => {
-        var request = await httpClient.get(
+        var request = await httpClient.getNoAuth(
           `${selectedYear?.value}/team/${team?.teamNumber}/awards`
         );
         var awards = await request.json();
@@ -1152,7 +1146,7 @@ function App() {
         ) {
           console.log("Getting Champs stats");
           champsTeams = teams.teams.map(async (team) => {
-            var champsRequest = await httpClient.get(
+            var champsRequest = await httpClient.getNoAuth(
               `/team/${team?.teamNumber}/appearances`
             );
             var appearances = await champsRequest.json();
@@ -1306,7 +1300,7 @@ function App() {
             // https://api.gatool.org/v3/team/172/updates
             console.log("Teams List loaded. Update from the Community");
             var adHocTeams = adHocTeamList.map(async (team) => {
-              var request = await httpClient.get(
+              var request = await httpClient.getNoAuth(
                 `/team/${team?.teamNumber}/updates`
               );
               var teamDetails = { teamNumber: team?.teamNumber };
@@ -1352,7 +1346,7 @@ function App() {
             teams = [];
           }
         } else if (!selectedEvent?.value?.code.includes("PRACTICE")) {
-          result = await httpClient.get(
+          result = await httpClient.getNoAuth(
             `${selectedYear?.value}/communityUpdates/${selectedEvent?.value.code}`
           );
           teams = await result.json();
@@ -1387,7 +1381,7 @@ function App() {
             );
             //get updates for these teams
             var EIUpdates = EITeams.map(async (EITeam) => {
-              var request = await httpClient.get(
+              var request = await httpClient.getNoAuth(
                 `/team/${EITeam?.teamNumber}/updates`
               );
               var teamDetails = { teamNumber: EITeam?.teamNumber };
@@ -1443,7 +1437,7 @@ function App() {
     if (selectedEvent?.value?.code.includes("OFFLINE")) {
       ranks = { rankings: { Rankings: [] } };
     } else if (!selectedEvent?.value?.code.includes("PRACTICE")) {
-      result = await httpClient.get(
+      result = await httpClient.getNoAuth(
         `${selectedYear?.value}/rankings/${selectedEvent?.value.code}`
       );
       ranks = await result.json();
@@ -1488,7 +1482,7 @@ function App() {
   async function getDistrictRanks() {
     var result = null;
     var districtranks = null;
-    result = await httpClient.get(
+    result = await httpClient.getNoAuth(
       `${selectedYear?.value}/district/rankings/${selectedEvent?.value.districtCode}`
     );
     districtranks = await result.json();
@@ -1505,7 +1499,7 @@ function App() {
    */
   async function getRobotImages() {
     var robotImageList = teamList?.teams.map(async (team) => {
-      var media = await httpClient.get(
+      var media = await httpClient.getNoAuth(
         `${selectedYear?.value}/team/${team?.teamNumber}/media`
       );
       var mediaArray = await media.json();
@@ -1528,7 +1522,7 @@ function App() {
    * @returns sets the world high scores
    */
   async function getWorldStats() {
-    var result = await httpClient.get(`${selectedYear?.value}/highscores`);
+    var result = await httpClient.getNoAuth(`${selectedYear?.value}/highscores`);
     var highscores = await result.json();
     var scores = {};
     var reducedScores = {};
@@ -1583,7 +1577,7 @@ function App() {
    * @returns sets the world high scores
    */
   async function getEventStats(year, code) {
-    var result = await httpClient.get(`${year}/highscores/${code}`);
+    var result = await httpClient.getNoAuth(`${year}/highscores/${code}`);
     var highscores = await result.json();
     var scores = {};
     var reducedScores = {};
@@ -1637,7 +1631,7 @@ function App() {
       !selectedEvent?.value?.code.includes("PRACTICE") &&
       !selectedEvent?.value?.code.includes("OFFLINE")
     ) {
-      result = await httpClient.get(
+      result = await httpClient.getNoAuth(
         `${selectedYear?.value}/alliances/${selectedEvent?.value.code}`
       );
       alliances = await result.json();
@@ -1788,7 +1782,7 @@ function App() {
    * @returns {Promise<object>} The team's update history array
    */
   async function getNotifications() {
-    var result = await httpClient.get(`announcements`);
+    var result = await httpClient.getNoAuth(`announcements`);
     var notifications = await result.json();
     if (result.status === 200) {
       return notifications;
@@ -1805,7 +1799,7 @@ function App() {
   }
 
   const getSyncStatus = async () => {
-    const result = await httpClient.get(`system/admin/syncUsers`);
+    const result = await httpClient.getNoAuth(`system/admin/syncUsers`);
     const syncResult = await result.json();
     if (result.status === 200) {
       return syncResult;
@@ -1835,7 +1829,7 @@ function App() {
    * @returns {Promise<object>} The team's update history array
    */
   async function getTeamHistory(teamNumber) {
-    var result = await httpClient.get(`team/${teamNumber}/updates/history/`);
+    var result = await httpClient.getNoAuth(`team/${teamNumber}/updates/history/`);
     var history = await result.json();
     return history;
   }
@@ -1984,7 +1978,7 @@ function App() {
 
   const getEvents = async () => {
     try {
-      const val = await httpClient.get(`${selectedYear?.value}/events`);
+      const val = await httpClient.getNoAuth(`${selectedYear?.value}/events`);
       const result = await val.json();
       if (typeof result.Events !== "undefined") {
         result.events = result.Events;
@@ -2095,7 +2089,7 @@ function App() {
 
   const getDistricts = async () => {
     try {
-      const val = await httpClient.get(`${selectedYear?.value}/districts`);
+      const val = await httpClient.getNoAuth(`${selectedYear?.value}/districts`);
       const json = await val.json();
       if (typeof json.Districts !== "undefined") {
         json.districts = json.Districts;
@@ -2167,7 +2161,7 @@ function App() {
 
   // Retrieve event list when year selection changes
   useEffect(() => {
-    if (httpClient && selectedYear && isAuthenticated) {
+    if (httpClient && selectedYear) {
       getDistricts();
       getEvents();
     }
@@ -2328,7 +2322,7 @@ function App() {
             <Blocks visible height="200" width="" ariaLabel="blocks-loading" />
           </Container>
         </div>
-      ) : canAccessApp() ? (
+      ) : (
         <BrowserRouter>
           <Routes>
             <Route
@@ -2409,6 +2403,7 @@ function App() {
                     monthsWarning={monthsWarning}
                     setMonthsWarning={setMonthsWarning}
                     user={user}
+                    isAuthenticated={isAuthenticated}
                     adHocMode={adHocMode}
                     setAdHocMode={setAdHocMode}
                     supportedYears={supportedYears}
@@ -2497,6 +2492,7 @@ function App() {
                     originalAndSustaining={originalAndSustaining}
                     monthsWarning={monthsWarning}
                     user={user}
+                    isAuthenticated={isAuthenticated}
                     getTeamHistory={getTeamHistory}
                     timeFormat={timeFormat}
                     getCommunityUpdates={getCommunityUpdates}
@@ -2748,8 +2744,6 @@ function App() {
             </Route>
           </Routes>
         </BrowserRouter>
-      ) : (
-        <AnonymousUserPage />
       )}
     </div>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -803,7 +803,8 @@ function App() {
       ) {
         lastMatchPlayed -= 1;
       }
-      setCurrentMatch(lastMatchPlayed + 1);
+      if (currentMatch <= lastMatchPlayed ){
+      setCurrentMatch(lastMatchPlayed + 1);}
     }
 
     //setEventHighScores(highScores);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -746,42 +746,21 @@ function App() {
 
       _.forEach(playoffScores.MatchScores, (score) => {
         if (score.alliances[0].totalPoints === score.alliances[1].totalPoints) {
-          var tiebreaker = {
-            level: 0,
-            red: 0,
-            blue: 0,
-            winner: "TBD",
-          };
-          for (
-            var i = 0;
-            i < playoffTiebreakers[selectedYear?.value].length;
-            i++
-          ) {
-            tiebreaker.level = i + 1;
-            var criterion =
-              playoffTiebreakers[selectedYear?.value][i].split("+");
-            for (var a = 0; a < criterion.length; a++) {
-              tiebreaker.red += Number(score.alliances[1][criterion[a]]);
-              tiebreaker.blue += Number(score.alliances[0][criterion[a]]);
-            }
-            if (tiebreaker.red > tiebreaker.blue) {
-              tiebreaker.winner = "red";
-              break;
-            } else if (tiebreaker.red < tiebreaker.blue) {
-              tiebreaker.winner = "blue";
-              break;
-            }
-          }
           playoffschedule.schedule[
             _.findIndex(playoffschedule.schedule, {
               matchNumber: score.matchNumber,
             })
-          ].winner.tieWinner = tiebreaker?.winner;
+          ].winner.tieWinner = score?.winningAlliance === 2 ? "blue" : score?.winningAlliance === 1 ? "red" : "TBD";
           playoffschedule.schedule[
             _.findIndex(playoffschedule.schedule, {
               matchNumber: score.matchNumber,
             })
-          ].winner.level = tiebreaker?.level;
+          ].winner.level = score?.tiebreaker?.item1>=0 ? score?.tiebreaker?.item1 : 0;
+          playoffschedule.schedule[
+            _.findIndex(playoffschedule.schedule, {
+              matchNumber: score.matchNumber,
+            })
+          ].winner.tieDetail = score?.tiebreaker?.item2;
         }
       });
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,54 +50,6 @@ export const TabStates = {
   Ready: "ready",
 };
 
-/**
- * Tiebreakers constant defines the sort order for breaking ties during playoffs.
- * Criteria 2025 has been updated.
- * 1st Cumulative TECH FOUL points due to opponent rule violations
- * 2nd ALLIANCE LEAVE + AUTO CORAL points
- * 3rd ALLIANCE BARGE points
- * 4th MATCH is replayed
- * @constant {object}
- * @default
- */
-const playoffTiebreakers = {
-  2026: ["foulPoints", "autoPoints", "endGameBargePoints"], // Update after rules release
-  2025: [
-    "foulPoints",
-    "autoMobilityPoints+autoCoralPoints",
-    "endGameBargePoints",
-  ],
-  2024: ["foulPoints", "autoPoints", "endGameTotalStagePoints"],
-  2023: ["foulPoints", "totalChargeStationPoints", "autoPoints"],
-  2022: ["foulPoints", "endgamePoints", "autoCargoTotal+autoTaxiPoints"],
-  2021: [
-    "foulPoints",
-    "autoPoints",
-    "endgamePoints",
-    "controlPanelPoints+teleopCellPoints",
-  ],
-  2020: [
-    "foulPoints",
-    "autoPoints",
-    "endgamePoints",
-    "controlPanelPoints+teleopCellPoints",
-  ],
-  2019: [
-    "foulPoints",
-    "cargoPoints",
-    "hatchPanelPoints",
-    "habClimbPoints",
-    "sandStormBonusPoints",
-  ],
-  2018: [
-    "foulPoints",
-    "endgamePoints",
-    "autoPoints",
-    "autoOwnershipPoints+teleopOwnershipPoints",
-    "vaultPoints",
-  ],
-};
-
 const navPages = [
   { href: "", id: "setupPage" },
   { href: "schedule", id: "schedulePage" },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -283,6 +283,11 @@ function App() {
     "setting:autoAdvance",
     null
   );
+  const [highScoreMode, setHighScoreMode] = usePersistentState(
+    "setting:highScoreMode",
+    null
+  );
+
   const [autoUpdate, setAutoUpdate] = usePersistentState(
     "setting:autoUpdate",
     null
@@ -2497,6 +2502,8 @@ function App() {
                     setShowInspection={setShowInspection}
                     showMinorAwards={showMinorAwards}
                     setShowMinorAwards={setShowMinorAwards}
+                    highScoreMode={highScoreMode}
+                    setHighScoreMode={setHighScoreMode}
                   />
                 }
               />
@@ -2640,6 +2647,7 @@ function App() {
                     eventLabel={eventLabel}
                     playoffCountOverride={playoffCountOverride}
                     showInspection={showInspection}
+                    highScoreMode={highScoreMode}
                   />
                 }
               />
@@ -2687,6 +2695,7 @@ function App() {
                     eventLabel={eventLabel}
                     playoffCountOverride={playoffCountOverride}
                     showInspection={showInspection}
+                    highScoreMode={highScoreMode}
                   />
                 }
               />

--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -1,5 +1,12 @@
 export const appUpdates = [
   {
+    date: "April 25, 2025",
+    message: (
+      <ul>
+        <li>On Announce and Play-By-Play, gatool now shows the high score based on tournament phase. You can make it show the event high score instead via a switch on the Setup page</li>
+      </ul>
+    ),
+  },{
     date: "April 23, 2025",
     message: (
       <ul>

--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -4,6 +4,8 @@ export const appUpdates = [
     message: (
       <ul>
         <li>On Announce and Play-By-Play, gatool now shows the high score based on tournament phase. You can make it show the event high score instead via a switch on the Setup page</li>
+        <li>Auto Advance now allows you to advance beyond the last known completed match + 1.</li>
+        <li>Updated how we calculate Tiebreakers for Playoff matches</li>
       </ul>
     ),
   },{

--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -1,8 +1,9 @@
 export const appUpdates = [
   {
-    date: "April 25, 2025",
+    date: "April 26, 2025",
     message: (
       <ul>
+        <li><b>Introducing Unauthenticated mode.</b><br /> Users can now use gatool without login. Unauthenticated users can load events, see schedule and score details, announce teams and call matches. </li>
         <li>On Announce and Play-By-Play, gatool now shows the high score based on tournament phase. You can make it show the event high score instead via a switch on the Setup page</li>
         <li>Auto Advance now allows you to advance beyond the last known completed match + 1.</li>
         <li>Updated how we calculate Tiebreakers for Playoff matches</li>

--- a/src/components/AuthWidget.jsx
+++ b/src/components/AuthWidget.jsx
@@ -44,7 +44,26 @@ const AuthWidget = () => {
       </span>
     ) : (
       <span>
-        <LoginButton />
+        <div className='d-block d-xl-none' style={{
+          marginRight: "5px"
+        }}>
+          {showSpinner ? <Blocks
+            visible={true}
+            height="31"
+            width=""
+            ariaLabel="blocks-loading"
+          /> : <LoginButton />}
+        </div>
+        <div className='d-none d-xl-block' style={{
+          marginRight: "10px"
+        }}>
+          {showSpinner ? <Blocks
+            visible={true}
+            height="45"
+            width=""
+            ariaLabel="blocks-loading"
+          /> : <LoginButton />}
+        </div>
       </span>
     )
   );

--- a/src/components/BottomButtons.jsx
+++ b/src/components/BottomButtons.jsx
@@ -4,12 +4,17 @@ import { CaretLeftFill, CaretRightFill } from "react-bootstrap-icons";
 import PlayoffDetails from "../components/PlayoffDetails";
 
 
-function BottomButtons({ previousMatch, nextMatch, matchDetails, playoffSchedule, eventHighScores, alliances, selectedEvent, adHocMode, playoffCountOverride }) {
+function BottomButtons({ previousMatch, nextMatch, matchDetails, playoffSchedule, eventHighScores, alliances, selectedEvent, adHocMode, playoffCountOverride, highScoreMode }) {
     var matches = playoffSchedule?.schedule;
     var eventHighScore = eventHighScores?.highscores?.overallqual;
-    if (eventHighScores?.highscores?.overallqual?.score < eventHighScores?.highscores?.overallplayoff?.score) {
-        eventHighScore = eventHighScores?.highscores?.overallplayoff;
-    }
+    if (!highScoreMode) {
+        if (matchDetails?.tournamentLevel === "Playoff") {
+            eventHighScore = eventHighScores?.highscores?.overallplayoff;
+        }
+    } else
+        if (eventHighScores?.highscores?.overallqual?.score < eventHighScores?.highscores?.overallplayoff?.score) {
+            eventHighScore = eventHighScores?.highscores?.overallplayoff;
+        }
 
 
     return (
@@ -18,17 +23,16 @@ function BottomButtons({ previousMatch, nextMatch, matchDetails, playoffSchedule
                 <Col xs={"2"} lg={"3"}>
                     {!adHocMode && <Button size="lg" variant="outline-success" className={"gatool-button buttonNoWrap"} onClick={previousMatch}><span className={"d-none d-lg-block"}><CaretLeftFill /> Previous Match</span><span className={"d-block d-lg-none"}><CaretLeftFill /> <CaretLeftFill /></span></Button>}
                 </Col>
-                {matchDetails?.tournamentLevel === "Playoff" && <Col xs={eventHighScore?.score? "5" : "8"} lg={eventHighScore?.score ? "4" : "6"} className={"playoffDetails"}>
+                {matchDetails?.tournamentLevel === "Playoff" && <Col xs={eventHighScore?.score ? "5" : "8"} lg={eventHighScore?.score ? "4" : "6"} className={"playoffDetails"}>
                     <PlayoffDetails matchDetails={matchDetails} alliances={alliances} matches={matches} selectedEvent={selectedEvent} playoffCountOverride={playoffCountOverride} />
                 </Col>}
 
-                {matchDetails?.tournamentLevel !== "Playoff" && eventHighScore?.score && <Col xs={"8"} lg={"6"}><p><b>Event High Score: {eventHighScore?.score}<br />
-                    in {eventHighScore?.matchName}<br />
-                    ({eventHighScore?.allianceMembers})</b></p></Col>}
-
-                {matchDetails?.tournamentLevel === "Playoff" && eventHighScore?.score && <Col xs={"3"} lg={"2"}><p><b>Event High Score: {eventHighScore?.score}<br />
-                    in {eventHighScore?.matchName}<br />
-                    ({eventHighScore?.allianceMembers})</b></p></Col>}
+                {eventHighScore?.score && <Col xs={matchDetails?.tournamentLevel !== "Playoff" ? "8" : "3"} lg={matchDetails?.tournamentLevel !== "Playoff" ? "6" : "2"}>
+                    <p><b>{highScoreMode ? 'Event' : matchDetails?.tournamentLevel === "Playoff" ? 'Playoffs' : 'Quals'} High Score: {eventHighScore?.score}<br />
+                        in {eventHighScore?.matchName}<br />
+                        ({eventHighScore?.allianceMembers})</b>
+                    </p>
+                </Col>}
 
                 {matchDetails?.tournamentLevel !== "Playoff" && !eventHighScore && <Col xs={"8"} lg={"6"}><h4>{matchDetails?.description}</h4></Col>}
 
@@ -36,7 +40,7 @@ function BottomButtons({ previousMatch, nextMatch, matchDetails, playoffSchedule
                     {!adHocMode && <Button size="lg" variant="outline-success" className={"gatool-button buttonNoWrap"} onClick={nextMatch}><span className={"d-none d-lg-block"}>Next Match <CaretRightFill /></span><span className={"d-block d-lg-none"}><CaretRightFill /> <CaretRightFill /></span></Button>}
                 </Col>
             </Row>
-            <Row><FoulButtons currentYear={selectedEvent?.year}/></Row>
+            <Row><FoulButtons currentYear={selectedEvent?.year} /></Row>
             <Row> <br /><br /><br /></Row>
         </>
     )

--- a/src/components/Bracket.jsx
+++ b/src/components/Bracket.jsx
@@ -101,7 +101,7 @@ function Bracket({ playoffSchedule, offlinePlayoffSchedule, setOfflinePlayoffSch
 	// returns the name of the alliance
 	function allianceName(matchNumber, allianceColor) {
 		var allianceName = "";
-		if (matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.teams[0]?.teamNumber || matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.teams[3]?.teamNumber) {
+		if ((matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.teams[0]?.teamNumber || matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.teams[3]?.teamNumber) && alliances?.Lookup) {
 			allianceName = alliances?.Lookup[`${matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.teams[0]?.teamNumber}`]?.alliance;
 			if (matchNumber <= 13 || matchNumber === 19) {
 				if (matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.winner?.tieWinner === "red") {
@@ -120,7 +120,7 @@ function Bracket({ playoffSchedule, offlinePlayoffSchedule, setOfflinePlayoffSch
 
 
 		}
-		return allianceName;
+		return allianceName || "";
 	}
 	// return the score of the match, by matchNumber
 	function matchScore(matchNumber, alliance) {

--- a/src/components/LoginButton.jsx
+++ b/src/components/LoginButton.jsx
@@ -1,11 +1,10 @@
-import React from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 import { Button } from "react-bootstrap";
 
 const LoginButton = ({ size = "sm", block = false }) => {
   const { loginWithRedirect } = useAuth0();
   // @ts-ignore
-  const loginButton = <Button size={size} onClick={() => loginWithRedirect()}>Log In</Button>;
+  const loginButton = <Button size={size} onClick={() => loginWithRedirect()}><img src="/favicon-16x16.png" alt="gatool logo"/><div className='d-none d-md-block navBarText'>Log In</div></Button>;
   return <>
     {block ? <div className="d-grid gap-2">
       {loginButton}

--- a/src/contextProviders/AuthClientContext.jsx
+++ b/src/contextProviders/AuthClientContext.jsx
@@ -48,6 +48,34 @@ class AuthClient {
         throw new Error(errorText);
     }
 
+    async getNoAuth(path) {
+        if (!this.online) {
+            throw new Error('You are offline.')
+        }
+
+        this.operationStart();
+        var response = await fetch(`${apiBaseUrl}${path}`).finally(() => {
+            this.operationDone();
+        });
+        if (response.ok) return response;
+        var errorText = `Received a ${response.status} error from backend: "${response.statusText}"`;
+        if (response.status === 400) {
+            errorText += " This is an error with the FIRST APIs, not one caused by gatool. These usually clear in a few minutes, so please try again soon."
+        }
+        if (response.status === 401) {
+            errorText += " Your session may have expired. Please log out and log in again."
+        }
+        if (response.status === 404) {
+            errorText += " We couldn't find "+path;
+            return response;
+        }
+        if (response.status === 500) {
+            errorText += " Something happened in the backend that we don't understand. We have logged the request and will investigate soon."
+        }
+        toast.error(errorText);
+        throw new Error(errorText);
+    }
+
     async put(path, body) {
         if (!this.online) {
             throw new Error('You are offline.')

--- a/src/pages/AnnouncePage.jsx
+++ b/src/pages/AnnouncePage.jsx
@@ -12,7 +12,7 @@ import NotificationBanner from "components/NotificationBanner";
 
 const paleGreen = "rgba(144, 238, 144, 0.5)"
 
-function AnnouncePage({ selectedEvent, selectedYear, teamList, rankings, communityUpdates, currentMatch, playoffSchedule, qualSchedule, allianceCount, alliances, setAlliances, awardsMenu, showNotesAnnounce, showAwards, showMinorAwards, showSponsors, showMottoes, showChampsStats, timeFormat, eventHighScores, backupTeam, setBackupTeam, nextMatch, previousMatch, setMatchFromMenu, practiceSchedule, eventNamesCY, districtRankings, showDistrictChampsStats, adHocMatch, setAdHocMatch, adHocMode, offlinePlayoffSchedule, swapScreen, autoHideSponsors, hidePracticeSchedule, teamReduction, qualsLength, playoffOnly, getSchedule, usePullDownToUpdate, useSwipe, eventLabel, playoffCountOverride, showInspection }) {
+function AnnouncePage({ selectedEvent, selectedYear, teamList, rankings, communityUpdates, currentMatch, playoffSchedule, qualSchedule, allianceCount, alliances, setAlliances, awardsMenu, showNotesAnnounce, showAwards, showMinorAwards, showSponsors, showMottoes, showChampsStats, timeFormat, eventHighScores, backupTeam, setBackupTeam, nextMatch, previousMatch, setMatchFromMenu, practiceSchedule, eventNamesCY, districtRankings, showDistrictChampsStats, adHocMatch, setAdHocMatch, adHocMode, offlinePlayoffSchedule, swapScreen, autoHideSponsors, hidePracticeSchedule, teamReduction, qualsLength, playoffOnly, getSchedule, usePullDownToUpdate, useSwipe, eventLabel, playoffCountOverride, showInspection, highScoreMode }) {
     const matchesToNotify = _.toInteger((teamList?.teams?.length - teamReduction) / 6);
     if (qualSchedule?.schedule?.schedule?.length || qualSchedule?.schedule?.length) {
     };
@@ -240,7 +240,7 @@ function AnnouncePage({ selectedEvent, selectedYear, teamList, rankings, communi
                     </table>}
                     {matchDetails?.description?.includes("Bye Match") && <Alert><h1><b>BYE MATCH</b></h1></Alert>
                     }
-                    <BottomButtons previousMatch={previousMatch} nextMatch={nextMatch} matchDetails={matchDetails} playoffSchedule={playoffSchedule} eventHighScores={eventHighScores} alliances={alliances} selectedEvent={selectedEvent} adHocMode={adHocMode} playoffCountOverride={playoffCountOverride} />
+                    <BottomButtons previousMatch={previousMatch} nextMatch={nextMatch} matchDetails={matchDetails} playoffSchedule={playoffSchedule} eventHighScores={eventHighScores} alliances={alliances} selectedEvent={selectedEvent} adHocMode={adHocMode} playoffCountOverride={playoffCountOverride} highScoreMode={highScoreMode} />
                 </Container>
             }
 

--- a/src/pages/AnnouncePage.jsx
+++ b/src/pages/AnnouncePage.jsx
@@ -145,7 +145,7 @@ function AnnouncePage({ selectedEvent, selectedYear, teamList, rankings, communi
         } : null);
 
     if (practiceSchedule?.schedule.length > 0 && adHocMatch && (!qualSchedule || qualSchedule?.schedule.length === 0)) {
-        if (typeof matchDetails?.teams === "undefined") { matchDetails.teams = adHocMatch }
+        if (matchDetails && typeof matchDetails?.teams === "undefined") { matchDetails.teams = adHocMatch }
     };
 
     var inPlayoffs = (matchDetails?.tournamentLevel === "Playoff" ? true : false);

--- a/src/pages/PlayByPlayPage.jsx
+++ b/src/pages/PlayByPlayPage.jsx
@@ -12,7 +12,7 @@ import moment from "moment";
 const paleGreen = "rgba(144, 238, 144, 0.5)"
 
 
-function PlayByPlayPage({ selectedEvent, selectedYear, teamList, rankings, communityUpdates, currentMatch, playoffSchedule, qualSchedule, allianceCount, alliances, setAlliances, showNotes, showMottoes, showQualsStats, showQualsStatsQuals, swapScreen, timeFormat, eventHighScores, backupTeam, setBackupTeam, nextMatch, previousMatch, setMatchFromMenu, practiceSchedule, offlinePlayoffSchedule, districtRankings, adHocMatch, setAdHocMatch, adHocMode, hidePracticeSchedule, teamReduction, qualsLength, playoffOnly, getSchedule, usePullDownToUpdate, useSwipe, eventLabel, playoffCountOverride, showInspection }) {
+function PlayByPlayPage({ selectedEvent, selectedYear, teamList, rankings, communityUpdates, currentMatch, playoffSchedule, qualSchedule, allianceCount, alliances, setAlliances, showNotes, showMottoes, showQualsStats, showQualsStatsQuals, swapScreen, timeFormat, eventHighScores, backupTeam, setBackupTeam, nextMatch, previousMatch, setMatchFromMenu, practiceSchedule, offlinePlayoffSchedule, districtRankings, adHocMatch, setAdHocMatch, adHocMode, hidePracticeSchedule, teamReduction, qualsLength, playoffOnly, getSchedule, usePullDownToUpdate, useSwipe, eventLabel, playoffCountOverride, showInspection, highScoreMode }) {
     const matchesToNotify = _.toInteger((teamList?.teams?.length - teamReduction) / 6);
     const notification = (currentMatch >= (qualsLength - matchesToNotify) && currentMatch <= (qualsLength) && showInspection) ? { "expiry": moment().add(1, "hour"), "onTime": moment(), "message": "Please remind teams to have their robots reinspected before Playoffs and to send their team rep(s) for Alliance Selection." } : {};
 
@@ -249,7 +249,7 @@ function PlayByPlayPage({ selectedEvent, selectedYear, teamList, rankings, commu
                     </table>}
                     {matchDetails?.description?.includes("Bye Match") && <Alert><h1><b>BYE MATCH</b></h1></Alert>
                     }
-                    <BottomButtons previousMatch={previousMatch} nextMatch={nextMatch} matchDetails={matchDetails} playoffSchedule={playoffSchedule} eventHighScores={eventHighScores} alliances={alliances} selectedEvent={selectedEvent} adHocMode={adHocMode} playoffCountOverride={playoffCountOverride} />
+                    <BottomButtons previousMatch={previousMatch} nextMatch={nextMatch} matchDetails={matchDetails} playoffSchedule={playoffSchedule} eventHighScores={eventHighScores} alliances={alliances} selectedEvent={selectedEvent} adHocMode={adHocMode} playoffCountOverride={playoffCountOverride} highScoreMode={highScoreMode} />
                 </Container>}
         </>
     )

--- a/src/pages/SchedulePage.jsx
+++ b/src/pages/SchedulePage.jsx
@@ -823,7 +823,18 @@ function SchedulePage({ selectedEvent, setSelectedEvent, playoffSchedule, qualSc
                                     <td >Post Time:</td><td colSpan={2}>{moment(scoresMatch?.postResultTime).format('dd hh:mm A')}</td>
                                 </tr>
                                 <tr>
-                                    <td >Winner:</td><td colSpan={2}>{scoresMatch?.winner.winner === "red" ? <span style={{ color: "red" }}><b>Red Alliance</b></span> : scoresMatch?.winner.winner === "blue" ? <span style={{ color: "blue" }}><b>Blue Alliance</b></span> : scoresMatch?.winner.winner === "tie" ? "Tie" : ""}</td>
+                                    <td >Winner:</td>
+                                    <td colSpan={2}>
+                                        {scoresMatch?.winner.winner === "red" ? 
+                                        <span style={{ color: "red" }}><b>Red Alliance</b></span> :
+                                         scoresMatch?.winner.winner === "blue" ? 
+                                         <span style={{ color: "blue" }}><b>Blue Alliance</b></span> : 
+                                         scoresMatch?.winner.tieWinner === "red" ? <span style={{ color: "red" }}><b>{scoresMatch?.winner.tieDetail}</b></span> : 
+                                         scoresMatch?.winner.tieWinner === "blue" ? 
+                                         <span style={{ color: "blue" }}><b>{scoresMatch?.winner.tieDetail}</b></span> : 
+                                         scoresMatch?.winner.tieWinner === "tie" ? <span style={{ color: "green" }}><b>{scoresMatch?.winner.tieDetail}</b></span> : 
+                                         <span>""</span>}
+                                    </td>
                                 </tr>
                                 <tr>
                                     <td >Coopertition:</td><td colSpan={2}><Handshake result={scoresMatch?.scores?.coopertitionBonusAchieved || scoresMatch?.scores.alliances[0]?.coopertitionCriteriaMet} /></td>

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -60,7 +60,7 @@ const monthsWarningMenu = [
 
 
 
-function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedYear, eventList, teamList, qualSchedule, playoffSchedule, rankings, eventFilters, setEventFilters, districts,timeFilter, setTimeFilter, timeFormat, setTimeFormat, showSponsors, setShowSponsors, showAwards, setShowAwards, showNotes, setShowNotes, showNotesAnnounce, setShowNotesAnnounce, showMottoes, setShowMottoes, showChampsStats, setShowChampsStats, swapScreen, setSwapScreen, autoAdvance, setAutoAdvance, autoUpdate, setAutoUpdate, getSchedule, awardsMenu, setAwardsMenu, showQualsStats, setShowQualsStats, showQualsStatsQuals, setShowQualsStatsQuals, teamReduction, setTeamReduction, playoffCountOverride, setPlayoffCountOverride, allianceCount, localUpdates, setLocalUpdates, putTeamData, getCommunityUpdates, reverseEmcee, setReverseEmcee, showDistrictChampsStats, setShowDistrictChampsStats, monthsWarning, setMonthsWarning, user, adHocMode, setAdHocMode, supportedYears, reloadPage, autoHideSponsors, setAutoHideSponsors, setLoadingCommunityUpdates, hidePracticeSchedule, setHidePracticeSchedule, systemMessage, setTeamListLoading, getTeamList, getAlliances, setHaveChampsTeams, appUpdates, usePullDownToUpdate, setUsePullDownToUpdate, useSwipe, setUseSwipe, eventLabel, setEventLabel, showInspection, setShowInspection, showMinorAwards, setShowMinorAwards }) {
+function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedYear, eventList, teamList, qualSchedule, playoffSchedule, rankings, eventFilters, setEventFilters, districts,timeFilter, setTimeFilter, timeFormat, setTimeFormat, showSponsors, setShowSponsors, showAwards, setShowAwards, showNotes, setShowNotes, showNotesAnnounce, setShowNotesAnnounce, showMottoes, setShowMottoes, showChampsStats, setShowChampsStats, swapScreen, setSwapScreen, autoAdvance, setAutoAdvance, autoUpdate, setAutoUpdate, getSchedule, awardsMenu, setAwardsMenu, showQualsStats, setShowQualsStats, showQualsStatsQuals, setShowQualsStatsQuals, teamReduction, setTeamReduction, playoffCountOverride, setPlayoffCountOverride, allianceCount, localUpdates, setLocalUpdates, putTeamData, getCommunityUpdates, reverseEmcee, setReverseEmcee, showDistrictChampsStats, setShowDistrictChampsStats, monthsWarning, setMonthsWarning, user, adHocMode, setAdHocMode, supportedYears, reloadPage, autoHideSponsors, setAutoHideSponsors, setLoadingCommunityUpdates, hidePracticeSchedule, setHidePracticeSchedule, systemMessage, setTeamListLoading, getTeamList, getAlliances, setHaveChampsTeams, appUpdates, usePullDownToUpdate, setUsePullDownToUpdate, useSwipe, setUseSwipe, eventLabel, setEventLabel, showInspection, setShowInspection, showMinorAwards, setShowMinorAwards, highScoreMode, setHighScoreMode }) {
     const isOnline = useOnlineStatus();
     const PWASupported = (isChrome && Number(browserVersion) >= 76) || (isSafari && Number(browserVersion) >= 15 && Number(fullBrowserVersion.split(".")[1]) >= 4);
 
@@ -341,6 +341,14 @@ function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedY
                                     </td>
                                     <td>
                                         <b>Show Quals Statistics on Play-By-Play during Playoffs</b>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <Switch checked={highScoreMode === null ? false : highScoreMode} onChange={setHighScoreMode} />
+                                    </td>
+                                    <td>
+                                        <b>Always show <b><i>event high score</i></b> on Announce and Play-By-Play</b>
                                     </td>
                                 </tr>
                                 <tr>

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -273,7 +273,7 @@ function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedY
                                 </tr>
                                 <tr>
                                     <td>
-                                        <Switch checked={showMinorAwards === null ? true : showMinorAwards} onChange={setShowMinorAwards} disabled={!showAwards} />
+                                        <Switch checked={_.isNull(showMinorAwards) ? true : showMinorAwards} onChange={setShowMinorAwards} disabled={!(showAwards || _.isNull(showAwards))} />
                                     </td>
                                     <td>
                                         <b>Show Minor Awards on Announce</b>

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -60,7 +60,7 @@ const monthsWarningMenu = [
 
 
 
-function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedYear, eventList, teamList, qualSchedule, playoffSchedule, rankings, eventFilters, setEventFilters, districts,timeFilter, setTimeFilter, timeFormat, setTimeFormat, showSponsors, setShowSponsors, showAwards, setShowAwards, showNotes, setShowNotes, showNotesAnnounce, setShowNotesAnnounce, showMottoes, setShowMottoes, showChampsStats, setShowChampsStats, swapScreen, setSwapScreen, autoAdvance, setAutoAdvance, autoUpdate, setAutoUpdate, getSchedule, awardsMenu, setAwardsMenu, showQualsStats, setShowQualsStats, showQualsStatsQuals, setShowQualsStatsQuals, teamReduction, setTeamReduction, playoffCountOverride, setPlayoffCountOverride, allianceCount, localUpdates, setLocalUpdates, putTeamData, getCommunityUpdates, reverseEmcee, setReverseEmcee, showDistrictChampsStats, setShowDistrictChampsStats, monthsWarning, setMonthsWarning, user, adHocMode, setAdHocMode, supportedYears, reloadPage, autoHideSponsors, setAutoHideSponsors, setLoadingCommunityUpdates, hidePracticeSchedule, setHidePracticeSchedule, systemMessage, setTeamListLoading, getTeamList, getAlliances, setHaveChampsTeams, appUpdates, usePullDownToUpdate, setUsePullDownToUpdate, useSwipe, setUseSwipe, eventLabel, setEventLabel, showInspection, setShowInspection, showMinorAwards, setShowMinorAwards, highScoreMode, setHighScoreMode }) {
+function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedYear, eventList, teamList, qualSchedule, playoffSchedule, rankings, eventFilters, setEventFilters, districts,timeFilter, setTimeFilter, timeFormat, setTimeFormat, showSponsors, setShowSponsors, showAwards, setShowAwards, showNotes, setShowNotes, showNotesAnnounce, setShowNotesAnnounce, showMottoes, setShowMottoes, showChampsStats, setShowChampsStats, swapScreen, setSwapScreen, autoAdvance, setAutoAdvance, autoUpdate, setAutoUpdate, getSchedule, awardsMenu, setAwardsMenu, showQualsStats, setShowQualsStats, showQualsStatsQuals, setShowQualsStatsQuals, teamReduction, setTeamReduction, playoffCountOverride, setPlayoffCountOverride, allianceCount, localUpdates, setLocalUpdates, putTeamData, getCommunityUpdates, reverseEmcee, setReverseEmcee, showDistrictChampsStats, setShowDistrictChampsStats, monthsWarning, setMonthsWarning, user, isAuthenticated, adHocMode, setAdHocMode, supportedYears, reloadPage, autoHideSponsors, setAutoHideSponsors, setLoadingCommunityUpdates, hidePracticeSchedule, setHidePracticeSchedule, systemMessage, setTeamListLoading, getTeamList, getAlliances, setHaveChampsTeams, appUpdates, usePullDownToUpdate, setUsePullDownToUpdate, useSwipe, setUseSwipe, eventLabel, setEventLabel, showInspection, setShowInspection, showMinorAwards, setShowMinorAwards, highScoreMode, setHighScoreMode }) {
     const isOnline = useOnlineStatus();
     const PWASupported = (isChrome && Number(browserVersion) >= 76) || (isSafari && Number(browserVersion) >= 15 && Number(fullBrowserVersion.split(".")[1]) >= 4);
 
@@ -203,7 +203,7 @@ function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedY
                 </Col>
             </Row>}
             {!selectedEvent && <div>
-                <Alert variant="warning" >You need to select an event before you can see anything here. <LogoutButton disabled={!isOnline} /></Alert>
+                <Alert variant="warning" >You need to select an event before you can see anything here. {isAuthenticated && <LogoutButton disabled={!isOnline} />}</Alert>
 
             </div>}
             {selectedEvent && <div>
@@ -245,9 +245,9 @@ function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedY
                         {playoffSchedule?.matchesLastModified && <p><b>Playoff Results last updated: </b><br />{moment(playoffSchedule?.matchesLastModified).format("ddd, MMM Do YYYY, " + timeFormat.value)}</p>}
                         {teamList?.lastUpdate && <p><b>Team List last updated: </b><br />{moment(teamList?.lastUpdate).format("ddd, MMM Do YYYY, " + timeFormat.value)}</p>}
                         {rankings?.lastModified && <p><b>Rankings last updated: </b><br />{moment(rankings?.lastModified).format("ddd, MMM Do YYYY, " + timeFormat.value)}</p>}
-                        {((user["https://gatool.org/roles"] && (user["https://gatool.org/roles"].indexOf("user") >= 0)) && localUpdates.length > 0) && <Alert><p><b>You have {localUpdates.length === 1 ? "an update for team" : "updates for teams"} {_.sortBy(updatedTeamList).join(", ")} that can be uploaded to gatool Cloud.</b></p><span><Button disabled={!isOnline} style={{ width: "45%" }} onClick={uploadLocalUpdates}>Upload to gatool Cloud now</Button>  <Button disabled={!isOnline} variant={"warning"} style={{ width: "50%" }} onClick={deleteLocalUpdates}>Delete stored updates</Button></span></Alert>}
+                        {((isAuthenticated && user["https://gatool.org/roles"] && (user["https://gatool.org/roles"].indexOf("user") >= 0)) && localUpdates.length > 0) && <Alert><p><b>You have {localUpdates.length === 1 ? "an update for team" : "updates for teams"} {_.sortBy(updatedTeamList).join(", ")} that can be uploaded to gatool Cloud.</b></p><span><Button disabled={!isOnline} style={{ width: "45%" }} onClick={uploadLocalUpdates}>Upload to gatool Cloud now</Button>  <Button disabled={!isOnline} variant={"warning"} style={{ width: "50%" }} onClick={deleteLocalUpdates}>Delete stored updates</Button></span></Alert>}
                         <Alert variant={"warning"}><p><b>Update Team Data</b><br />You can refresh your community-sourced team data if it has changed on another device. <i><b>Know that we fetch all team data automatically when you load an event</b></i>, so you should not need this very often.</p><Button variant={"warning"} disabled={!isOnline} onClick={() => { handleGetTeamUpdates() }}>Update now</Button></Alert>
-                        { (user["https://gatool.org/roles"].indexOf("admin") >= 0) &&
+                        { (isAuthenticated && user["https://gatool.org/roles"].indexOf("admin") >= 0) &&
                                 <Link to="/dev">
                                     <Button variant="outline-danger" size="lg" onClick={() => {}} >Go to developer tools</Button>
                                 </Link>}
@@ -442,7 +442,7 @@ function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedY
                                 </tr>
                                 <tr>
                                     <td colSpan={2}>
-                                        <LogoutButton disabled={!isOnline} />
+                                        {isAuthenticated && <LogoutButton disabled={!isOnline} />}
                                     </td>
                                 </tr>
                             </tbody>

--- a/src/pages/TeamDataPage.jsx
+++ b/src/pages/TeamDataPage.jsx
@@ -18,7 +18,7 @@ import 'react-quill/dist/quill.snow.css';
 import TeamTimer from "components/TeamTimer";
 import { useInterval } from "react-interval-hook";
 
-function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSort, setTeamSort, communityUpdates, setCommunityUpdates, allianceCount, lastVisit, setLastVisit, putTeamData, localUpdates, setLocalUpdates, qualSchedule, playoffSchedule, originalAndSustaining, monthsWarning, user, getTeamHistory, timeFormat, getCommunityUpdates, getTeamList, eventLabel }) {
+function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSort, setTeamSort, communityUpdates, setCommunityUpdates, allianceCount, lastVisit, setLastVisit, putTeamData, localUpdates, setLocalUpdates, qualSchedule, playoffSchedule, originalAndSustaining, monthsWarning, user, isAuthenticated, getTeamHistory, timeFormat, getCommunityUpdates, getTeamList, eventLabel }) {
     const [currentTime, setCurrentTime] = useState(moment());
     const [clockRunning, setClockRunning] = useState(true);
     const { disableScope, enableScope } = useHotkeysContext();
@@ -256,7 +256,7 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
      * @param {*} e  - the inbound event from clicking the button. 
      */
     const handleShow = (team, e) => {
-        if (user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("user") >= 0) {
+        if (isAuthenticated && user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("user") >= 0) {
             setUpdateTeam(team);
             setNameShortLocal(team?.updates?.nameShortLocal || "");
             setOrganizationLocal(team?.updates?.organizationLocal || "");
@@ -279,7 +279,7 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
     }
 
     const handleHistory = async (team, e) => {
-        if (user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("user") >= 0) {
+        if (isAuthenticated && user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("user") >= 0) {
             var history = await getTeamHistory(team.teamNumber);
             setShowHistory(true);
             setTeamHistory(_.orderBy(history, ['modifiedDate'], ['desc']));
@@ -674,7 +674,7 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
             </div>}
             {selectedEvent && teamList?.teams.length > 0 && <><div>
                 <h4>{eventLabel || selectedEvent?.label}</h4>
-                <p className={"leftTable"}>This table is {(user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("user") >= 0) ? <>editable and sortable. Tap on a team number to change data for a specific team. Edits you make are local to this browser, and they will persist here if you do not clear your browser cache. You can save your changes to the gatool Cloud on the team details page or on the Setup Screen. </> : <>sortable. </>}Cells <span className={"teamTableHighlight"}>highlighted in green</span> have been modified, either by you or by other gatool users.</p>
+                <p className={"leftTable"}>This table is {(isAuthenticated && user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("user") >= 0) ? <>editable and sortable. Tap on a team number to change data for a specific team. Edits you make are local to this browser, and they will persist here if you do not clear your browser cache. You can save your changes to the gatool Cloud on the team details page or on the Setup Screen. </> : <>sortable. </>}Cells <span className={"teamTableHighlight"}>highlighted in green</span> have been modified, either by you or by other gatool users.</p>
                 <Table responsive className={"leftTable topBorderLine"}>
                     <thead>
                         <tr>
@@ -684,7 +684,7 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
                             <td>
                                 <span style={{ cursor: "pointer", color: "darkblue" }} onClick={downloadTeamInfoSheets}><img style={{ float: "left" }} width="30" src="images/wordicon.png" alt="Word Logo" /> <b>Tap here to download a merged document (docx).</b></span>
                             </td>
-                            {(user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("user") >= 0) && <td>
+                            {(isAuthenticated && user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("user") >= 0) && <td>
                                 <span style={{ cursor: "pointer", color: "darkblue" }} onClick={clickRestoreBackup}><input type="file" id="BackupFiles" onChange={handleRestoreBackup} className={"hiddenInput"} /><b><img style={{ float: "left" }} width="30" src="images/excelicon.png" alt="Excel Logo" /> Tap here to restore team data from Excel</b></span>
                             </td>}
                         </tr>
@@ -698,7 +698,7 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
                             <td>
                                 <p>This merged doc contains all of the information in your Teams List, merged onto a template you can print and distribute to teams. <i>Note: this will save to Files on iOS 13+</i></p>
                             </td>
-                            {(user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("user") >= 0) && <td>
+                            {(isAuthenticated && user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("user") >= 0) && <td>
                                 <p>You can export your teams data to Excel using the button on the left, and then restore it from backup here. This is handy in low or no network situations, where you may be unable to update changes to gatool Cloud. <i>Note: Be careful if you modify the Excel file and then import it here.</i></p>
                             </td>}
                         </tr>
@@ -887,7 +887,7 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
                             <td>Announce Screen Notes</td>
                             <td>Sponsors</td>
                             <td>How to pronounce #</td>
-                            {(user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("admin") >= 0) && <td>
+                            {(isAuthenticated && user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("admin") >= 0) && <td>
                                 Source</td>}
                             <td></td>
                         </tr>
@@ -906,7 +906,7 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
                                 <td>{updateTeam?.updates?.teamNotesLocal}</td>
                                 <td>{updateTeam?.updates?.topSponsorsLocal}</td>
                                 <td><td>{updateTeam?.updates?.sayNumber}</td></td>
-                                {(user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("admin") >= 0) && <td>
+                                {(isAuthenticated && user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("admin") >= 0) && <td>
                                     {updateTeam?.updates?.source}</td>}
                                 <td>Current Value</td>
                             </tr>
@@ -924,7 +924,7 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
                                     <td>{team?.teamNotesLocal}</td>
                                     <td>{team?.sponsorsLocal}</td>
                                     <td>{team?.sayNumber}</td>
-                                    {(user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("admin") >= 0) && <td>
+                                    {(isAuthenticated && user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("admin") >= 0) && <td>
                                         {team?.source}</td>}
                                     <td><Button onClick={() => { handleRestoreData({ "team": updateTeam, "update": team }) }}>Restore</Button></td>
                                 </tr>


### PR DESCRIPTION
This introduces **Unauthenticated** access to gatool.

Unauthenticated users can:

- load events
- view but not edit team data
- announce teams
- call matches
- run Alliance Selection
- announce awards

We will consider a reduced-functionality "simple" mode at a later date.

This also adds controls to show high scores based on tournament stage (Quals or Playoffs), removes the manual tiebreaker calculations for Playoffs, and updated the auto-advance to allow users to remain on matches ahead of the match that gatool thinks is the current match.