### PR TITLE
Updates for Rankings and Alliance Selection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3478,7 +3478,8 @@ function App() {
       // first let's get the EPA for the team
 
       var epaData = await httpClient.getNoAuth(
-        `${selectedYear?.value}/ftcscout/quick-stats/${team?.teamNumber}`
+        `${selectedYear?.value}/ftcscout/quick-stats/${team?.teamNumber}`,
+        ftcMode ? ftcBaseURL : undefined
       );
       // var epaData = await httpClient.getNoAuth(
       //   `teams/${team?.teamNumber}/quick-stats?season=${selectedYear?.value}`,
@@ -3492,8 +3493,10 @@ function App() {
         // https://api.ftcscout.org/rest/v1/teams/172/events/2023
         // to get wins, losses, ties, played, dq
         var seasonResult = await httpClient.getNoAuth(
-          `${selectedYear?.value}/ftcscout/events/${team?.teamNumber}`
-        ); // var seasonResult = await httpClient.getNoAuth(
+          `${selectedYear?.value}/ftcscout/events/${team?.teamNumber}`,
+          ftcMode ? ftcBaseURL : undefined
+        ); 
+        // var seasonResult = await httpClient.getNoAuth(
         //   `teams/${team?.teamNumber}/events/${selectedYear?.value}`,
         //   "https://api.ftcscout.org/rest/v1/",
         //   20000

--- a/src/components/AllianceSelection.jsx
+++ b/src/components/AllianceSelection.jsx
@@ -74,6 +74,10 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
     })
 
     var sortedTeams = _.orderBy(rankings?.ranks, "teamNumber", "asc");
