### PR TITLE
Playoff fixes for team remappings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1000,10 +1000,10 @@ function App() {
         const eventData = await result.json();
         const remappedTeams = eventData?.remapTeams || null;
         const keys = Object.keys(remappedTeams);
-        const remappedTeamsObject = {numbers: {}, strings: {}};
+        const remappedTeamsObject = { numbers: {}, strings: {} };
         keys.forEach((key, index) => {
-          remappedTeamsObject.numbers[key.replace("frc","")] = remappedTeams[key].replace("frc","");
-          remappedTeamsObject.strings[remappedTeams[key].replace("frc","")] = key.replace("frc","");
+          remappedTeamsObject.numbers[key.replace("frc", "")] = remappedTeams[key].replace("frc", "");
+          remappedTeamsObject.strings[remappedTeams[key].replace("frc", "")] = key.replace("frc", "");
         });
         return remappedTeamsObject;
       }
@@ -1807,7 +1807,7 @@ function App() {
     }
     getRanks();
     getSystemMessages();
-    
+
     // Calculate event high scores after schedule is loaded
     getEventStats(selectedYear?.value, selectedEvent?.value?.code);
   }
@@ -2704,7 +2704,7 @@ function App() {
           playoffOnly &&
           champsStyle)
       );
-      
+
       if (shouldFetchChampsData) {
         console.log("Getting Champs stats", {
           champLevel: selectedEvent?.value?.champLevel,
@@ -3541,49 +3541,52 @@ function App() {
       return;
     }
     // @ts-ignore
-    var highscores = await result.json();
-    var scores = {};
-    var reducedScores = {};
+    if (result.status === 200) {
+      // @ts-ignore
+      var highscores = await result.json();
+      var scores = {};
+      var reducedScores = {};
 
-    scores.year = selectedYear?.value;
-    scores.lastUpdate = moment().format();
+      scores.year = selectedYear?.value;
+      scores.lastUpdate = moment().format();
 
-    highscores.forEach((score) => {
-      if (score?.matchData?.match) {
-        var details = {};
-        if (!_.isEmpty(eventnames[worldStats?.year])) {
-          details.eventName =
-            eventnames[worldStats?.year][score?.matchData?.event?.eventCode] ||
-            score?.matchData?.event?.eventCode;
-        } else {
-          details.eventName = score?.matchData?.event?.eventCode;
-        }
-
-        //if (worldStats) {
-        //  details.eventName = eventnames[worldStats?.year][score?.matchData?.event?.eventCode]
-        //} else {
-        //  details.eventName = score?.matchData?.event?.eventCode;
-        //}
-        details.alliance = _.upperFirst(score?.matchData?.highScoreAlliance);
-        details.scoreType = score?.yearType;
-        details.matchName = score?.matchData?.match?.description;
-        details.allianceMembers = _.filter(
-          score?.matchData?.match?.teams,
-          function (o) {
-            return _.startsWith(o.station, details.alliance);
+      highscores.forEach((score) => {
+        if (score?.matchData?.match) {
+          var details = {};
+          if (!_.isEmpty(eventnames[worldStats?.year])) {
+            details.eventName =
+              eventnames[worldStats?.year][score?.matchData?.event?.eventCode] ||
+              score?.matchData?.event?.eventCode;
+          } else {
+            details.eventName = score?.matchData?.event?.eventCode;
           }
-        )
-          .map((team) => {
-            return team.teamNumber;
-          })
-          .join(" ");
-        details.score = score.matchData.match[`score${details.alliance}Final`];
-        reducedScores[details.scoreType] = details;
-      }
-    });
-    scores.highscores = reducedScores;
 
-    setWorldStats(scores);
+          //if (worldStats) {
+          //  details.eventName = eventnames[worldStats?.year][score?.matchData?.event?.eventCode]
+          //} else {
+          //  details.eventName = score?.matchData?.event?.eventCode;
+          //}
+          details.alliance = _.upperFirst(score?.matchData?.highScoreAlliance);
+          details.scoreType = score?.yearType;
+          details.matchName = score?.matchData?.match?.description;
+          details.allianceMembers = _.filter(
+            score?.matchData?.match?.teams,
+            function (o) {
+              return _.startsWith(o.station, details.alliance);
+            }
+          )
+            .map((team) => {
+              return team.teamNumber;
+            })
+            .join(" ");
+          details.score = score.matchData.match[`score${details.alliance}Final`];
+          reducedScores[details.scoreType] = details;
+        }
+      });
+      scores.highscores = reducedScores;
+
+      setWorldStats(scores);
+    }
   }
 
   /**
@@ -4363,7 +4366,7 @@ function App() {
       setSystemBell("");
       setTeamListLoading("");
       setHaveChampsTeams(false);
-      
+
       // Fetch team remappings for TBA offseason events
       if (selectedEvent?.value?.type === "OffSeason" && selectedEvent?.value?.tbaEventKey && !ftcMode) {
         const remappings = await fetchTeamRemappings(
@@ -4375,7 +4378,7 @@ function App() {
         // Clear remappings for non-TBA events
         await setTeamRemappings(null);
       }
-      
+
       getTeamList();
       await getSchedule(true);
       getSystemMessages();

--- a/src/pages/AllianceSelectionPage.jsx
+++ b/src/pages/AllianceSelectionPage.jsx
@@ -78,7 +78,7 @@ function AllianceSelectionPage({ selectedYear, selectedEvent, qualSchedule, play
             alliance = "Bye Match"
         } else if ((getTeamByStation(match?.teams, "Red1") || getTeamByStation(match?.teams, "Blue1")) && alliances?.Lookup) {
             const lookupTeam = getTeamByStation(match?.teams, allianceColor === "red" ? "Red1" : "Blue1");
-            targetAlliance = alliances?.Lookup[`${lookupTeam}`];
+            targetAlliance = alliances?.Lookup[`${remapNumberToString(lookupTeam)}`];
             allianceMembers = _.compact([targetAlliance?.captain, targetAlliance?.round1, targetAlliance?.round2, targetAlliance?.round3, targetAlliance?.backup]);
             alliance = allianceMembers.join("  ");
         }
@@ -93,7 +93,7 @@ function AllianceSelectionPage({ selectedYear, selectedEvent, qualSchedule, play
         var match = matches[_.findIndex(matches, { "matchNumber": matchNumber })];
         const lookupTeam = match?.teams[_.findIndex(match?.teams, { "station": allianceColor === "red" ? "Red1" : "Blue1" })]?.teamNumber;
         if (lookupTeam && alliances?.Lookup) {
-            const targetAlliance = alliances?.Lookup[`${lookupTeam}`];
+            const targetAlliance = alliances?.Lookup[`${remapNumberToString(lookupTeam)}`];
             allianceName = targetAlliance?.alliance;
             if (matchNumber <= tieLevel || matchNumber === tieLevel + 6) {
                 if (matches[_.findIndex(matches, { "matchNumber": matchNumber })]?.winner?.tieWinner === "red") {

--- a/src/pages/AnnouncePage.jsx
+++ b/src/pages/AnnouncePage.jsx
@@ -77,14 +77,14 @@ function AnnouncePage({
   }
   const notification =
     currentMatch >= qualsLength - matchesToNotify &&
-    currentMatch <= qualsLength &&
-    showInspection
+      currentMatch <= qualsLength &&
+      showInspection
       ? {
-          expiry: moment().add(1, "hour"),
-          onTime: moment(),
-          message:
-            "Please remind teams to have their robots reinspected before Playoffs and to send their team rep(s) for Alliance Selection.",
-        }
+        expiry: moment().add(1, "hour"),
+        onTime: moment(),
+        message:
+          "Please remind teams to have their robots reinspected before Playoffs and to send their team rep(s) for Alliance Selection.",
+      }
       : {};
 
   function updateTeamDetails(station, matchDetails) {
@@ -95,38 +95,39 @@ function AnnouncePage({
         _.findIndex(matchDetails?.teams, { station: `${alliance}1` })
       ]?.alliance;
 
+
     if (station.slice(-1) !== "4") {
       team =
         matchDetails?.teams[
-          _.findIndex(matchDetails?.teams, { station: station })
+        _.findIndex(matchDetails?.teams, { station: station })
         ];
-      
       // Reverse-map the team number to get the actual team number for lookups
       const lookupTeamNumber = remapNumberToString(team?.teamNumber);
-      
+
+
       team = communityUpdates
         ? _.merge(
-            team,
-            teamList?.teams[
-              _.findIndex(teamList?.teams, { teamNumber: team?.teamNumber })
-            ],
-            rankings?.ranks[
-              _.findIndex(rankings?.ranks, { teamNumber: lookupTeamNumber })
-            ],
-            communityUpdates[
-              _.findIndex(communityUpdates, { teamNumber: team?.teamNumber })
-            ]
-          )
+          team,
+          teamList?.teams[
+          _.findIndex(teamList?.teams, { teamNumber: team?.teamNumber })
+          ],
+          rankings?.ranks[
+          _.findIndex(rankings?.ranks, { teamNumber: lookupTeamNumber })
+          ],
+          communityUpdates[
+          _.findIndex(communityUpdates, { teamNumber: team?.teamNumber })
+          ]
+        )
         : _.merge(
-            team,
-            teamList?.teams[
-              _.findIndex(teamList?.teams, { teamNumber: team?.teamNumber })
-            ],
-            rankings?.ranks[
-              _.findIndex(rankings?.ranks, { teamNumber: lookupTeamNumber })
-            ]
-          );
-      
+          team,
+          teamList?.teams[
+          _.findIndex(teamList?.teams, { teamNumber: team?.teamNumber })
+          ],
+          rankings?.ranks[
+          _.findIndex(rankings?.ranks, { teamNumber: lookupTeamNumber })
+          ]
+        );
+
       team.rankStyle = rankHighlight(team?.rank, allianceCount || { count: 8 });
       team.alliance = alliances?.Lookup[`${lookupTeamNumber}`]
         ? alliances?.Lookup[`${lookupTeamNumber}`]?.alliance || null
@@ -137,7 +138,7 @@ function AnnouncePage({
 
       var teamDistrictRanks =
         _.filter(districtRankings?.districtRanks, {
-          teamNumber: lookupTeamNumber,
+          teamNumber: team?.teamNumber,
         })[0] || null;
       team.districtRanking = teamDistrictRanks?.rank;
       team.qualifiedDistrictCmp = teamDistrictRanks?.qualifiedDistrictCmp;
@@ -145,14 +146,17 @@ function AnnouncePage({
     }
 
     if (station?.slice(-1) === "4") {
+
       if (inPlayoffs || selectedEvent?.value?.champLevel === "CHAMPS") {
         var playoffTeams = matchDetails?.teams.map((team) => {
-          return { teamNumber: team?.teamNumber, alliance: team?.alliance };
+          // Reverse-map the team number to get the actual team number for lookups
+          const lookupTeamNumber = remapNumberToString(team?.teamNumber);
+          return { teamNumber: lookupTeamNumber, alliance: team?.alliance };
         });
         var allianceTeams = allianceNumber
           ? _.filter(playoffTeams, { alliance: allianceNumber }).map((o) => {
-              return o.teamNumber;
-            })
+            return o.teamNumber;
+          })
           : [];
         // var allianceMembers = allianceNumber ? _.filter(alliances?.alliances, { "number": Number(allianceNumber.slice(-1)) })[0] : [];
         var allianceMembers = allianceNumber
@@ -172,27 +176,27 @@ function AnnouncePage({
         var remainingTeam = _.difference(allianceArray, allianceTeams);
         if (remainingTeam.length > 0 && teamList?.teams?.length > 0) {
           // Reverse-map the team number to get the actual team number for lookups
-          const lookupRemainingTeam = remapNumberToString(remainingTeam[0]);
-          
+          const lookupRemainingTeam = remainingTeam[0];
+
           team = _.merge(
             team,
             teamList?.teams[
-              _.findIndex(teamList?.teams, { teamNumber: lookupRemainingTeam })
+            _.findIndex(teamList?.teams, { teamNumber: remapStringToNumber(lookupRemainingTeam) })
             ],
             rankings?.ranks?.length > 0
               ? rankings?.ranks[
-                  _.findIndex(rankings?.ranks, { teamNumber: lookupRemainingTeam })
-                ]
+              _.findIndex(rankings?.ranks, { teamNumber: lookupRemainingTeam })
+              ]
               : null,
             communityUpdates?.length > 0
               ? communityUpdates[
-                  _.findIndex(communityUpdates, {
-                    teamNumber: lookupRemainingTeam,
-                  })
-                ]
+              _.findIndex(communityUpdates, {
+                teamNumber: remapStringToNumber(lookupRemainingTeam),
+              })
+              ]
               : null
           );
-          
+
           team.rankStyle = rankHighlight(
             team?.rank,
             allianceCount || { count: 8 }
@@ -259,7 +263,7 @@ function AnnouncePage({
   var matchDetails = !adHocMode
     ? schedule[currentMatch - 1]
     : adHocMatch
-    ? {
+      ? {
         description: "Practice Match",
         startTime: null,
         matchNumber: 1,
@@ -332,7 +336,7 @@ function AnnouncePage({
           level: null,
         },
       }
-    : null;
+      : null;
 
   if (
     practiceSchedule?.schedule.length > 0 &&

--- a/src/pages/PlayByPlayPage.jsx
+++ b/src/pages/PlayByPlayPage.jsx
@@ -84,41 +84,7 @@ function PlayByPlayPage({
       : ["Red3", "Blue1", "Red2", "Blue2", "Red1", "Blue3", "Red4", "Blue4"];
   }
 
-  // Helper function to reverse-map display team numbers back to actual team numbers
-  const reverseMapTeamNumber = (teamNumber) => {
-    if (!teamNumber) return teamNumber;
-    
-    // If it's a string team identifier (like "1323B")
-    if (typeof teamNumber === 'string') {
-      // First try using remapStringToNumber if available
-      const numericTeam = remapStringToNumber ? remapStringToNumber(teamNumber) : null;
-      if (numericTeam !== null) {
-        return numericTeam;
-      }
-      
-      // If no mapping exists, extract the numeric part from the string
-      const match = teamNumber.match(/^(\d+)/);
-      if (match) {
-        return parseInt(match[1]);
-      }
-      
-      return teamNumber;
-    }
-    
-    // If it's a remapped number (9990-9999), convert back to the original team number
-    if (teamNumber >= 9990 && teamNumber <= 9999 && remapNumberToString) {
-      const displayString = remapNumberToString(teamNumber);
-      // Extract the numeric part from the display string (e.g., "1323B" -> 1323)
-      if (typeof displayString === 'string') {
-        const match = displayString.match(/^(\d+)/);
-        if (match) {
-          return parseInt(match[1]);
-        }
-      }
-    }
-    
-    return teamNumber;
-  };
+ 
 
   function updateTeamDetails(station, matchDetails) {
     var team = {};
@@ -134,12 +100,12 @@ function PlayByPlayPage({
         ];
       
       // Reverse-map the team number to get the actual team number for lookups
-      const lookupTeamNumber = reverseMapTeamNumber(team?.teamNumber);
+      const lookupTeamNumber = remapNumberToString(team?.teamNumber);
       
       team = _.merge(
         team,
         teamList?.teams[
-          _.findIndex(teamList?.teams, { teamNumber: lookupTeamNumber })
+          _.findIndex(teamList?.teams, { teamNumber: team?.teamNumber })
         ],
         rankings?.ranks?.length > 0
           ? rankings?.ranks[
@@ -147,11 +113,11 @@ function PlayByPlayPage({
             ]
           : null,
         EPA?.length > 0
-          ? EPA[_.findIndex(EPA, { teamNumber: lookupTeamNumber })]
+          ? EPA[_.findIndex(EPA, { teamNumber: team?.teamNumber })]
           : null,
         communityUpdates?.length > 0
           ? communityUpdates[
-              _.findIndex(communityUpdates, { teamNumber: lookupTeamNumber })
+              _.findIndex(communityUpdates, { teamNumber: team?.teamNumber })
             ]
           : null
       );
@@ -166,7 +132,7 @@ function PlayByPlayPage({
 
       var teamDistrictRanks =
         _.filter(districtRankings?.districtRanks, {
-          teamNumber: lookupTeamNumber,
+          teamNumber: team?.teamNumber,
         })[0] || null;
       team.districtRanking = teamDistrictRanks?.rank;
       team.qualifiedDistrictCmp = teamDistrictRanks?.qualifiedDistrictCmp;
@@ -201,18 +167,18 @@ function PlayByPlayPage({
         var remainingTeam = _.difference(allianceArray, allianceTeams);
         if (remainingTeam.length > 0) {
           // Reverse-map the team number to get the actual team number for lookups
-          const lookupRemainingTeam = reverseMapTeamNumber(remainingTeam[0]);
+          const lookupRemainingTeam = remainingTeam[0];
           
           team = _.merge(
             team,
             teamList?.teams[
-              _.findIndex(teamList?.teams, { teamNumber: lookupRemainingTeam })
+              _.findIndex(teamList?.teams, { teamNumber: remapStringToNumber(lookupRemainingTeam) })
             ],
             rankings?.ranks[
               _.findIndex(rankings?.ranks, { teamNumber: lookupRemainingTeam })
             ],
             communityUpdates[
-              _.findIndex(communityUpdates, { teamNumber: lookupRemainingTeam })
+              _.findIndex(communityUpdates, { teamNumber: remapStringToNumber(lookupRemainingTeam) })
             ]
           );
           
@@ -227,7 +193,7 @@ function PlayByPlayPage({
 
           teamDistrictRanks =
             _.filter(districtRankings?.districtRanks, {
-              teamNumber: lookupRemainingTeam,
+              teamNumber: remapStringToNumber(lookupRemainingTeam),
             })[0] || null;
           team.districtRanking = teamDistrictRanks?.rank;
           team.qualifiedDistrictCmp = teamDistrictRanks?.qualifiedDistrictCmp;

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -438,9 +438,11 @@ function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedY
                                         <td><Switch checked={showAwards === null ? true : showAwards} onChange={setShowAwards} /></td>
                                         <td><b>Show Awards on Announce</b></td>
                                     </tr>
-                                    <td colSpan={2} className={"teamInfoSettings"}>
-                                        <label><b>For how many years should we display awards on the Announce Screen?</b><Select options={awardsMenuOptions} value={awardsMenu ? awardsMenu : awardsMenuOptions[0]} onChange={setAwardsMenu} /></label>
-                                    </td>
+                                    <tr className={"teamInfoSettings"}>
+                                        <td colSpan={2}>
+                                            <label><b>For how many years should we display awards on the Announce Screen?</b><Select options={awardsMenuOptions} value={awardsMenu ? awardsMenu : awardsMenuOptions[0]} onChange={setAwardsMenu} /></label>
+                                        </td>
+                                    </tr>
                                     <tr className={"teamInfoSettings"}>
                                         <td><Switch checked={_.isNull(showMinorAwards) ? true : showMinorAwards} onChange={setShowMinorAwards} disabled={!(showAwards || _.isNull(showAwards))} /></td>
                                         <td><b>Show Minor Awards on Announce</b></td>
@@ -503,7 +505,7 @@ function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedY
                                             <Switch checked={showBlueBanners === null ? false : showBlueBanners} onChange={setShowBlueBanners} />
                                         </td>
                                         <td>
-                                            <b>Show Blue Banners Statistics on Announce</b>
+                                            <b>Show Blue Banners Statistics on Announce.</b>
                                         </td>
                                     </tr>}
                                     <tr className={"statsSettings"}>


### PR DESCRIPTION
Fix team number lookups for remapped teams in alliance selection and playoff matches

- AllianceSelectionPage: Updated alliance lookups to use remapNumberToString() for proper handling of remapped team numbers in playoff brackets

- AnnouncePage & PlayByPlayPage: Fixed team number lookups to correctly handle remapped team numbers (e.g., "254B" for replacement teams)
  - Use original team numbers for teamList, EPA, and communityUpdates lookups
  - Use remapNumberToString() for rankings lookups
  - Use remapStringToNumber() when looking up data by remapped team numbers
  - Fixed 4th alliance member lookup to preserve remapped team format from alliance array

- PlayByPlayPage: Removed custom reverseMapTeamNumber() helper function in favor of existing remapNumberToString() and remapStringToNumber() utilities

- SetupPage: Fixed HTML validation error where <td> element was not properly wrapped in <tr> element (line 441-445)

- App.jsx: Added status code check for highscores API response to prevent errors when API returns non-200 responses; minor formatting improvements These changes ensure proper display of team information in playoff matches when teams use replacement numbers (e.g., "254B") due to multiple teams with the same base number at offseason events.