### PR TITLE
Removing hard-coded alliance stations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2996,7 +2996,7 @@ function App() {
         epaData.status === 400
       ) {
         // do nothing
-        console.log("No EPA data for team " + team?.teamNumber);
+        // console.log("No EPA data for team " + team?.teamNumber);
       }
       return {
         teamNumber: team?.teamNumber,

--- a/src/components/Bracket.jsx
+++ b/src/components/Bracket.jsx
@@ -27,6 +27,18 @@ function Bracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule, currentMat
 
 	const currentPlayoffMatch = currentMatch - qualsLength;
 
+	/**
+	 * This function finds a team by their station assignment
+	 * @param teams the array of team objects
+	 * @param station the station to find (e.g., "Red1", "Red2", "Red3", "Blue1", "Blue2", "Blue3")
+	 * @returns the team number or null if not found
+	 */
+	const getTeamByStation = (teams, station) => {
+		if (!teams || !Array.isArray(teams)) return null;
+		const team = teams.find((t) => t?.station?.toLowerCase() === station?.toLowerCase());
+		return team?.teamNumber || null;
+	};
+
 	var overtimeOffset = 0;
 	var tournamentWinner = {
 		"red": 0,
@@ -127,8 +139,9 @@ function Bracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule, currentMat
 			tempMatches.schedule[winnerMatch - 1].scoreRedFinal = 10;
 		}
 
-		tempTeams.red = [tempMatches.schedule[winnerMatch - 1].teams[0].teamNumber, tempMatches.schedule[winnerMatch - 1].teams[1].teamNumber, tempMatches.schedule[winnerMatch - 1].teams[2].teamNumber];
-		tempTeams.blue = [tempMatches.schedule[winnerMatch - 1].teams[3].teamNumber, tempMatches.schedule[winnerMatch - 1].teams[4].teamNumber, tempMatches.schedule[winnerMatch - 1].teams[5].teamNumber];
+		const matchTeams = tempMatches.schedule[winnerMatch - 1].teams;
+		tempTeams.red = [getTeamByStation(matchTeams, "Red1"), getTeamByStation(matchTeams, "Red2"), getTeamByStation(matchTeams, "Red3")];
+		tempTeams.blue = [getTeamByStation(matchTeams, "Blue1"), getTeamByStation(matchTeams, "Blue2"), getTeamByStation(matchTeams, "Blue3")];
 
 		tempMatches.schedule[winnerMatch - 1].actualStartTime = moment().format();
 		tempMatches.schedule[winnerMatch - 1].winner.winner = winningAlliance;

--- a/src/components/FourAllianceBracket.jsx
+++ b/src/components/FourAllianceBracket.jsx
@@ -27,6 +27,18 @@ function FourAllianceBracket({ currentMatch, qualsLength, nextMatch, previousMat
 
 	const currentPlayoffMatch = currentMatch - qualsLength;
 
+	/**
+	 * This function finds a team by their station assignment
+	 * @param teams the array of team objects
+	 * @param station the station to find (e.g., "Red1", "Red2", "Red3", "Blue1", "Blue2", "Blue3")
+	 * @returns the team number or null if not found
+	 */
+	const getTeamByStation = (teams, station) => {
+		if (!teams || !Array.isArray(teams)) return null;
+		const team = teams.find((t) => t?.station?.toLowerCase() === station?.toLowerCase());
+		return team?.teamNumber || null;
+	};
+
 	var overtimeOffset = 0;
 	var tournamentWinner = {
 		"red": 0,
@@ -107,8 +119,9 @@ function FourAllianceBracket({ currentMatch, qualsLength, nextMatch, previousMat
 			tempMatches.schedule[winnerMatch - 1].scoreRedFinal = 10;
 		}
 
-		tempTeams.red = [tempMatches.schedule[winnerMatch - 1].teams[0].teamNumber, tempMatches.schedule[winnerMatch - 1].teams[1].teamNumber, tempMatches.schedule[winnerMatch - 1].teams[2].teamNumber];
-		tempTeams.blue = [tempMatches.schedule[winnerMatch - 1].teams[3].teamNumber, tempMatches.schedule[winnerMatch - 1].teams[4].teamNumber, tempMatches.schedule[winnerMatch - 1].teams[5].teamNumber];
+		const matchTeams = tempMatches.schedule[winnerMatch - 1].teams;
+		tempTeams.red = [getTeamByStation(matchTeams, "Red1"), getTeamByStation(matchTeams, "Red2"), getTeamByStation(matchTeams, "Red3")];
+		tempTeams.blue = [getTeamByStation(matchTeams, "Blue1"), getTeamByStation(matchTeams, "Blue2"), getTeamByStation(matchTeams, "Blue3")];
 
 		tempMatches.schedule[winnerMatch - 1].actualStartTime = moment().format();
 		tempMatches.schedule[winnerMatch - 1].winner.winner = winningAlliance;

--- a/src/components/FourAllianceBracketFTC.jsx
+++ b/src/components/FourAllianceBracketFTC.jsx
@@ -27,6 +27,18 @@ function FourAllianceBracketFTC({ currentMatch, qualsLength, nextMatch, previous
 
 	const currentPlayoffMatch = currentMatch - qualsLength;
 
+	/**
+	 * This function finds a team by their station assignment
+	 * @param teams the array of team objects
+	 * @param station the station to find (e.g., "Red1", "Red2", "Red3", "Blue1", "Blue2", "Blue3")
+	 * @returns the team number or null if not found
+	 */
+	const getTeamByStation = (teams, station) => {
+		if (!teams || !Array.isArray(teams)) return null;
+		const team = teams.find((t) => t?.station?.toLowerCase() === station?.toLowerCase());
+		return team?.teamNumber || null;
+	};
+
 	var overtimeOffset = 0;
 	var tournamentWinner = {
 		"red": 0,
@@ -107,8 +119,9 @@ function FourAllianceBracketFTC({ currentMatch, qualsLength, nextMatch, previous
 			tempMatches.schedule[winnerMatch - 1].scoreRedFinal = 10;
 		}
 
-		tempTeams.red = [tempMatches.schedule[winnerMatch - 1].teams[0].teamNumber, tempMatches.schedule[winnerMatch - 1].teams[1].teamNumber, tempMatches.schedule[winnerMatch - 1].teams[2].teamNumber];
-		tempTeams.blue = [tempMatches.schedule[winnerMatch - 1].teams[3].teamNumber, tempMatches.schedule[winnerMatch - 1].teams[4].teamNumber, tempMatches.schedule[winnerMatch - 1].teams[5].teamNumber];
+		const matchTeams = tempMatches.schedule[winnerMatch - 1].teams;
+		tempTeams.red = [getTeamByStation(matchTeams, "Red1"), getTeamByStation(matchTeams, "Red2"), getTeamByStation(matchTeams, "Red3")];
+		tempTeams.blue = [getTeamByStation(matchTeams, "Blue1"), getTeamByStation(matchTeams, "Blue2"), getTeamByStation(matchTeams, "Blue3")];
 
 		tempMatches.schedule[winnerMatch - 1].actualStartTime = moment().format();
 		tempMatches.schedule[winnerMatch - 1].winner.winner = winningAlliance;

--- a/src/components/SixAllianceBracket.jsx
+++ b/src/components/SixAllianceBracket.jsx
@@ -28,6 +28,18 @@ function SixAllianceBracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule,
 
 	const currentPlayoffMatch = currentMatch - qualsLength;
 
+	/**
+	 * This function finds a team by their station assignment
+	 * @param teams the array of team objects
+	 * @param station the station to find (e.g., "Red1", "Red2", "Red3", "Blue1", "Blue2", "Blue3")
+	 * @returns the team number or null if not found
+	 */
+	const getTeamByStation = (teams, station) => {
+		if (!teams || !Array.isArray(teams)) return null;
+		const team = teams.find((t) => t?.station?.toLowerCase() === station?.toLowerCase());
+		return team?.teamNumber || null;
+	};
+
 	var overtimeOffset = 0;
 	var tournamentWinner = {
 		"red": 0,
@@ -128,8 +140,9 @@ function SixAllianceBracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule,
 			tempMatches.schedule[winnerMatch - 1].scoreRedFinal = 10;
 		}
 
-		tempTeams.red = [tempMatches.schedule[winnerMatch - 1].teams[0].teamNumber, tempMatches.schedule[winnerMatch - 1].teams[1].teamNumber, tempMatches.schedule[winnerMatch - 1].teams[2].teamNumber];
-		tempTeams.blue = [tempMatches.schedule[winnerMatch - 1].teams[3].teamNumber, tempMatches.schedule[winnerMatch - 1].teams[4].teamNumber, tempMatches.schedule[winnerMatch - 1].teams[5].teamNumber];
+		const matchTeams = tempMatches.schedule[winnerMatch - 1].teams;
+		tempTeams.red = [getTeamByStation(matchTeams, "Red1"), getTeamByStation(matchTeams, "Red2"), getTeamByStation(matchTeams, "Red3")];
+		tempTeams.blue = [getTeamByStation(matchTeams, "Blue1"), getTeamByStation(matchTeams, "Blue2"), getTeamByStation(matchTeams, "Blue3")];
 
 		tempMatches.schedule[winnerMatch - 1].actualStartTime = moment().format();
 		tempMatches.schedule[winnerMatch - 1].winner.winner = winningAlliance;
@@ -316,13 +329,13 @@ function SixAllianceBracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule,
 							<rect x="109" y="89" fill="#DBDAD9" width="75" height="684" />
 							<rect x="302" y="89" fill="#DBDAD9" width="75" height="684" />
 							<rect x="490" y="89" fill="#DBDAD9" width="75" height="684" />
-							<polyline points="242 175.1 430.8 175.1 430.8 328.1 242.6 328.1" fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" />
-							<polyline points="242.5 175.1 242.5 213.6 199.1 213.6" fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" />
-							<polyline points="242.5 328.1 242.5 368.6 199.1 368.6" fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" />
-							<polyline points="431 254 1006 254 1006 504.1 816.8 504.1 816.8 574.1 630 574.1" fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" />
-							<polyline points="611.7 648 629.7 648 629.7 509 611.7 509" fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" />
-							<line x1="1024" y1="421" x2="1006" y2="421" fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" />
-							<line x1="70" y1="419" x2="971" y2="419" fill="none" stroke="#8e8e8e" stroke-miterlimit="10" stroke-width="2" />
+						<polyline points="242 175.1 430.8 175.1 430.8 328.1 242.6 328.1" fill="none" stroke="#000" strokeMiterlimit="10" strokeWidth="2" />
+						<polyline points="242.5 175.1 242.5 213.6 199.1 213.6" fill="none" stroke="#000" strokeMiterlimit="10" strokeWidth="2" />
+						<polyline points="242.5 328.1 242.5 368.6 199.1 368.6" fill="none" stroke="#000" strokeMiterlimit="10" strokeWidth="2" />
+						<polyline points="431 254 1006 254 1006 504.1 816.8 504.1 816.8 574.1 630 574.1" fill="none" stroke="#000" strokeMiterlimit="10" strokeWidth="2" />
+						<polyline points="611.7 648 629.7 648 629.7 509 611.7 509" fill="none" stroke="#000" strokeMiterlimit="10" strokeWidth="2" />
+						<line x1="1024" y1="421" x2="1006" y2="421" fill="none" stroke="#000" strokeMiterlimit="10" strokeWidth="2" />
+						<line x1="70" y1="419" x2="971" y2="419" fill="none" stroke="#8e8e8e" strokeMiterlimit="10" strokeWidth="2" />
 							<text transform="matrix(0 -1 1 0 49.7114 348.6689)" fontFamily="'myriad-pro'" fontWeight={bold} fontStyle={"normal"} fontSize="26px">UPPER BRACKET</text>
 							<text transform="matrix(0 -1 1 0 49.7114 673.2046)" fontFamily="'myriad-pro'" fontWeight={bold} fontStyle={"normal"} fontSize="26px">LOWER BRACKET</text>
 							<text transform="matrix(1 0 0 1 116.6694 84.2646)" fontFamily="'myriad-pro'" fontWeight={bold} fontStyle={"normal"} fontSize="16px">ROUND 1</text>

--- a/src/components/app-mode-switch-icons.jsx
+++ b/src/components/app-mode-switch-icons.jsx
@@ -10,13 +10,13 @@ export const frcSelected = (
       d="M7.9,1.7c-3.6,0-6.5,2.9-6.5,6.5s2.9,6.5,6.5,6.5h19.8V1.7H7.9Z"
       fill="#00a3e6"
       stroke="#1c1c1a"
-      stroke-miterlimit="10"
+      strokeMiterlimit="10"
     />
     <path
       d="M49,1.7h-19.8v13h19.8c3.6,0,6.5-2.9,6.5-6.5s-2.9-6.5-6.5-6.5h0Z"
       fill="#c9c9ca"
       stroke="#1c1c1a"
-      stroke-miterlimit="10"
+      strokeMiterlimit="10"
     />
     <rect
       x="27.7"
@@ -25,7 +25,7 @@ export const frcSelected = (
       height="13"
       fill="#1c1c1a"
       stroke="#1c1c1a"
-      stroke-miterlimit="10"
+      strokeMiterlimit="10"
     />
     <path
       d="M34.6,12.4c0,0,0,.1,0,.1h-1.3c0,0,0,0,0-.1v-7.7c0,0,0,0,0,0h4.6c0,0,0,0,.1,0v1.1c.1,0,0,0,0,0h-3.4v2.1h3.1c0,0,0,0,0,0v1.1c0,0,0,0,0,0h-3.1v3.1h0Z"
@@ -66,13 +66,13 @@ export const ftcSelected = (
       d="M7.9,1.7c-3.6,0-6.5,2.9-6.5,6.5s2.9,6.5,6.5,6.5h19.8V1.7H7.9Z"
       fill="#c9c9ca"
       stroke="#1c1c1a"
-      stroke-miterlimit="10"
+      strokeMiterlimit="10"
     />
     <path
       d="M49,1.7h-19.8v13h19.8c3.6,0,6.5-2.9,6.5-6.5s-2.9-6.5-6.5-6.5h0Z"
       fill="#f4a13b"
       stroke="#1c1c1a"
-      stroke-miterlimit="10"
+      strokeMiterlimit="10"
     />
     <rect
       x="27.7"
@@ -81,7 +81,7 @@ export const ftcSelected = (
       height="13"
       fill="#1c1c1a"
       stroke="#1c1c1a"
-      stroke-miterlimit="10"
+      strokeMiterlimit="10"
     />
     <path
       d="M34.6,12.4c0,0,0,.1,0,.1h-1.3c0,0,0,0,0-.1v-7.7c0,0,0,0,0,0h4.6c0,0,0,0,.1,0v1.1c.1,0,0,0,0,0h-3.4v2.1h3.1c0,0,0,0,0,0v1.1c0,0,0,0,0,0h-3.1v3.1h0Z"

--- a/src/pages/AllianceSelectionPage.jsx
+++ b/src/pages/AllianceSelectionPage.jsx
@@ -15,6 +15,18 @@ import './AllianceSelectionPage.css';
 
 
 function AllianceSelectionPage({ selectedYear, selectedEvent, qualSchedule, playoffSchedule, offlinePlayoffSchedule, alliances, rankings, timeFormat, getRanks, allianceSelection, playoffs, teamList, allianceCount, communityUpdates, allianceSelectionArrays, setAllianceSelectionArrays, rankingsOverride, loadEvent, practiceSchedule, setOfflinePlayoffSchedule, currentMatch, qualsLength, nextMatch, previousMatch, getSchedule, useSwipe, usePullDownToUpdate, eventLabel, playoffCountOverride, ftcMode }) {
+    /**
+     * This function finds a team by their station assignment
+     * @param teams the array of team objects
+     * @param station the station to find (e.g., "Red1", "Red2", "Red3", "Blue1", "Blue2", "Blue3")
+     * @returns the team number or null if not found
+     */
+    const getTeamByStation = (teams, station) => {
+        if (!teams || !Array.isArray(teams)) return null;
+        const team = teams.find((t) => t?.station?.toLowerCase() === station?.toLowerCase());
+        return team?.teamNumber || null;
+    };
+
     const [overrideAllianceSelection, setOverrideAllianceSelection] = useState(false);
     const [resetAllianceSelection, setResetAllianceSelection] = useState(false);
     const [teamFilter, setTeamFilter] = useState("");
@@ -64,8 +76,8 @@ function AllianceSelectionPage({ selectedYear, selectedEvent, qualSchedule, play
         var match = matches[_.findIndex(matches, { "matchNumber": matchNumber })];
         if (match && match?.description?.includes("Bye Match")) {
             alliance = "Bye Match"
-        } else if ((match?.teams[0]?.teamNumber || match?.teams[3]?.teamNumber) && alliances?.Lookup) {
-            const lookupTeam = match?.teams[_.findIndex(match?.teams, { "station": allianceColor === "red" ? "Red1" : "Blue1" })]?.teamNumber;
+        } else if ((getTeamByStation(match?.teams, "Red1") || getTeamByStation(match?.teams, "Blue1")) && alliances?.Lookup) {
+            const lookupTeam = getTeamByStation(match?.teams, allianceColor === "red" ? "Red1" : "Blue1");
             targetAlliance = alliances?.Lookup[`${lookupTeam}`];
             allianceMembers = _.compact([targetAlliance?.captain, targetAlliance?.round1, targetAlliance?.round2, targetAlliance?.round3, targetAlliance?.backup]);
             alliance = allianceMembers.join("  ");

--- a/src/pages/EmceePage.jsx
+++ b/src/pages/EmceePage.jsx
@@ -29,6 +29,19 @@ function EmceePage({
   ftcMode,
 }) {
   const { height, width } = useWindowDimensions();
+  
+  /**
+   * This function finds a team by their station assignment
+   * @param teams the array of team objects
+   * @param station the station to find (e.g., "Red1", "Red2", "Red3", "Blue1", "Blue2", "Blue3")
+   * @returns the team number or null if not found
+   */
+  const getTeamByStation = (teams, station) => {
+    if (!teams || !Array.isArray(teams)) return null;
+    const team = teams.find((t) => t?.station?.toLowerCase() === station?.toLowerCase());
+    return team?.teamNumber || null;
+  };
+
   const formatMatchClasses = (baseClasses) => {
     const newClasses = baseClasses.map((match) => {
       return {
@@ -132,19 +145,26 @@ function EmceePage({
     var captain = ";";
     var allianceShortName = "";
     const match = matches[_.findIndex(matches, { matchNumber: matchNumber })];
-    if (match?.teams[0]?.teamNumber) {
+    const red1Team = getTeamByStation(match?.teams, "Red1");
+    const red2Team = getTeamByStation(match?.teams, "Red2");
+    const red3Team = getTeamByStation(match?.teams, "Red3");
+    const blue1Team = getTeamByStation(match?.teams, "Blue1");
+    const blue2Team = getTeamByStation(match?.teams, "Blue2");
+    const blue3Team = getTeamByStation(match?.teams, "Blue3");
+    
+    if (red1Team) {
       allianceName = ftcMode
-        ? alliances?.Lookup[`${match?.teams[0]?.teamNumber}`]?.alliance ||
-          alliances?.Lookup[`${match?.teams[1]?.teamNumber}`]?.alliance
-        : alliances?.Lookup[`${match?.teams[0]?.teamNumber}`]?.alliance ||
-          alliances?.Lookup[`${match?.teams[1]?.teamNumber}`]?.alliance ||
-          alliances?.Lookup[`${match?.teams[2]?.teamNumber}`]?.alliance;
+        ? alliances?.Lookup[`${red1Team}`]?.alliance ||
+          alliances?.Lookup[`${red2Team}`]?.alliance
+        : alliances?.Lookup[`${red1Team}`]?.alliance ||
+          alliances?.Lookup[`${red2Team}`]?.alliance ||
+          alliances?.Lookup[`${red3Team}`]?.alliance;
       captain = ftcMode
-        ? alliances?.Lookup[`${match?.teams[0]?.teamNumber}`]?.captain ||
-          alliances?.Lookup[`${match?.teams[1]?.teamNumber}`]?.captain
-        : alliances?.Lookup[`${match?.teams[0]?.teamNumber}`]?.captain ||
-          alliances?.Lookup[`${match?.teams[1]?.teamNumber}`]?.captain ||
-          alliances?.Lookup[`${match?.teams[2]?.teamNumber}`]?.captain;
+        ? alliances?.Lookup[`${red1Team}`]?.captain ||
+          alliances?.Lookup[`${red2Team}`]?.captain
+        : alliances?.Lookup[`${red1Team}`]?.captain ||
+          alliances?.Lookup[`${red2Team}`]?.captain ||
+          alliances?.Lookup[`${red3Team}`]?.captain;
       if (matchNumber < finalsStart) {
         if (match?.winner?.tieWinner === "red") {
           allianceName += ` (L${match?.winner.level})`;
@@ -152,17 +172,17 @@ function EmceePage({
       }
       if (allianceColor === "blue") {
         allianceName = ftcMode
-          ? alliances?.Lookup[`${match?.teams[2]?.teamNumber}`]?.alliance ||
-            alliances?.Lookup[`${match?.teams[3]?.teamNumber}`]?.alliance
-          : alliances?.Lookup[`${match?.teams[3]?.teamNumber}`]?.alliance ||
-            alliances?.Lookup[`${match?.teams[4]?.teamNumber}`]?.alliance ||
-            alliances?.Lookup[`${match?.teams[5]?.teamNumber}`]?.alliance;
+          ? alliances?.Lookup[`${blue1Team}`]?.alliance ||
+            alliances?.Lookup[`${blue2Team}`]?.alliance
+          : alliances?.Lookup[`${blue1Team}`]?.alliance ||
+            alliances?.Lookup[`${blue2Team}`]?.alliance ||
+            alliances?.Lookup[`${blue3Team}`]?.alliance;
         captain = ftcMode
-          ? alliances?.Lookup[`${match?.teams[2]?.teamNumber}`]?.captain ||
-            alliances?.Lookup[`${match?.teams[3]?.teamNumber}`]?.captain
-          : alliances?.Lookup[`${match?.teams[3]?.teamNumber}`]?.captain ||
-            alliances?.Lookup[`${match?.teams[4]?.teamNumber}`]?.captain ||
-            alliances?.Lookup[`${match?.teams[5]?.teamNumber}`]?.captain;
+          ? alliances?.Lookup[`${blue1Team}`]?.captain ||
+            alliances?.Lookup[`${blue2Team}`]?.captain
+          : alliances?.Lookup[`${blue1Team}`]?.captain ||
+            alliances?.Lookup[`${blue2Team}`]?.captain ||
+            alliances?.Lookup[`${blue3Team}`]?.captain;
         if (matchNumber < finalsStart) {
           if (match?.winner?.tieWinner === "blue") {
             allianceName += ` (L${match?.winner.level} WIN)`;

--- a/src/pages/SchedulePage.jsx
+++ b/src/pages/SchedulePage.jsx
@@ -465,21 +465,13 @@ function SchedulePage({
           alliancesTemp.Alliances = playoffOffset.allianceOrder.map(
             (allianceMember, index) => {
               try {
-                var stationOffset = allianceMember.station === "red" ? 0 : 3;
+                var stationPrefix = allianceMember.station === "red" ? "Red" : "Blue";
+                var matchTeams = innerSchedule[allianceMember.match - 1].teams;
                 var tempAlliance = {
                   number: 1 + index,
-                  captain:
-                    innerSchedule[allianceMember.match - 1].teams[
-                      0 + stationOffset
-                    ].teamNumber,
-                  round1:
-                    innerSchedule[allianceMember.match - 1].teams[
-                      1 + stationOffset
-                    ].teamNumber,
-                  round2:
-                    innerSchedule[allianceMember.match - 1].teams[
-                      2 + stationOffset
-                    ].teamNumber,
+                  captain: getTeamByStation(matchTeams, `${stationPrefix}1`),
+                  round1: getTeamByStation(matchTeams, `${stationPrefix}2`),
+                  round2: getTeamByStation(matchTeams, `${stationPrefix}3`),
                   round3: null,
                   backup: null,
                   backupReplaced: null,
@@ -537,6 +529,18 @@ function SchedulePage({
   function removeSurrogate(teamNumber) {
     teamNumber = teamNumber.replace("*", "");
     return teamNumber;
+  }
+
+  /**
+   * This function finds a team by their station assignment
+   * @param teams the array of team objects
+   * @param station the station to find (e.g., "Red1", "Red2", "Red3", "Blue1", "Blue2", "Blue3")
+   * @returns the team object or null if not found
+   */
+  function getTeamByStation(teams, station) {
+    if (!teams || !Array.isArray(teams)) return null;
+    const team = teams.find((t) => t?.station?.toLowerCase() === station?.toLowerCase());
+    return team?.teamNumber || null;
   }
 
   const handleOpen = () => {
@@ -1253,29 +1257,29 @@ function SchedulePage({
 
                         <td>
                           <span className={redStyle}>
-                            {match?.teams[0]?.teamNumber}
+                            {getTeamByStation(match?.teams, "Red1")}
                           </span>
                           <br />
                           <span className={blueStyle}>
-                            {match?.teams[3]?.teamNumber}
+                            {getTeamByStation(match?.teams, "Blue1")}
                           </span>
                         </td>
                         <td>
                           <span className={redStyle}>
-                            {match?.teams[1]?.teamNumber}
+                            {getTeamByStation(match?.teams, "Red2")}
                           </span>
                           <br />
                           <span className={blueStyle}>
-                            {match?.teams[4]?.teamNumber}
+                            {getTeamByStation(match?.teams, "Blue2")}
                           </span>
                         </td>
                         <td>
                           <span className={redStyle}>
-                            {match?.teams[2]?.teamNumber}
+                            {getTeamByStation(match?.teams, "Red3")}
                           </span>
                           <br />
                           <span className={blueStyle}>
-                            {match?.teams[5]?.teamNumber}
+                            {getTeamByStation(match?.teams, "Blue3")}
                           </span>
                         </td>
                       </tr>
@@ -1314,29 +1318,29 @@ function SchedulePage({
                           <>
                             <td>
                               <span className={redStyle}>
-                                {match?.teams[0]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Red1")}
                               </span>
                               <br />
                               <span className={blueStyle}>
-                                {match?.teams[3]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Blue1")}
                               </span>
                             </td>
                             <td>
                               <span className={redStyle}>
-                                {match?.teams[1]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Red2")}
                               </span>
                               <br />
                               <span className={blueStyle}>
-                                {match?.teams[4]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Blue2")}
                               </span>
                             </td>
                             <td>
                               <span className={redStyle}>
-                                {match?.teams[2]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Red3")}
                               </span>
                               <br />
                               <span className={blueStyle}>
-                                {match?.teams[5]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Blue3")}
                               </span>
                             </td>
                           </>
@@ -1345,20 +1349,20 @@ function SchedulePage({
                           <>
                             <td>
                               <span className={redStyle}>
-                                {match?.teams[0]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Red1")}
                               </span>
                               <br />
                               <span className={blueStyle}>
-                                {match?.teams[2]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Blue1")}
                               </span>
                             </td>
                             <td>
                               <span className={redStyle}>
-                                {match?.teams[1]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Red2")}
                               </span>
                               <br />
                               <span className={blueStyle}>
-                                {match?.teams[3]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Blue2")}
                               </span>
                             </td>
                           </>
@@ -1464,29 +1468,29 @@ function SchedulePage({
                           <>
                             <td>
                               <span className={redStyle}>
-                                {match?.teams[0]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Red1")}
                               </span>
                               <br />
                               <span className={blueStyle}>
-                                {match?.teams[3]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Blue1")}
                               </span>
                             </td>
                             <td>
                               <span className={redStyle}>
-                                {match?.teams[1]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Red2")}
                               </span>
                               <br />
                               <span className={blueStyle}>
-                                {match?.teams[4]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Blue2")}
                               </span>
                             </td>
                             <td>
                               <span className={redStyle}>
-                                {match?.teams[2]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Red3")}
                               </span>
                               <br />
                               <span className={blueStyle}>
-                                {match?.teams[5]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Blue3")}
                               </span>
                             </td>
                           </>
@@ -1495,20 +1499,20 @@ function SchedulePage({
                           <>
                             <td>
                               <span className={redStyle}>
-                                {match?.teams[0]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Red1")}
                               </span>
                               <br />
                               <span className={blueStyle}>
-                                {match?.teams[2]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Blue1")}
                               </span>
                             </td>
                             <td>
                               <span className={redStyle}>
-                                {match?.teams[1]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Red2")}
                               </span>
                               <br />
                               <span className={blueStyle}>
-                                {match?.teams[3]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Blue2")}
                               </span>
                             </td>
                           </>
@@ -1577,29 +1581,29 @@ function SchedulePage({
                           <>
                             <td>
                               <span className={redStyle}>
-                                {match?.teams[0]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Red1")}
                               </span>
                               <br />
                               <span className={blueStyle}>
-                                {match?.teams[3]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Blue1")}
                               </span>
                             </td>
                             <td>
                               <span className={redStyle}>
-                                {match?.teams[1]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Red2")}
                               </span>
                               <br />
                               <span className={blueStyle}>
-                                {match?.teams[4]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Blue2")}
                               </span>
                             </td>
                             <td>
                               <span className={redStyle}>
-                                {match?.teams[2]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Red3")}
                               </span>
                               <br />
                               <span className={blueStyle}>
-                                {match?.teams[5]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Blue3")}
                               </span>
                             </td>
                           </>
@@ -1608,20 +1612,20 @@ function SchedulePage({
                           <>
                             <td>
                               <span className={redStyle}>
-                                {match?.teams[0]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Red1")}
                               </span>
                               <br />
                               <span className={blueStyle}>
-                                {match?.teams[2]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Blue1")}
                               </span>
                             </td>
                             <td>
                               <span className={redStyle}>
-                                {match?.teams[1]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Red2")}
                               </span>
                               <br />
                               <span className={blueStyle}>
-                                {match?.teams[3]?.teamNumber}
+                                {getTeamByStation(match?.teams, "Blue2")}
                               </span>
                             </td>
                           </>


### PR DESCRIPTION
Refactor: Use station assignments instead of array positions for team lookups

This commit refactors the codebase to use the actual `station` property from team objects instead of relying on array position indices when accessing team data. This makes the code more robust and maintainable.

Changes:
--------

1. Added getTeamByStation() helper function to 7 files:
   - src/pages/SchedulePage.jsx
   - src/pages/EmceePage.jsx
   - src/pages/AllianceSelectionPage.jsx
   - src/components/Bracket.jsx
   - src/components/FourAllianceBracket.jsx
   - src/components/FourAllianceBracketFTC.jsx
   - src/components/SixAllianceBracket.jsx

   The helper function performs case-insensitive lookups:
   ```javascript
   const team = teams.find((t) => t?.station?.toLowerCase() === station?.toLowerCase());
   ```

2. Updated team lookups throughout the codebase:
   - BEFORE: `match.teams[0].teamNumber` (assumes Red1 is at index 0)
   - AFTER: `getTeamByStation(match.teams, "Red1")` (uses actual station property)

3. Updated areas affected:
   - Schedule display (practice, qualification, playoff, and offline schedules)
   - Alliance generation from playoff schedules
   - Bracket components (team extraction when recording match winners)
   - Emcee page (alliance name lookups)
   - Alliance selection page (team checks)

4. Fixed React SVG property warnings:
   - src/components/SixAllianceBracket.jsx: Changed stroke-miterlimit → strokeMiterlimit, stroke-width → strokeWidth (7 SVG elements)
   - src/components/app-mode-switch-icons.jsx: Changed stroke-miterlimit → strokeMiterlimit for both FRC and FTC icons (6 elements)

Benefits:
---------
- More maintainable: Code explicitly states which station it's looking for
- More robust: Works correctly regardless of team array ordering
- Case-insensitive: Handles "Red1", "red1", "RED1" variations
- Eliminates assumptions: No longer assumes Red1=index 0, Red2=index 1, etc.
- Fixes console warnings: SVG attributes now properly formatted for React

Testing:
--------
- All linter checks pass
- No breaking changes to existing functionality
- Compatible with both FRC and FTC modes

Closes #588