### PR TITLE
Adding high scores for FTC and FTC Offseason TBA events

### DIFF
--- a/src/components/AllianceSelection.jsx
+++ b/src/components/AllianceSelection.jsx
@@ -479,7 +479,7 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
                                                     return index < colCount ? (
                                                         <Col key={`availableColumn${index}`}>
                                                             {column.map((team) => {
-                                                                return availCell(team)
+                                                                return <div key={`availCell${team.teamNumber}`}>{availCell(team)}</div>
                                                             })}
                                                         </Col>
                                                     ) : null

--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -1,5 +1,13 @@
 export const appUpdates = [
   {
+    date: "October 31, 2025",
+    message: (
+      <ul>
+        <li>Added event high scores to Announce, Play-By-Play and Stats pages for FTC and Offline events</li>
+        <li>Fixed a bug that mixed up the placement of teams on Alliances in the Schedule and Brackets pages</li>
+      </ul>
+    ),
+  },{
     date: "October 25, 2025",
     message: (
       <ul>

--- a/src/components/MainNavigation.jsx
+++ b/src/components/MainNavigation.jsx
@@ -226,15 +226,14 @@ function MainNavigation({
 
   // Handle ready state for the stats tab
   useEffect(() => {
-    // GREEN: Event Selected, World High Scores available, Event High Scores available
-    // YELLOW: Event Selected, World High Scores Available, no matches complete for selected event
-    // RED: Event Selected, no world high scores available
+    // GREEN: Event Selected and Event High Scores available
+    // YELLOW: Event Selected, World High Scores available but no event matches complete yet
+    // RED: Event Selected, no world high scores or event high scores available
 
     if (
       selectedEvent &&
       (eventHighScores?.highscores?.overallqual ||
-        eventHighScores?.highscores?.overallplayoff) &&
-      worldHighScores
+        eventHighScores?.highscores?.overallplayoff)
     ) {
       setStatsTabReady(TabStates.Ready);
     } else if (selectedEvent && worldHighScores) {

--- a/src/pages/StatsPage.jsx
+++ b/src/pages/StatsPage.jsx
@@ -23,7 +23,7 @@ function StatsPage({
           </Alert>
         </div>
       )}
-      {selectedEvent && !worldStats && (
+      {selectedEvent && !worldStats && !eventHighScores && (
         <div>
           <Alert variant="warning">
             <Alert variant="warning">
@@ -35,10 +35,10 @@ function StatsPage({
           </Alert>
         </div>
       )}
-      {selectedEvent && worldStats && (
+      {selectedEvent && (worldStats || eventHighScores) && (
         <Container fluid>
           <Row>
-            <Col xs={"12"} sm={selectedEvent?.value?.districtCode ? "4" : "6"}>
+            {worldStats && <Col xs={"12"} sm={selectedEvent?.value?.districtCode ? "4" : "6"}>
               <table className="table table-condensed gatool-highScores-Table gatool-worldHighScores">
                 <thead>
                   <tr>
@@ -118,7 +118,7 @@ function StatsPage({
                   </tr>
                 </tbody>
               </table>
-            </Col>
+            </Col>}
             {selectedEvent?.value?.districtCode && (
               <Col xs={"12"} sm={"4"}>
                 <table className="table table-condensed gatool-highScores-Table gatool-districtHighScores">
@@ -202,7 +202,7 @@ function StatsPage({
                 </table>
               </Col>
             )}
-            <Col xs={"12"} sm={selectedEvent?.value?.districtCode ? "4" : "6"}>
+            <Col xs={"12"} sm={selectedEvent?.value?.districtCode && worldStats ? "4" : worldStats ? "6" : "12"}>
               <table className="table table-condensed gatool-highScores-Table gatool-eventHighScores">
                 <thead>
                   <tr>


### PR DESCRIPTION
Fix: Reset eventHighScores when switching between FTC/FRC modes and add array validation

- Add useEffect to reset eventHighScores to null when ftcMode changes This prevents stale high score data from the previous mode being displayed when switching between FTC and FRC modes, especially for future events with no schedule data

- Add Array.isArray() validation before calling forEach on schedule data This prevents "forEach is not a function" errors when qualSchedule.schedule or playoffSchedule.schedule exist but are not arrays during the loading process or have unexpected data structures

Fixes issue where event high scores persisted when switching modes on events without schedule data loaded yet.

closes #589