### PR TITLE
Alliance Selection and selected event dropdown

### DIFF
--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -1,5 +1,16 @@
 export const appUpdates = [
   {
+    date: "November 17, 2025",
+    message: (
+      <ul>
+        <li>ALL PROGRAMS:Refined the reload experience to reduce the number of times a user must choose program, season and events</li>
+        <li>FRC: Persisting OFFLINE event details across reloads</li>
+        <li>FTC: Fixing a bug that prevented Alliance Selection screen from activating</li>
+        <li>FTC: Fixed event winner display on the Playoff Brackets for FTC events</li>
+        <li>FTC: Fixed cache timing issues in our APIs that prevented some team data from loading in a timely manner</li>
+      </ul>
+    ),
+  },{
     date: "November 8, 2025",
     message: (
       <ul>

--- a/src/pages/AllianceSelectionPage.jsx
+++ b/src/pages/AllianceSelectionPage.jsx
@@ -184,7 +184,15 @@ function AllianceSelectionPage({ selectedYear, selectedEvent, qualSchedule, play
                 </div>}
             {selectedEvent && ((qualSchedule?.schedule?.length > 0 || qualSchedule?.schedule?.schedule?.length > 0 || practiceSchedule?.schedule?.length > 0) && !playoffs && (allianceSelection || overrideAllianceSelection)) &&
                 <div>
-                    <AllianceSelection selectedYear={selectedYear} selectedEvent={selectedEvent} rankings={rankings} teamList={teamList} allianceCount={allianceCount} communityUpdates={communityUpdates} allianceSelectionArrays={allianceSelectionArrays} setAllianceSelectionArrays={setAllianceSelectionArrays} handleReset={handleReset} teamFilter={teamFilter} setTeamFilter={setTeamFilter} ftcMode={ftcMode} remapNumberToString={remapNumberToString} useFourTeamAlliances={useFourTeamAlliances} />
+                    {!allianceCount || !allianceCount?.count || allianceCount?.count <= 0 ? (
+                        <Alert variant="danger">
+                            <h4>Alliance Count Required</h4>
+                            <p>Please go to the <b>Setup Page</b> and choose an Alliance Count before proceeding with Alliance Selection.</p>
+                            <p>The Alliance Count determines how many alliances will participate in playoffs (typically 2, 4, 6, or 8 alliances).</p>
+                        </Alert>
+                    ) : (
+                        <AllianceSelection selectedYear={selectedYear} selectedEvent={selectedEvent} rankings={rankings} teamList={teamList} allianceCount={allianceCount} communityUpdates={communityUpdates} allianceSelectionArrays={allianceSelectionArrays} setAllianceSelectionArrays={setAllianceSelectionArrays} handleReset={handleReset} teamFilter={teamFilter} setTeamFilter={setTeamFilter} ftcMode={ftcMode} remapNumberToString={remapNumberToString} useFourTeamAlliances={useFourTeamAlliances} />
+                    )}
                 </div>}
 
             {selectedEvent && (alliancesCount === 8) && playoffs &&

--- a/src/pages/AnnouncePage.jsx
+++ b/src/pages/AnnouncePage.jsx
@@ -252,7 +252,10 @@ function AnnouncePage({
     schedule = _.concat(schedule, offlinePlayoffSchedule?.schedule);
   }
 
-  if (qualSchedule?.schedule.length > 0) {
+  // Handle nested structure (standard from API/uploads) or flat structure (legacy)
+  if (qualSchedule?.schedule?.schedule?.length > 0) {
+    schedule = _.concat(schedule, qualSchedule?.schedule?.schedule);
+  } else if (qualSchedule?.schedule?.length > 0) {
     schedule = _.concat(schedule, qualSchedule?.schedule);
   }
 

--- a/src/pages/PlayByPlayPage.jsx
+++ b/src/pages/PlayByPlayPage.jsx
@@ -237,7 +237,10 @@ function PlayByPlayPage({
     schedule = _.concat(schedule, offlinePlayoffSchedule?.schedule);
   }
 
-  if (qualSchedule?.schedule.length > 0) {
+  // Handle nested structure (standard from API/uploads) or flat structure (legacy)
+  if (qualSchedule?.schedule?.schedule?.length > 0) {
+    schedule = _.concat(schedule, qualSchedule?.schedule?.schedule);
+  } else if (qualSchedule?.schedule?.length > 0) {
     schedule = _.concat(schedule, qualSchedule?.schedule);
   }
 

--- a/src/pages/RanksPage.jsx
+++ b/src/pages/RanksPage.jsx
@@ -17,6 +17,7 @@ import { utils, read } from "xlsx";
 import { toast } from "react-toastify";
 import _ from "lodash";
 import moment from "moment";
+import { rankHighlight } from "../components/HelperFunctions";
 
 function RanksPage({
   selectedEvent,
@@ -162,24 +163,6 @@ function RanksPage({
     const lookupNumber = remapStringToNumber ? remapStringToNumber(teamNumber) : teamNumber;
     var team = _.find(teamList?.teams, { teamNumber: lookupNumber });
     return team?.nameShortLocal ? team?.nameShortLocal : team?.nameShort;
-  }
-
-  function rankHighlight(rank) {
-    var style = { color: "black", backgroundColor: "white" };
-    if (rank <= allianceCount?.count && rank > 1) {
-      style.color = "white";
-      style.backgroundColor = "green";
-    } else if (rank < allianceCount?.count + 3 && rank > allianceCount?.count) {
-      style.color = "black";
-      style.backgroundColor = "yellow";
-    } else if (rank === 1) {
-      style.color = "white";
-      style.backgroundColor = "orange";
-    } else {
-      style.color = "";
-      style.backgroundColor = "";
-    }
-    return style;
   }
 
   var rankingsList = rankings?.ranks?.map((teamRow) => {
@@ -666,7 +649,7 @@ function RanksPage({
                     return (
                       <tr key={"rankings" + rankRow.teamNumber}>
                         <td>{displayTeamNumber}</td>
-                        <td style={rankHighlight(rankRow.rank)}>
+                        <td style={rankHighlight(rankRow.rank, allianceCount || { count: 8 })}>
                           {rankRow.rank}
                         </td>
                         <td

--- a/src/pages/SchedulePage.jsx
+++ b/src/pages/SchedulePage.jsx
@@ -270,7 +270,9 @@ function SchedulePage({
   function addTeamsToTeamList(formattedSchedule) {
     //generate the team list from the schedule
     var tempTeamList = [];
-    _.forEach(formattedSchedule.schedule, function (row) {
+    // Handle both nested structure (schedule.schedule) and flat structure (schedule)
+    const scheduleArray = formattedSchedule.schedule?.schedule || formattedSchedule.schedule;
+    _.forEach(scheduleArray, function (row) {
       //do something
       _.forEach(row.teams, function (team) {
         if (_.findIndex(tempTeamList, team.teamNumber) < 0) {
@@ -566,10 +568,14 @@ function SchedulePage({
           getAlliances(alliancesTemp);
         }
 
-        formattedSchedule.schedule = _.filter(innerSchedule, "description");
+        const scheduleArray = _.filter(innerSchedule, "description");
+        // Normalize to match API structure: schedule.schedule (nested)
+        // This ensures consistency with how getSchedule formats data from FIRST API
+        formattedSchedule.schedule = { schedule: scheduleArray };
+        
         if (!forPlayoffs) {
           await setPracticeSchedule(formattedSchedule);
-          setQualsLength(formattedSchedule?.schedule?.length);
+          setQualsLength(formattedSchedule?.schedule?.schedule?.length);
         } else {
           await setOfflinePlayoffSchedule(formattedSchedule);
         }


### PR DESCRIPTION
Fix Alliance Selection readiness detection for FTC events

- Cross-reference schedule teams with rankings to exclude no-shows (matchesPlayed = 0)
- Use Math.round() instead of _.toInteger() for match-per-team calculation
- Calculate expected matches based on actual competing teams, not registered count
- Handle both nested (API) and flat (uploaded) schedule structures

Files: src/App.jsx (lines 5030-5125)

---

Add visual highlighting for selected event in dropdown

- Added getOptionValue/getOptionLabel props for proper selection matching
- Added singleValue style to show color-coded background for selected event
- Highlight selected item with blue background when dropdown is open

Files: src/pages/SetupPage.jsx (lines 278-306)