+    // remove non-competing teams from sortedTeams
+    sortedTeams = _.filter(sortedTeams, (team) => {
+        return _.findIndex(teamList?.teams, { "teamNumber": team?.teamNumber }) >= 0;
+    });
 
     if (allianceCount?.count <= 4) {
         allianceDisplayOrder = [[1, 4], [2, 3]]
@@ -275,12 +279,12 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
 
     const colCount = !ftcMode && width > 1040 ? 5 :
         !ftcMode && width > 850 ? 4 :
-        ftcMode && width > 1500 ? 5 :
-        ftcMode && width > 1220 ? 4 :
-        ftcMode && width > 930 ? 3 :
-        ftcMode && width > 600 ? 2 :
-        ftcMode && width <= 600 ? 1 :
-            3;
+            ftcMode && width > 1500 ? 5 :
+                ftcMode && width > 1220 ? 4 :
+                    ftcMode && width > 930 ? 3 :
+                        ftcMode && width > 600 ? 2 :
+                            ftcMode && width <= 600 ? 1 :
+                                3;
 
     useEffect(() => {
         if (teamFilter !== "") {
@@ -294,12 +298,12 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
     useEffect(() => {
         if (allianceSelectionArrays && allianceSelectionArrays.allianceCount > 0) {
             // Check if the current stored rounds configuration matches what it should be
-            const expectedRounds = inChamps 
+            const expectedRounds = inChamps
                 ? (ftcMode ? ["round1", "round2"] : ["round1", "round2", "round3"])
                 : (ftcMode ? ["round1"] : ["round1", "round2"]);
-            
+
             const currentRounds = Object.keys(allianceSelectionArrays.rounds || {});
-            
+
             // If the rounds don't match, reset the alliance selection
             if (JSON.stringify(currentRounds.sort()) !== JSON.stringify(expectedRounds.sort())) {
                 console.log("Alliance configuration changed, resetting alliance selection");
@@ -562,7 +566,7 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
                                             </Container>}
                                     </Col>}
                                     <Col xs={width < 600 ? 12 : inChamps ? 6 : 5}>
-                                        <Row className={"alliancesTeamsTable alliancesTeamsTableHeader"}>{currentRound >= 0 ? `Round ${currentRound} of ${inChamps ? "3" : "2"}` : asArrays?.nextChoice > 0 ? "Alliance Selection Complete" : "Alliance Selection not started"}</Row>
+                                        <Row className={"alliancesTeamsTable alliancesTeamsTableHeader"}>{currentRound >= 0 ? `Round ${currentRound} of ${allianceSelectionRounds?.length}` : asArrays?.nextChoice > 0 ? "Alliance Selection Complete" : "Alliance Selection not started"}</Row>
                                         <Container fluid className={"alliancesTeamsTable"}>
                                             {allianceDisplayOrder.map((row) => {
 
@@ -574,7 +578,7 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
 
                                                                 const alliance = _.filter(alliances, { "number": allianceNumber })
                                                                 const allianceName = alliance[0]?.name;
-                                                                const fullAlliance = inChamps ? alliance[0]?.round3 : alliance[0]?.round2;
+                                                                const fullAlliance = allianceSelectionRounds?.length === 3 ? alliance[0]?.round3 : allianceSelectionRounds?.length === 2 ? alliance[0]?.round2 : alliance[0]?.round1;
                                                                 var captain = alliance[0]?.captain;
                                                                 if (captain) {
                                                                     captain.declined = asArrays?.declined?.includes(captain?.teamNumber);

--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -1,5 +1,16 @@
 export const appUpdates = [
   {
+    date: "December 9, 2025",
+    message: (
+      <ul>
+        <li>ALL PROGRAMS: Updated logic for Alliance Selection to only show teams that are competing in the event</li>
+        <li>FRC: Updated game brand on Setting page to REBUILT™</li>
+        <li>FTC: Updated Alliance Selection screen to show correct number of rounds for FTC events</li>
+        <li>FTC: Removed non-competing teams from rankings on League Meet events</li>
+        <li>FTC: Fixed a bug that prevented OPA and season stats from displaying correctly on the Ranks and Play-By-Play pages</li>
+      </ul>
+    ),
+  },{
     date: "November 17, 2025",
     message: (
       <ul>

--- a/src/components/FourAllianceBracketFTC.jsx
+++ b/src/components/FourAllianceBracketFTC.jsx
@@ -328,7 +328,7 @@ function FourAllianceBracketFTC({ currentMatch, qualsLength, nextMatch, previous
 								<polygon points="934.7 365 818.43 365 818.43 328.99 934.7 328.99 947.64 346.99 934.7 365" fill={BLUE} stroke={(tournamentWinner?.winner === "blue") ? GOLD : "none"} strokeWidth="5" />
 								<line x1="934.7" y1="328.75" x2="796" y2="328.75" fill="none" stroke="#fff" strokeMiterlimit="10" />
 							<rect x="796" y="292.54" width="22.43" height="72.46" fill={currentPlayoffMatch >= 6 ? GOLD : BLACK} />
-							<text transform="translate(811.78 357.63) rotate(-90)" fill={currentPlayoffMatch >= 6 ? BLACK : WHITE} fontFamily="'myriad-pro'" fontWeight={bold} fontStyle={"normal"} fontSize="10.076px">FINALS</text>
+							<text transform="translate(811.78 350.63) rotate(-90)" fill={currentPlayoffMatch >= 6 ? BLACK : WHITE} fontFamily="'myriad-pro'" fontWeight={bold} fontStyle={"normal"} fontSize="12px">FINALS</text>
 
 								<text transform="matrix(0.9941 0 0 1 880 307)" textAnchor="middle">
 									<tspan x="0" y="0" fill="#FFFFFF" fontFamily="'myriad-pro'" fontWeight={bold} fontStyle={"normal"} fontSize="12.1471px">{allianceName(6, "red") ? allianceName(6, "red") : "Winner of M3"}</tspan>

--- a/src/pages/RanksPage.jsx
+++ b/src/pages/RanksPage.jsx
@@ -39,7 +39,7 @@ function RanksPage({
   EPA,
   ftcMode,
   remapNumberToString,
-  remapStringToNumber
+  remapStringToNumber,
 }) {
   // This function clicks the hidden file upload button
   function clickLoadRanks() {
@@ -89,7 +89,9 @@ function RanksPage({
           (errorRanks.length > 1 ? "es:" : ":") +
           "</br>";
         errorRanks.forEach((match) => {
-          const displayTeamNumber = remapNumberToString ? remapNumberToString(match["teamNumber"]) : match["teamNumber"];
+          const displayTeamNumber = remapNumberToString
+            ? remapNumberToString(match["teamNumber"])
+            : match["teamNumber"];
           errorMessage += displayTeamNumber + "</br>";
         });
         errorMessage += "Please check the report and reload.</br>";
@@ -160,16 +162,22 @@ function RanksPage({
   function getTeamName(teamNumber) {
     // If teamNumber is a string like "1323B", we need to find the actual team by looking it up
     // Otherwise, use remapStringToNumber to convert it to the lookup number
-    const lookupNumber = remapStringToNumber ? remapStringToNumber(teamNumber) : teamNumber;
+    const lookupNumber = remapStringToNumber
+      ? remapStringToNumber(teamNumber)
+      : teamNumber;
     var team = _.find(teamList?.teams, { teamNumber: lookupNumber });
     return team?.nameShortLocal ? team?.nameShortLocal : team?.nameShort;
   }
+
+  const isLeagueMeet = ftcMode && selectedEvent?.value?.type === "1";
 
   var rankingsList = rankings?.ranks?.map((teamRow) => {
     teamRow.teamName = getTeamName(teamRow.teamNumber);
     if (selectedEvent?.value?.districtCode) {
       // Use remapStringToNumber to get the lookup number for district rankings
-      const lookupNumber = remapStringToNumber ? remapStringToNumber(teamRow.teamNumber) : teamRow.teamNumber;
+      const lookupNumber = remapStringToNumber
+        ? remapStringToNumber(teamRow.teamNumber)
+        : teamRow.teamNumber;
       teamRow.districtRankDetails = _.cloneDeep(
         _.filter(districtRankings?.districtRanks, {
           teamNumber: lookupNumber,
@@ -178,6 +186,11 @@ function RanksPage({
       teamRow.districtRanking = teamRow.districtRankDetails?.rank;
     }
     return teamRow;
+  });
+
+  // remove teams not in the team list
+  rankingsList = _.filter(rankingsList, (teamRow) => {
+    return teamRow.teamName !== undefined;
   });
 
   if (rankSort.charAt(0) === "-") {
@@ -455,14 +468,26 @@ function RanksPage({
             <Table responsive striped bordered size="sm">
               <thead className="thead-default">
                 <tr>
-                  <td colSpan={12}>
-                    <b>
-                      This table lists the teams in rank order for this
-                      competition. Its columns are sortable. This table updates
-                      during the competition, and freezes once Playoff Matches
-                      begin.
-                    </b>
-                  </td>
+                  {isLeagueMeet && (
+                    <td colSpan={12}>
+                      <b>
+                        This table lists the teams competing in this event. It
+                        shows their ranks based on performance in the League.
+                        Its columns are sortable. This table updates during the
+                        competition, and freezes once Playoff Matches begin.
+                      </b>
+                    </td>
+                  )}
+                  {!isLeagueMeet && (
+                    <td colSpan={12}>
+                      <b>
+                        This table lists the teams in rank order for this
+                        competition. Its columns are sortable. This table
+                        updates during the competition, and freezes once Playoff
+                        Matches begin.
+                      </b>
+                    </td>
+                  )}
                 </tr>
                 <tr>
                   <th
@@ -485,7 +510,8 @@ function RanksPage({
                     }
                   >
                     <b>
-                      Rank{rankSort === "rank" ? <SortNumericUp /> : ""}
+                      {isLeagueMeet ? "League Rank" : "Rank"}
+                      {rankSort === "rank" ? <SortNumericUp /> : ""}
                       {rankSort === "-rank" ? <SortNumericDown /> : ""}
                     </b>
                   </th>
@@ -509,7 +535,7 @@ function RanksPage({
                     }
                   >
                     <b>
-                      RP Avg.
+                      {isLeagueMeet ? "League " : ""}RP Avg.
                       {rankSort === "sortOrder1" ? <SortNumericUp /> : ""}
                       {rankSort === "-sortOrder1" ? <SortNumericDown /> : ""}
                     </b>
@@ -522,7 +548,8 @@ function RanksPage({
                     }
                   >
                     <b>
-                      Event Record{rankSort === "event" ? <SortAlphaUp /> : ""}
+                      {isLeagueMeet ? "League" : "Event"} Record
+                      {rankSort === "event" ? <SortAlphaUp /> : ""}
                       {rankSort === "-event" ? <SortAlphaDown /> : ""}
                     </b>
                   </th>
@@ -557,7 +584,7 @@ function RanksPage({
                     }
                   >
                     <b>
-                      Matches Played
+                      {isLeagueMeet ? "League " : ""}Matches Played
                       {rankSort === "matchesPlayed" ? <SortNumericUp /> : ""}
                       {rankSort === "-matchesPlayed" ? <SortNumericDown /> : ""}
                     </b>
@@ -583,7 +610,8 @@ function RanksPage({
                     }
                   >
                     <b>
-                      {ftcMode?'OPA':'EPA'}{rankSort === "epaVal" ? <SortNumericUp /> : ""}
+                      {ftcMode ? "OPA" : "EPA"}
+                      {rankSort === "epaVal" ? <SortNumericUp /> : ""}
                       {rankSort === "-epaVal" ? <SortNumericDown /> : ""}
                     </b>
                   </th>
@@ -617,7 +645,9 @@ function RanksPage({
                   rankings?.ranks &&
                   rankingsList.map((rankRow) => {
                     // Use remapStringToNumber to get the lookup number for updates and EPA
-                    const lookupNumber = remapStringToNumber ? remapStringToNumber(rankRow.teamNumber) : rankRow.teamNumber;
+                    const lookupNumber = remapStringToNumber
+                      ? remapStringToNumber(rankRow.teamNumber)
+                      : rankRow.teamNumber;
                     rankRow = _.merge(
                       rankRow,
                       communityUpdates
@@ -636,20 +666,29 @@ function RanksPage({
                         : null
                     );
                     rankRow.record = `${rankRow.wins}-${rankRow.losses}-${rankRow.ties}`;
-                    rankRow.epaVal = rankRow?.epa?.epa?.total_points?.mean>=0
-                      ? rankRow?.epa?.epa?.total_points?.mean
-                      : "TBD";
-                    rankRow.season = rankRow?.epa?.record?.wins>=0
-                      ? `${rankRow?.epa?.record?.wins}-${rankRow?.epa?.record?.losses}-${rankRow?.epa?.record?.ties}`
-                      : `TBD`;
-                    
+                    rankRow.epaVal =
+                      rankRow?.epa?.epa?.total_points?.mean >= 0
+                        ? rankRow?.epa?.epa?.total_points?.mean
+                        : "TBD";
+                    rankRow.season =
+                      rankRow?.epa?.record?.wins >= 0
+                        ? `${rankRow?.epa?.record?.wins}-${rankRow?.epa?.record?.losses}-${rankRow?.epa?.record?.ties}`
+                        : `TBD`;
+
                     // Display remapped team number if available
-                    const displayTeamNumber = remapNumberToString ? remapNumberToString(rankRow.teamNumber) : rankRow.teamNumber;
-                    
+                    const displayTeamNumber = remapNumberToString
+                      ? remapNumberToString(rankRow.teamNumber)
+                      : rankRow.teamNumber;
+
                     return (
                       <tr key={"rankings" + rankRow.teamNumber}>
                         <td>{displayTeamNumber}</td>
-                        <td style={rankHighlight(rankRow.rank, allianceCount || { count: 8 })}>
+                        <td
+                          style={rankHighlight(
+                            rankRow.rank,
+                            allianceCount || { count: 8 }
+                          )}
+                        >
                           {rankRow.rank}
                         </td>
                         <td
@@ -661,7 +700,7 @@ function RanksPage({
                         ></td>
                         <td>{rankRow.sortOrder1}</td>
                         <td>{rankRow.record}</td>
-                        <td>{Math.floor(rankRow.qualAverage*100)/100}</td>
+                        <td>{Math.floor(rankRow.qualAverage * 100) / 100}</td>
                         <td>{rankRow.dq}</td>
                         <td>{rankRow.matchesPlayed}</td>
                         <td>{rankRow.season}</td>

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -387,8 +387,8 @@ function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedY
                             If your event requires a reduced Alliance Count, you can override the Alliance Count here. <b>THIS SHOULD ONLY APPLY TO EVENTS WITH LESS THAN 26 TEAMS. </b><Select options={playoffOverrideMenu} value={playoffCountOverride ? playoffCountOverride : (allianceCount?.menu ? allianceCount.menu : playoffOverrideMenu[0])} onChange={setPlayoffCountOverride} />
                         </Alert>
                         <div>
-                            {!ftcMode && <img style={{ width: "100%" }} src="/images/frc_reefscape.gif" alt="REEFSCAPE℠ presented by Haas Logo" />}
-                            {ftcMode && <img style={{ width: "100%" }} src="/images/first_age_ftc_decode_logo_vertical_rgb_fullcolor.png" alt="DECODE℠ presented by Haas Logo" />}
+                            {!ftcMode && <img style={{ width: "100%" }} src="/images/first_age_frc_rebuilt_logo_vertical_rgb_fullcolor.png" alt="REEFSCAPE℠ presented by Haas Logo" />}
+                            {ftcMode && <img style={{ width: "100%" }} src="/images/first_age_ftc_decode_logo_vertical_rgb_fullcolor.png" alt="DECODE℠ presented by RTC Logo" />}
                         </div>
                     </Col>
                     <Col sm={4}>


### PR DESCRIPTION
Several updates
ALL PROGRAMS: Updated logic for Alliance Selection to only show teams that are competing in the event
FRC: Updated game brand on Setting page to REBUILT™
FTC: Updated Alliance Selection screen to show correct number of rounds for FTC events
FTC: Removed non-competing teams from rankings on League Meet events
FTC: Fixed a bug that prevented OPA and season stats from displaying correctly on the Ranks and Play-By-Play pages