### PR TITLE
Forgot to exclude the actual error response

### DIFF
--- a/src/contextProviders/AuthClientContext.jsx
+++ b/src/contextProviders/AuthClientContext.jsx
@@ -79,7 +79,8 @@ class AuthClient {
     if (response.status === 400) {
       if (
         customAPIBaseUrl.includes("statbotics") ||
-        customAPIBaseUrl.includes("ftcscout")
+        customAPIBaseUrl.includes("ftcscout") ||
+        path.includes("/teams?teamNumber=")
       ) {
         return response;
       } else {


### PR DESCRIPTION
when loading a non-existent team