### PR TITLE
FTC Playoffs and Alliance Selection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1134,7 +1134,7 @@ function App() {
 
       if (
         selectedEvent?.value?.code.includes("OFFLINE") ||
-        inWorldChamps() ||
+        (inWorldChamps() && !ftcMode) ||
         (cheesyArenaAvailable && useCheesyArena)
       ) {
         teams = {
@@ -1481,11 +1481,12 @@ function App() {
 
       var champsTeams = [];
       if (
-        selectedEvent?.value?.champLevel !== "" ||
+        // Do not attempt to get Champs stats for FTC events
+        (selectedEvent?.value?.champLevel !== "" ||
         showDistrictChampsStats ||
         (selectedEvent?.value?.code.includes("OFFLINE") &&
           playoffOnly &&
-          champsStyle)
+          champsStyle)) && !ftcMode
       ) {
         console.log("Getting Champs stats");
         champsTeams = teams.teams.map(async (team) => {
@@ -1597,18 +1598,18 @@ function App() {
 
           teams.teams = values;
           setTeamList(teams);
-          
+
         });
       } else {
         teams.lastUpdate = moment();
         setTeamList(teams);
-        
+
       }
       // });
       // determine the number of Alliances in the playoffs for FTC events
       if (ftcMode && !selectedEvent.value.allianceCount) {
         var allianceCount = "EightAlliance";
-        if (teams.teams.length<=10) {
+        if (teams.teams.length <= 10) {
           allianceCount = "TwoAlliance"
         } else if (teams.teams.length <= 20) {
           allianceCount = "FourAlliance";
@@ -1715,9 +1716,9 @@ function App() {
           );
           if (result.status === 200) {
             teams = await result.json();
-          } else  { 
+          } else {
             setCommunityUpdates([]);
-            setLoadingCommunityUpdates(false); 
+            setLoadingCommunityUpdates(false);
           }
         } else {
           teams = training.teams.communityUpdates;
@@ -2652,6 +2653,8 @@ function App() {
           } else if (e.type === "ChampionshipSubdivision") {
             e.champLevel = "CMPSUB";
           } else if (e.type === "Championship") {
+            e.champLevel = "CHAMPS";
+          } else if (e.type === "6") {
             e.champLevel = "CHAMPS";
           }
 

--- a/src/components/AllianceSelection.jsx
+++ b/src/components/AllianceSelection.jsx
@@ -7,7 +7,7 @@ import { useEffect } from "react";
 import { originalAndSustaining, allianceSelectionBaseRounds } from "./Constants";
 import useWindowDimensions from "hooks/UseWindowDimensions";
 
-function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, allianceCount, communityUpdates, allianceSelectionArrays, setAllianceSelectionArrays, handleReset, teamFilter, setTeamFilter }) {
+function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, allianceCount, communityUpdates, allianceSelectionArrays, setAllianceSelectionArrays, handleReset, teamFilter, setTeamFilter, ftcMode }) {
     const OriginalAndSustaining = _.cloneDeep(originalAndSustaining);
     const AllianceSelectionBaseRounds = _.cloneDeep(allianceSelectionBaseRounds);
 
@@ -19,7 +19,7 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
 
 
     var availColumns = [[], [], [], [], []];
-    var allianceSelectionRounds = ["round1", "round2"]
+    var allianceSelectionRounds = ftcMode ? ["round1"] : ["round1", "round2"]
     var backupTeams = [];
     var alliances = null;
     var allianceDisplayOrder = [];
@@ -43,11 +43,16 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
             : false;
 
     var allianceSelectionOrder = [];
-    var allianceSelectionOrderRounds = { round1: [], round2: [] };
+    var allianceSelectionOrderRounds = ftcMode ? { round1: [] } : { round1: [], round2: [] };
 
     if (inChamps) {
-        allianceSelectionOrderRounds.round3 = [];
-        allianceSelectionRounds.push("round3");
+        if (!ftcMode) {
+            allianceSelectionOrderRounds.round3 = [];
+            allianceSelectionRounds.push("round3");
+        } else {
+            allianceSelectionOrderRounds.round2 = [];
+            allianceSelectionRounds.push("round2");
+        }
     };
 
     allianceSelectionRounds.forEach((round, index) => {
@@ -262,8 +267,13 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
         setShow(true);
     }
 
-    const colCount = width > 1040 ? 5 :
-        width > 850 ? 4 :
+    const colCount = !ftcMode && width > 1040 ? 5 :
+        !ftcMode && width > 850 ? 4 :
+        ftcMode && width > 1500 ? 5 :
+        ftcMode && width > 1220 ? 4 :
+        ftcMode && width > 930 ? 3 :
+        ftcMode && width > 600 ? 2 :
+        ftcMode && width <= 600 ? 1 :
             3;
 
     useEffect(() => {
@@ -482,7 +492,7 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
                                         <Container fluid className={"backupAlliancesTable"}>
                                             <Row>
                                                 <Col>
-                                                    <p><strong>Backup Teams</strong><br />(Teams here are initially ranked {allianceCount?.count + 1} to {allianceCount?.count + 8} top to bottom. As Alliance Selection progresses, teams will rise up into this section as teams are selected.)</p>
+                                                    <p><strong>{ftcMode ? "Top Ranked Teams" : "Backup Teams"}</strong><br />(Teams here are initially ranked {allianceCount?.count + 1} to {allianceCount?.count + 8} top to bottom. As Alliance Selection progresses, teams will rise up into this section as teams are selected.)</p>
                                                 </Col>
                                             </Row>
                                             <Row>
@@ -589,22 +599,23 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
                                                                                     </Row>}
 
                                                                                 <Row>
-                                                                                    <Col xs={inChamps ? 4 : 6} className={(asArrays.allianceSelectionOrder[asArrays?.nextChoice]?.number === allianceNumber) && (asArrays.allianceSelectionOrder[asArrays?.nextChoice]?.round === 1) ? "alliancedrop nextAllianceChoice" : "alliancedrop"}>
+                                                                                    <Col xs={inChamps && !ftcMode ? 4 : !inChamps && ftcMode ? 12 : 6} className={(asArrays.allianceSelectionOrder[asArrays?.nextChoice]?.number === allianceNumber) && (asArrays.allianceSelectionOrder[asArrays?.nextChoice]?.round === 1) ? "alliancedrop nextAllianceChoice" : "alliancedrop"}>
                                                                                         <div><b>1<sup>st</sup> pick</b></div>
                                                                                         <div key={`${allianceName}round1`}
                                                                                             className={round1?.declined ? "allianceDecline allianceTeamChoice" : round1?.teamNumber ? "allianceTeam allianceTeamChosen" : "allianceTeam allianceTeamChoice"}>{round1?.teamNumber ? <b>{round1?.teamNumber}</b> : <b>TBD</b>}
                                                                                         </div>
                                                                                     </Col>
 
-                                                                                    <Col xs={inChamps ? 4 : 6} className={(asArrays.allianceSelectionOrder[asArrays?.nextChoice]?.number === allianceNumber) && (asArrays.allianceSelectionOrder[asArrays?.nextChoice]?.round === 2) ? "alliancedrop nextAllianceChoice" : "alliancedrop"}>
-                                                                                        <div><b>2<sup>nd</sup> pick</b></div>
-                                                                                        <div key={`${allianceName}round2`}
-                                                                                            className={round2?.declined ? "allianceDecline allianceTeamChoice" : round2?.teamNumber ? "allianceTeam allianceTeamChosen" : "allianceTeam allianceTeamChoice"}>{round2?.teamNumber ? <b>{round2?.teamNumber}</b> : <b>TBD</b>}
-                                                                                        </div>
-                                                                                    </Col>
+                                                                                    {((inChamps && ftcMode) || !ftcMode) &&
+                                                                                        <Col xs={inChamps && !ftcMode ? 4 : 6} className={(asArrays.allianceSelectionOrder[asArrays?.nextChoice]?.number === allianceNumber) && (asArrays.allianceSelectionOrder[asArrays?.nextChoice]?.round === 2) ? "alliancedrop nextAllianceChoice" : "alliancedrop"}>
+                                                                                            <div><b>2<sup>nd</sup> pick</b></div>
+                                                                                            <div key={`${allianceName}round2`}
+                                                                                                className={round2?.declined ? "allianceDecline allianceTeamChoice" : round2?.teamNumber ? "allianceTeam allianceTeamChosen" : "allianceTeam allianceTeamChoice"}>{round2?.teamNumber ? <b>{round2?.teamNumber}</b> : <b>TBD</b>}
+                                                                                            </div>
+                                                                                        </Col>}
 
 
-                                                                                    {inChamps &&
+                                                                                    {inChamps && !ftcMode &&
                                                                                         <Col xs={inChamps ? 4 : 6} className={(asArrays.allianceSelectionOrder[asArrays?.nextChoice]?.number === allianceNumber) && (asArrays.allianceSelectionOrder[asArrays?.nextChoice]?.round === 3) ? "alliancedrop nextAllianceChoice" : "alliancedrop"}>
                                                                                             <div><b>3<sup>rd</sup> pick</b></div>
                                                                                             <div key={`${allianceName}round3`}
@@ -630,7 +641,7 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
                                         <Container fluid className={"backupAlliancesTable"}>
                                             <Row>
                                                 <Col>
-                                                    <p><strong>Backup Teams</strong><br />(Teams here are initially ranked {allianceCount?.count + 1} to {allianceCount?.count + 8} top to bottom. As Alliance Selection progresses, teams will rise up into this section as teams are selected.)</p>
+                                                    <p><strong>{ftcMode ? "Top Ranked Teams" : "Backup Teams"}</strong><br />(Teams here are initially ranked {allianceCount?.count + 1} to {allianceCount?.count + 8} top to bottom. As Alliance Selection progresses, teams will rise up into this section as teams are selected.)</p>
                                                 </Col>
                                             </Row>
                                             <Row>
@@ -701,34 +712,34 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
 
                     </Modal.Body>
                     <Modal.Footer>
-                                <Button variant="primary" size="sm" onClick={handleClose} style={{ marginBottom: "10px" }}>
-                                    {allianceMode === "show" && <span> <TrophyFill /> Alliance Announce</span>}
-                                    {allianceMode === "a1captain" && <span> <TrophyFill /> Top Seeded Alliance</span>}
-                                    {allianceMode === "captain" && <span> <TrophyFill /> Alliance Captain</span>}
-                                    {allianceMode === "declined" && <span> <TrophyFill /> Sorry</span>}
-                                    {(allianceMode === "decline" || allianceMode === "accept" || allianceMode === "skip") && <span><TrophyFill /> Oops, they reconsidered.</span>}
-                                </Button>
-                            
-                            {(allianceMode === "show" || allianceMode === "decline") &&
-                                <Button id="declineButton" variant="danger" size="sm" style={{ marginBottom: "10px" }} onClick={(e) => { handleDecline(allianceTeam, allianceMode === "decline" ? "confirm" : "decline", e) }}>
-                                    <HandThumbsDownFill /> Respectfully Decline
-                                </Button>
-                                }
-                            {(allianceMode === "show" || allianceMode === "accept") &&
-                                
-                                    <Button id="acceptButton" variant="success" size="sm" style={{ marginBottom: "10px" }} onClick={(e) => { handleAccept(allianceTeam, allianceMode === "accept" ? "confirm" : "accept", e) }}>
-                                        <HandThumbsUpFill /> Gratefully Accept
-                                    </Button>
-                                }
-                            {(allianceMode === "a1captain" || allianceMode === "captain" || allianceMode === "skip") &&
-                                
-                                    <Button id="skipButton" variant="warning" size="sm" style={{
-                                        marginBottom: "10px"
-                                    }} onClick={(e) => { handleSkip(allianceTeam, allianceMode === "skip" ? "confirm" : "skip", e) }}>
-                                        <HandThumbsUpFill /> Skip Alliance
-                                    </Button>
-                                }
-                        
+                        <Button variant="primary" size="sm" onClick={handleClose} style={{ marginBottom: "10px" }}>
+                            {allianceMode === "show" && <span> <TrophyFill /> Alliance Announce</span>}
+                            {allianceMode === "a1captain" && <span> <TrophyFill /> Top Seeded Alliance</span>}
+                            {allianceMode === "captain" && <span> <TrophyFill /> Alliance Captain</span>}
+                            {allianceMode === "declined" && <span> <TrophyFill /> Sorry</span>}
+                            {(allianceMode === "decline" || allianceMode === "accept" || allianceMode === "skip") && <span><TrophyFill /> Oops, they reconsidered.</span>}
+                        </Button>
+
+                        {(allianceMode === "show" || allianceMode === "decline") &&
+                            <Button id="declineButton" variant="danger" size="sm" style={{ marginBottom: "10px" }} onClick={(e) => { handleDecline(allianceTeam, allianceMode === "decline" ? "confirm" : "decline", e) }}>
+                                <HandThumbsDownFill /> Respectfully Decline
+                            </Button>
+                        }
+                        {(allianceMode === "show" || allianceMode === "accept") &&
+
+                            <Button id="acceptButton" variant="success" size="sm" style={{ marginBottom: "10px" }} onClick={(e) => { handleAccept(allianceTeam, allianceMode === "accept" ? "confirm" : "accept", e) }}>
+                                <HandThumbsUpFill /> Gratefully Accept
+                            </Button>
+                        }
+                        {(allianceMode === "a1captain" || allianceMode === "captain" || allianceMode === "skip") &&
+
+                            <Button id="skipButton" variant="warning" size="sm" style={{
+                                marginBottom: "10px"
+                            }} onClick={(e) => { handleSkip(allianceTeam, allianceMode === "skip" ? "confirm" : "skip", e) }}>
+                                <HandThumbsUpFill /> Skip Alliance
+                            </Button>
+                        }
+
                     </Modal.Footer>
                 </Modal>}
             </Container>

--- a/src/components/TopButtons.jsx
+++ b/src/components/TopButtons.jsx
@@ -124,7 +124,7 @@ function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatc
 
     availableTeams = _.orderBy(availableTeams, ["label"], "asc");
     const inPractice = matchDetails?.description.toLowerCase().includes("practice");
-    const addBackupButton = inPlayoffs && ((selectedEvent?.value?.champLevel !== "CHAMPS" && selectedEvent?.value?.champLevel !== "CMPDIV" && selectedEvent?.value?.champLevel !== "CMPSUB") || (selectedEvent?.value?.code === "OFFLINE" && !playoffOnly));
+    const addBackupButton = !ftcMode && inPlayoffs && ((selectedEvent?.value?.champLevel !== "CHAMPS" && selectedEvent?.value?.champLevel !== "CMPDIV" && selectedEvent?.value?.champLevel !== "CMPSUB") || (selectedEvent?.value?.code === "OFFLINE" && !playoffOnly));
 
     let eventTeams = teamList?.teams.map((team) => {
         return ({ "label": team.teamNumber, "value": team.teamNumber })
@@ -144,7 +144,7 @@ function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatc
                     {!adHocMode && <Button size="lg" variant="outline-success" className={"gatool-button buttonNoWrap"} onClick={previousMatch}>{inPractice ? <span><CaretLeftFill /> <CaretLeftFill /></span> : <><span className={"d-none d-lg-block"}><CaretLeftFill /> Previous Match</span><span className={"d-block d-lg-none"}><CaretLeftFill /> <CaretLeftFill /></span></>}</Button>}
                 </Col>
                 {!adHocMode && <MatchClock matchDetails={matchDetails} timeFormat={timeFormat} />}
-                <Col xs={addBackupButton || inPractice ? "4" : "5"} lg={inPlayoffs || inPractice ? "3" : "4"}><b>{eventLabel?.replace("FIRST Championship - ", "").replace("FIRST In Texas District Championship - ", "").replace("FIRST Ontario Provincial Championship - ", "").replace("New England FIRST District Championship - ", "")}</b><br />
+                <Col xs={addBackupButton || inPractice ? "4" : "5"} lg={!ftcMode && (inPlayoffs || inPractice) ? "3" : "4"}><b>{eventLabel?.replace("FIRST Championship - ", "").replace("FIRST In Texas District Championship - ", "").replace("FIRST Ontario Provincial Championship - ", "").replace("New England FIRST District Championship - ", "")}</b><br />
                     {!adHocMode && <Select options={matchMenu} value={currentMatch ? matchMenu[currentMatch - 1] : matchMenu[0]} onChange={handleMatchSelection} styles={{
                         // @ts-ignore
                         option: (styles, { data }) => {

--- a/src/pages/AllianceSelectionPage.jsx
+++ b/src/pages/AllianceSelectionPage.jsx
@@ -78,8 +78,8 @@ function AllianceSelectionPage({ selectedYear, selectedEvent, qualSchedule, play
         const tieLevel = allianceCount === 8 ? 13 : allianceCount === 6 ? 10 : allianceCount === 4 ? 6 : 1;
         var allianceName = "";
         var match = matches[_.findIndex(matches, { "matchNumber": matchNumber })];
-        if ((match?.teams[0]?.teamNumber || match?.teams[3]?.teamNumber) && alliances?.Lookup) {
-            const lookupTeam = match?.teams[_.findIndex(match?.teams, { "station": allianceColor === "red" ? "Red1" : "Blue1" })]?.teamNumber;
+        const lookupTeam = match?.teams[_.findIndex(match?.teams, { "station": allianceColor === "red" ? "Red1" : "Blue1" })]?.teamNumber;
+        if (lookupTeam && alliances?.Lookup) {
             const targetAlliance = alliances?.Lookup[`${lookupTeam}`];
             allianceName = targetAlliance?.alliance;
             if (matchNumber <= tieLevel || matchNumber === tieLevel + 6) {
@@ -169,9 +169,9 @@ function AllianceSelectionPage({ selectedYear, selectedEvent, qualSchedule, play
                             }
                         </Alert>}
                 </div>}
-            {selectedEvent && (qualSchedule?.schedule?.length > 0 || qualSchedule?.schedule?.schedule?.length > 0 || practiceSchedule?.schedule?.length > 0) && !playoffs && (allianceSelection || overrideAllianceSelection) &&
+            {selectedEvent && ((qualSchedule?.schedule?.length > 0 || qualSchedule?.schedule?.schedule?.length > 0 || practiceSchedule?.schedule?.length > 0) && !playoffs && (allianceSelection || overrideAllianceSelection)) &&
                 <div>
-                    <AllianceSelection selectedYear={selectedYear} selectedEvent={selectedEvent} rankings={rankings} teamList={teamList} allianceCount={allianceCount} communityUpdates={communityUpdates} allianceSelectionArrays={allianceSelectionArrays} setAllianceSelectionArrays={setAllianceSelectionArrays} handleReset={handleReset} teamFilter={teamFilter} setTeamFilter={setTeamFilter} />
+                    <AllianceSelection selectedYear={selectedYear} selectedEvent={selectedEvent} rankings={rankings} teamList={teamList} allianceCount={allianceCount} communityUpdates={communityUpdates} allianceSelectionArrays={allianceSelectionArrays} setAllianceSelectionArrays={setAllianceSelectionArrays} handleReset={handleReset} teamFilter={teamFilter} setTeamFilter={setTeamFilter} ftcMode={ftcMode}/>
                 </div>}
 
             {selectedEvent && (alliancesCount === 8) && playoffs &&

--- a/src/pages/AllianceSelectionPage.jsx
+++ b/src/pages/AllianceSelectionPage.jsx
@@ -174,13 +174,13 @@ function AllianceSelectionPage({ selectedYear, selectedEvent, qualSchedule, play
                     <AllianceSelection selectedYear={selectedYear} selectedEvent={selectedEvent} rankings={rankings} teamList={teamList} allianceCount={allianceCount} communityUpdates={communityUpdates} allianceSelectionArrays={allianceSelectionArrays} setAllianceSelectionArrays={setAllianceSelectionArrays} handleReset={handleReset} teamFilter={teamFilter} setTeamFilter={setTeamFilter} />
                 </div>}
 
-            {(alliancesCount === 8) && playoffs &&
+            {selectedEvent && (alliancesCount === 8) && playoffs &&
                 <Bracket offlinePlayoffSchedule={offlinePlayoffSchedule} setOfflinePlayoffSchedule={setOfflinePlayoffSchedule} currentMatch={currentMatch} qualsLength={qualsLength} nextMatch={nextMatch} previousMatch={previousMatch} getSchedule={getSchedule} usePullDownToUpdate={usePullDownToUpdate} useSwipe={useSwipe} eventLabel={eventLabel} playoffCountOverride={playoffCountOverride} ftcMode={ftcMode} matches={matches} allianceNumbers={allianceNumbers} allianceName={allianceName} matchScore={matchScore} matchWinner={matchWinner} />}
-            {(alliancesCount === 6) && playoffs &&
+            {selectedEvent && (alliancesCount === 6) && playoffs &&
                 <SixAllianceBracket offlinePlayoffSchedule={offlinePlayoffSchedule} setOfflinePlayoffSchedule={setOfflinePlayoffSchedule} currentMatch={currentMatch} qualsLength={qualsLength} nextMatch={nextMatch} previousMatch={previousMatch} getSchedule={getSchedule} usePullDownToUpdate={usePullDownToUpdate} useSwipe={useSwipe} eventLabel={eventLabel} playoffCountOverride={playoffCountOverride} ftcMode={ftcMode} matches={matches} allianceNumbers={allianceNumbers} allianceName={allianceName} matchScore={matchScore} matchWinner={matchWinner} />}
-            {(alliancesCount === 4) && playoffs &&
+            {selectedEvent && (alliancesCount === 4) && playoffs &&
                 <FourAllianceBracket currentMatch={currentMatch} qualsLength={qualsLength} nextMatch={nextMatch} previousMatch={previousMatch} getSchedule={getSchedule} useSwipe={useSwipe} usePullDownToUpdate={usePullDownToUpdate} offlinePlayoffSchedule={offlinePlayoffSchedule} setOfflinePlayoffSchedule={setOfflinePlayoffSchedule} eventLabel={eventLabel} ftcMode={ftcMode} matches={matches} allianceNumbers={allianceNumbers} allianceName={allianceName} matchScore={matchScore} matchWinner={matchWinner} />}
-            {(alliancesCount === 2) && playoffs &&
+            {selectedEvent && (alliancesCount === 2) && playoffs &&
                 <TwoAllianceBracket nextMatch={nextMatch} previousMatch={previousMatch} getSchedule={getSchedule} useSwipe={useSwipe} usePullDownToUpdate={usePullDownToUpdate} eventLabel={eventLabel} ftcMode={ftcMode} matches={matches} allianceNumbers={allianceNumbers} allianceName={allianceName} matchScore={matchScore} matchWinner={matchWinner} />}
             <Modal centered={true} show={resetAllianceSelection} onHide={handleClose}>
                 <Modal.Header className={"allianceSelectionDecline"} closeVariant={"white"} closeButton>

--- a/src/pages/AnnouncePage.jsx
+++ b/src/pages/AnnouncePage.jsx
@@ -74,14 +74,14 @@ function AnnouncePage({
   }
   const notification =
     currentMatch >= qualsLength - matchesToNotify &&
-    currentMatch <= qualsLength &&
-    showInspection
+      currentMatch <= qualsLength &&
+      showInspection
       ? {
-          expiry: moment().add(1, "hour"),
-          onTime: moment(),
-          message:
-            "Please remind teams to have their robots reinspected before Playoffs and to send their team rep(s) for Alliance Selection.",
-        }
+        expiry: moment().add(1, "hour"),
+        onTime: moment(),
+        message:
+          "Please remind teams to have their robots reinspected before Playoffs and to send their team rep(s) for Alliance Selection.",
+      }
       : {};
 
   function updateTeamDetails(station, matchDetails) {
@@ -95,30 +95,30 @@ function AnnouncePage({
     if (station.slice(-1) !== "4") {
       team =
         matchDetails?.teams[
-          _.findIndex(matchDetails?.teams, { station: station })
+        _.findIndex(matchDetails?.teams, { station: station })
         ];
       team = communityUpdates
         ? _.merge(
-            team,
-            teamList?.teams[
-              _.findIndex(teamList?.teams, { teamNumber: team?.teamNumber })
-            ],
-            rankings?.ranks[
-              _.findIndex(rankings?.ranks, { teamNumber: team?.teamNumber })
-            ],
-            communityUpdates[
-              _.findIndex(communityUpdates, { teamNumber: team?.teamNumber })
-            ]
-          )
+          team,
+          teamList?.teams[
+          _.findIndex(teamList?.teams, { teamNumber: team?.teamNumber })
+          ],
+          rankings?.ranks[
+          _.findIndex(rankings?.ranks, { teamNumber: team?.teamNumber })
+          ],
+          communityUpdates[
+          _.findIndex(communityUpdates, { teamNumber: team?.teamNumber })
+          ]
+        )
         : _.merge(
-            team,
-            teamList?.teams[
-              _.findIndex(teamList?.teams, { teamNumber: team?.teamNumber })
-            ],
-            rankings?.ranks[
-              _.findIndex(rankings?.ranks, { teamNumber: team?.teamNumber })
-            ]
-          );
+          team,
+          teamList?.teams[
+          _.findIndex(teamList?.teams, { teamNumber: team?.teamNumber })
+          ],
+          rankings?.ranks[
+          _.findIndex(rankings?.ranks, { teamNumber: team?.teamNumber })
+          ]
+        );
       team.rankStyle = rankHighlight(team?.rank, allianceCount || { count: 8 });
       team.alliance = alliances?.Lookup[`${team?.teamNumber}`]
         ? alliances?.Lookup[`${team?.teamNumber}`]?.alliance || null
@@ -143,8 +143,8 @@ function AnnouncePage({
         });
         var allianceTeams = allianceNumber
           ? _.filter(playoffTeams, { alliance: allianceNumber }).map((o) => {
-              return o.teamNumber;
-            })
+            return o.teamNumber;
+          })
           : [];
         // var allianceMembers = allianceNumber ? _.filter(alliances?.alliances, { "number": Number(allianceNumber.slice(-1)) })[0] : [];
         var allianceMembers = allianceNumber
@@ -166,19 +166,19 @@ function AnnouncePage({
           team = _.merge(
             team,
             teamList?.teams[
-              _.findIndex(teamList?.teams, { teamNumber: remainingTeam[0] })
+            _.findIndex(teamList?.teams, { teamNumber: remainingTeam[0] })
             ],
             rankings?.ranks?.length > 0
               ? rankings?.ranks[
-                  _.findIndex(rankings?.ranks, { teamNumber: remainingTeam[0] })
-                ]
+              _.findIndex(rankings?.ranks, { teamNumber: remainingTeam[0] })
+              ]
               : null,
             communityUpdates?.length > 0
               ? communityUpdates[
-                  _.findIndex(communityUpdates, {
-                    teamNumber: remainingTeam[0],
-                  })
-                ]
+              _.findIndex(communityUpdates, {
+                teamNumber: remainingTeam[0],
+              })
+              ]
               : null
           );
           team.rankStyle = rankHighlight(
@@ -247,7 +247,7 @@ function AnnouncePage({
   var matchDetails = !adHocMode
     ? schedule[currentMatch - 1]
     : adHocMatch
-    ? {
+      ? {
         description: "Practice Match",
         startTime: null,
         matchNumber: 1,
@@ -320,7 +320,7 @@ function AnnouncePage({
           level: null,
         },
       }
-    : null;
+      : null;
 
   if (
     practiceSchedule?.schedule.length > 0 &&
@@ -332,13 +332,13 @@ function AnnouncePage({
     }
   }
 
-  var inPlayoffs = matchDetails?.tournamentLevel === "Playoff" ? true : false;
+  var inPlayoffs = matchDetails?.tournamentLevel ? matchDetails?.tournamentLevel.toLowerCase() === "playoff" ? true : false : false;
 
   const matchMenu = schedule.map((match, index) => {
     var tag = `${match?.description} of ${qualSchedule?.schedule?.length}`;
     if (
-      match?.tournamentLevel === "Playoff" ||
-      match?.tournamentLevel === "Practice"
+      (match?.tournamentLevel && match?.tournamentLevel?.toLowerCase() === "playoff") ||
+      (match?.tournamentLevel && match?.tournamentLevel?.toLowerCase() === "practice")
     ) {
       tag = match?.description;
     }
@@ -497,7 +497,7 @@ function AnnouncePage({
                         />
                       );
                     } else {
-                      if ((!ftcMode && (station.slice(-1) !== "4") ) && (ftcMode && (station.slice(-1) !== "3") )) {
+                      if ((!ftcMode && (station.slice(-1) !== "4")) && (ftcMode && (station.slice(-1) !== "3"))) {
                         var allianceColor = _.toLower(station.slice(0, -1));
                         return (
                           <tr

--- a/src/pages/PlayByPlayPage.jsx
+++ b/src/pages/PlayByPlayPage.jsx
@@ -375,12 +375,12 @@ function PlayByPlayPage({
     }
   }
 
-  var inPlayoffs = matchDetails?.tournamentLevel === "Playoff" ? true : false;
+  var inPlayoffs = matchDetails?.tournamentLevel ? matchDetails?.tournamentLevel.toLowerCase() === "playoff" ? true : false : false;
   const matchMenu = schedule.map((match, index) => {
     var tag = `${match?.description} of ${qualSchedule?.schedule?.length}`;
     if (
-      match?.tournamentLevel === "Playoff" ||
-      match?.tournamentLevel === "Practice"
+      (match?.tournamentLevel && match?.tournamentLevel?.toLowerCase() === "playoff") ||
+      (match?.tournamentLevel && match?.tournamentLevel?.toLowerCase() === "practice")
     ) {
       tag = match?.description;
     }

--- a/src/pages/SchedulePage.jsx
+++ b/src/pages/SchedulePage.jsx
@@ -667,7 +667,7 @@ function SchedulePage({ selectedEvent, setSelectedEvent, playoffSchedule, qualSc
                         <thead className="thead-default">
                             <tr>
                                 <th className="col2"><b>Time</b></th>
-                                <th className="col2"><b>Description{selectedEvent?.value?.fieldCount>1?` (${selectedEvent?.value?.fieldCount} fields)`:''}</b></th>
+                                <th className="col2"><b>Description</b></th>
                                 <th className="col1"><b>Match Number</b></th>
                                 <th className="col1" colSpan={ftcMode?1:2}><b>Score</b></th>
                                 <th className="col1"><b>Station 1</b></th>
@@ -682,7 +682,7 @@ function SchedulePage({ selectedEvent, setSelectedEvent, playoffSchedule, qualSc
                                 return (
                                     <tr key={"practiceSchedule" + match?.matchNumber} className="centerTable">
                                         <td>{match?.actualStartTime ? "Actual:" : "Scheduled:"}<br /> {match?.actualStartTime ? moment(match.actualStartTime).format('dd hh:mm A') : moment(match?.startTime).format('dd hh:mm A')}</td>
-                                        <td>{match?.description}{selectedEvent?.value?.fieldCount>1?` Field ${match?.series}`:''}</td>
+                                        <td>{match?.description}</td>
                                         <td>{match?.matchNumber}</td>
                                         <td colSpan={ftcMode?1:2}>
                                             <tr className={`centerTable ${redStyle} block`} ><span>{match?.scoreRedFinal}</span></tr>
@@ -704,7 +704,7 @@ function SchedulePage({ selectedEvent, setSelectedEvent, playoffSchedule, qualSc
                                 let blueStyle = "blue";
                                 return (<tr key={"practiceSchedule" + match?.matchNumber} className="centerTable">
                                     <td>{match?.actualStartTime ? "Actual:" : "Scheduled:"}<br /> {match?.actualStartTime ? moment(match.actualStartTime).format('dd hh:mm A') : moment(match?.startTime).format('dd hh:mm A')}</td>
-                                    <td>{match?.description}{selectedEvent?.value?.fieldCount>1?` Field ${match?.series}`:''}</td>
+                                    <td>{match?.description}</td>
                                     <td>{match?.matchNumber}</td>
                                     <td colSpan={ftcMode?1:2}><span className={redStyle}>{match?.scoreRedFinal}</span><br /><span className={blueStyle}>{match?.scoreBlueFinal}</span></td>
                                     {!ftcMode && <>
@@ -737,7 +737,7 @@ function SchedulePage({ selectedEvent, setSelectedEvent, playoffSchedule, qualSc
 
                                 return (<tr key={"qualSchedule" + match?.matchNumber} className="centerTable">
                                     <td>{match?.actualStartTime ? "Actual:" : "Scheduled:"}<br /> {match?.actualStartTime ? moment(match?.actualStartTime).format('dd hh:mm A') : moment(match?.startTime).format('dd hh:mm A')}</td>
-                                    <td>{match?.description}{selectedEvent?.value?.fieldCount>1?` Field ${match?.series}`:''}</td>
+                                    <td>{match?.description}</td>
                                     <td>{match?.matchNumber}</td>
                                     <td className={(match?.actualStartTime) ? `scheduleTable${winnerStyle}` : ""} onClick={() => { if (match.scores) { handleOpenScores(match) } }}>
                                         <tr className={`centerTable ${redStyle} block`}><span>{match?.scoreRedFinal}</span></tr>
@@ -774,7 +774,7 @@ function SchedulePage({ selectedEvent, setSelectedEvent, playoffSchedule, qualSc
 
                                 return (<tr key={"playoffSchedule" + (index+1)} className="centerTable">
                                     <td>{match?.actualStartTime ? "Actual:" : "Scheduled:"}<br /> {match?.actualStartTime ? moment(match?.actualStartTime).format('dd hh:mm A') : moment(match?.startTime).format('dd hh:mm A')}</td>
-                                   <td>{match?.description}{selectedEvent?.value?.fieldCount>1?` Field ${match?.series}`:''}</td>
+                                   <td>{match?.description}</td>
                                     <td>{(index+1) + (qualMatchCount || 0)}</td>
                                     <td className={(match?.actualStartTime) ? `scheduleTable${winnerStyle}` : " "} onClick={() => { if (match?.scores) { handleOpenScores(match) } }} colSpan={ftcMode?1:2}>
                                         <tr className={`centerTable ${redStyle} block`} ><span>{match?.scoreRedFinal}</span></tr>


### PR DESCRIPTION
This adds Alliance Selection and Playoff screens for FTC
FTC introduces 6 Alliance Playoffs, so we have added that screen
FTC has many 5 digit team numbers, so we've adjusted the Alliance Selection available teams block to accommodate
FTC has 2 team Alliances with no backups, with the exception of FTRST Champs. We now handle 2 team Alliances