### PR TITLE
Switching from statbotics/ftcScout direct calls to gatool API

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3621,15 +3621,6 @@ function App() {
     }
   };
 
-  // reset after mode change
-  const resetForModeChange = () => {
-    setEventFilters([]);
-    setRegionFilters([]);
-    setTimeFilter({ label: "All Events", value: "all" });
-    setSelectedEvent(null);
-    setSelectedYear(ftcMode ? FTCSupportedYears[0] : supportedYears[0]);
-  }
-
   // Retrieve Community Updates when the team list changes
   useEffect(() => {
     if (

--- a/src/contextProviders/AuthClientContext.jsx
+++ b/src/contextProviders/AuthClientContext.jsx
@@ -77,7 +77,7 @@ class AuthClient {
     }
     var errorText = `Received a ${response.status} error from backend: "${response.statusText}"`;
     if (response.status === 400) {
-      if (customAPIBaseUrl === "https://api.statbotics.io/v3/" || customAPIBaseUrl === 'https://api.ftcscout.org/rest/v1/'
+      if (customAPIBaseUrl === "https://api.statbotics.io/v3/" || customAPIBaseUrl === 'https://api.ftcscout.org/rest/v1/' 
 ) {
         return response;
       } else { errorText +=
@@ -285,6 +285,7 @@ class AuthClient {
 
   operationDone() {
     this.operationsInProgress -= 1;
+    this.operationsInProgress = Math.max(0, this.operationsInProgress);
     this.setOperationsInProgress(this.operationsInProgress);
   }
 

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -75,7 +75,7 @@ const ftcModeOptions = [
 
 
 
-function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedYear, eventList, teamList, qualSchedule, playoffSchedule, rankings, eventFilters, setEventFilters, regionFilters, setRegionFilters, districts, timeFilter, setTimeFilter, timeFormat, setTimeFormat, showSponsors, setShowSponsors, showAwards, setShowAwards, showNotes, setShowNotes, showNotesAnnounce, setShowNotesAnnounce, showMottoes, setShowMottoes, showChampsStats, setShowChampsStats, swapScreen, setSwapScreen, autoAdvance, setAutoAdvance, autoUpdate, setAutoUpdate, getSchedule, awardsMenu, setAwardsMenu, showQualsStats, setShowQualsStats, showQualsStatsQuals, setShowQualsStatsQuals, teamReduction, setTeamReduction, playoffCountOverride, setPlayoffCountOverride, allianceCount, localUpdates, setLocalUpdates, putTeamData, getCommunityUpdates, reverseEmcee, setReverseEmcee, showDistrictChampsStats, setShowDistrictChampsStats, monthsWarning, setMonthsWarning, user, isAuthenticated, adHocMode, setAdHocMode, supportedYears, FTCSupportedYears, reloadPage, autoHideSponsors, setAutoHideSponsors, setLoadingCommunityUpdates, hidePracticeSchedule, setHidePracticeSchedule, systemMessage, setTeamListLoading, getTeamList, getAlliances, setHaveChampsTeams, appUpdates, usePullDownToUpdate, setUsePullDownToUpdate, useSwipe, setUseSwipe, eventLabel, setEventLabel, showInspection, setShowInspection, showMinorAwards, setShowMinorAwards, highScoreMode, setHighScoreMode, systemBell, setSystemBell, eventBell, setEventBell, eventMessage, setEventMessage, putEventNotifications, useCheesyArena, setUseCheesyArena, cheesyArenaAvailable, ftcLeagues, ftcRegions, ftcMode, setFTCMode, ftcTypes, useFTCOffline, setUseFTCOffline, FTCServerURL, setFTCServerURL, FTCKey, requestFTCKey, checkFTCKey, FTCOfflineAvailable, getFTCOfflineStatus }) {
+function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedYear, eventList, teamList, qualSchedule, playoffSchedule, rankings, eventFilters, setEventFilters, regionFilters, setRegionFilters, districts, timeFilter, setTimeFilter, timeFormat, setTimeFormat, showSponsors, setShowSponsors, showAwards, setShowAwards, showNotes, setShowNotes, showNotesAnnounce, setShowNotesAnnounce, showMottoes, setShowMottoes, showChampsStats, setShowChampsStats, swapScreen, setSwapScreen, autoAdvance, setAutoAdvance, autoUpdate, setAutoUpdate, getSchedule, awardsMenu, setAwardsMenu, showQualsStats, setShowQualsStats, showQualsStatsQuals, setShowQualsStatsQuals, teamReduction, setTeamReduction, playoffCountOverride, setPlayoffCountOverride, allianceCount, localUpdates, setLocalUpdates, putTeamData, getCommunityUpdates, reverseEmcee, setReverseEmcee, showDistrictChampsStats, setShowDistrictChampsStats, monthsWarning, setMonthsWarning, user, isAuthenticated, adHocMode, setAdHocMode, supportedYears, FTCSupportedYears, reloadPage, autoHideSponsors, setAutoHideSponsors, setLoadingCommunityUpdates, hidePracticeSchedule, setHidePracticeSchedule, systemMessage, setTeamListLoading, getTeamList, getAlliances, setHaveChampsTeams, appUpdates, usePullDownToUpdate, setUsePullDownToUpdate, useSwipe, setUseSwipe, eventLabel, setEventLabel, showInspection, setShowInspection, showMinorAwards, setShowMinorAwards, highScoreMode, setHighScoreMode, systemBell, setSystemBell, eventBell, setEventBell, eventMessage, setEventMessage, putEventNotifications, useCheesyArena, setUseCheesyArena, ftcLeagues, ftcRegions, ftcMode, setFTCMode, ftcTypes, useFTCOffline, setUseFTCOffline, FTCServerURL, setFTCServerURL, FTCKey, requestFTCKey, checkFTCKey, FTCOfflineAvailable, getFTCOfflineStatus }) {
     const isOnline = useOnlineStatus();
     const PWASupported = (isChrome && Number(browserVersion) >= 76) || (isSafari && Number(browserVersion) >= 15 && Number(fullBrowserVersion.split(".")[1]) >= 4);
 
@@ -193,7 +193,12 @@ function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedY
 
     const handleFTCMode = (checked) => {
         setFTCMode(checked.value === "FRC" ? null : checked);
-        setUseFTCOffline(checked.value === "FTCLocal")
+        setUseFTCOffline(checked.value === "FTCLocal");
+        setEventFilters([]);
+        setRegionFilters([]);
+        setTimeFilter({ label: "All Events", value: "all" });
+        setSelectedEvent(null);
+        setSelectedYear(checked.value === "FRC" ? supportedYears[0] : FTCSupportedYears[0]);
     }
 
     const handleEventNotification = (property, index, value, user) => {
@@ -305,16 +310,16 @@ function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedY
                     </Form.Group>
                 </Form>
                     {!FTCKey?.key && !FTCKey?.active && FTCOfflineAvailable && <Button onClick={requestFTCKey}>Request API Access</Button>}
-                    {FTCKey?.key && FTCKey?.FTCServerURL !== FTCServerURL && FTCOfflineAvailable && <Button  onClick={requestFTCKey}>Request new API Access</Button>}
+                    {FTCKey?.key && FTCKey?.FTCServerURL !== FTCServerURL && FTCOfflineAvailable && <Button onClick={requestFTCKey}>Request new API Access</Button>}
                     {FTCKey?.key && FTCKey?.FTCServerURL === FTCServerURL && !FTCKey?.active && FTCOfflineAvailable && <Button onClick={checkFTCKey}>Verify API Access</Button>}
-                    {FTCKey?.key && FTCKey?.FTCServerURL === FTCServerURL && FTCKey?.active && FTCOfflineAvailable &&<><Button onClick={checkFTCKey} variant="success">API Access Granted!</Button>{FTCKey?.key ? <><br/>{`Key: ${FTCKey?.key}`}</> : ""}</>}
+                    {FTCKey?.key && FTCKey?.FTCServerURL === FTCServerURL && FTCKey?.active && FTCOfflineAvailable && <><Button onClick={checkFTCKey} variant="success">API Access Granted!</Button>{FTCKey?.key ? <><br />{`Key: ${FTCKey?.key}`}</> : ""}</>}
                     {!FTCOfflineAvailable && <Button onClick={getFTCOfflineStatus} variant={"danger"}>FTC Local Server unavailable. Click to check status.</Button>}
 
                 </Col>
             </Row>}
             {!selectedEvent && <div>
                 <Alert variant="warning" >You need to select an event before you can see anything here. {isAuthenticated && <LogoutButton disabled={!isOnline} />}
-                {!isAuthenticated && <LoginButton disabled={!isOnline} />}</Alert>
+                    {!isAuthenticated && <LoginButton disabled={!isOnline} />}</Alert>
 
             </div>}
             {selectedEvent && <div>


### PR DESCRIPTION
This switches calls to statbotics and ftcScout to gatool API. This allows us to enable an unsecured endpoint for ftc local server and cheesy arena modes.

This also reduces the number of spurious 500 errors that will occur when loading an event that has not started. These were caused by calls to endpoints that returned 500 errors when there was no data. We can ensure that these endpoints query only when we know there should be data there.