### PR TITLE
 Resolve timing issues for Alliance Selection and Stats page updates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5169,6 +5169,15 @@ function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ftcMode]);
 
+  // Recalculate event high scores whenever schedules update (when event loads or matches are played)
+  useEffect(() => {
+    if (selectedEvent?.value?.code && selectedYear?.value && (qualSchedule || playoffSchedule)) {
+      console.log('Schedules updated, recalculating event high scores...');
+      getEventStats(selectedYear?.value, selectedEvent?.value?.code);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [qualSchedule?.lastUpdate, playoffSchedule?.lastUpdate, selectedEvent?.value?.code, selectedYear?.value]);
+
   // Retrieve robot images when the team list changes
   useEffect(() => {
     if (

--- a/src/components/AllianceSelection.jsx
+++ b/src/components/AllianceSelection.jsx
@@ -7,7 +7,7 @@ import { useEffect } from "react";
 import { originalAndSustaining, allianceSelectionBaseRounds } from "./Constants";
 import useWindowDimensions from "hooks/UseWindowDimensions";
 
-function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, allianceCount, communityUpdates, allianceSelectionArrays, setAllianceSelectionArrays, handleReset, teamFilter, setTeamFilter, ftcMode, remapNumberToString, useFourTeamAlliances }) {
+function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, allianceCount, communityUpdates, allianceSelectionArrays, setAllianceSelectionArrays, handleReset, teamFilter, setTeamFilter, ftcMode, remapNumberToString, useFourTeamAlliances, setResetAllianceSelection }) {
     const OriginalAndSustaining = _.cloneDeep(originalAndSustaining);
     const AllianceSelectionBaseRounds = _.cloneDeep(allianceSelectionBaseRounds);
 
@@ -561,7 +561,7 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
                                     <span>    </span>
                                     {(asArrays?.undo?.length > 0) && <Button id="undoButton" size="sm" onClick={handleUndo} active >Undo Previous Choice</Button>}
                                     {(asArrays?.undo?.length === 0) && <Button size="sm" onClick={handleUndo} disabled >Undo Previous Choice</Button>}
-                                    <span>    </span><Button size="sm" variant="warning" onClick={handleReset} active>Restart Alliance Selection</Button>
+                                    <span>    </span><Button size="sm" variant="success" onClick={()=>setResetAllianceSelection(true)} active>Refresh Rankings</Button><span>    </span><Button size="sm" variant="warning" onClick={handleReset} active>Restart Alliance Selection</Button>
                                 </InputGroup>
                             </Form>
                         </Row>

--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -1,10 +1,19 @@
 export const appUpdates = [
   {
-    date: "December 9, 2025",
+    date: "December 16, 2025",
     message: (
       <ul>
-        <li>ALL PROGRAMS: Added option to remove a team from the list of available teams in Alliance Selection</li>
-        <li>FRC: Updated game brand on Setting page to animated REBUILT™ logo</li>
+        <li>ALL PROGRAMS: </li>
+        <ul>
+          <li>Added option to remove a team from the list of available teams in Alliance Selection</li>
+          <li>Added button to refresh rankings in Alliance Selection. This also restarts Alliance Selection to ensure proper ranking order is displayed</li>
+          <li>Fixed timing issue with displaying event stats on first event load</li>
+        </ul>
+        
+        <li>FRC:</li>
+        <ul>
+        <li>Updated game brand on Setting page to animated REBUILT™ logo</li>
+        </ul>
       </ul>
     ),
   },{


### PR DESCRIPTION
Fix two critical timing issues related to data updates:

1. Alliance Selection - Rankings Refresh Timing
   - Added state tracking (waitingForRankingsUpdate) and ref (previousRankingsRef) to monitor when rankings complete updating
   - Implemented useEffect hook that watches rankings?.lastUpdate timestamp
   - handleResetAllianceSelection now waits for getRanks() to complete before calling handleReset(), ensuring alliance selection arrays are built from fresh rankings data
   - Green alert handler updated to use same pattern when loadEvent() is called
   - Prevents race condition where alliance selection was reset with stale rankings before new data finished loading

2. Stats Page - Event High Scores Updates
   - Added useEffect hook that watches qualSchedule?.lastUpdate and playoffSchedule?.lastUpdate timestamps
   - Automatically recalculates event high scores whenever schedules update
   - Fixes issue where stats would not populate when event first loads
   - Ensures stats update every time a user navigates between matches
   - Works for online events, offline events, and manually uploaded schedules

These changes ensure data consistency and proper sequencing of async operations, improving the user experience by displaying accurate, up-to-date information at all times.
Closes #619