### PR TITLE
Adding reset button for Team Data for start of the season

### DIFF
--- a/src/components/Announce.jsx
+++ b/src/components/Announce.jsx
@@ -122,10 +122,10 @@ function Announce({ station, team, inPlayoffs, awardsMenu, selectedYear, selecte
                         let formattedAward = <></>;
                         if (award.year > selectedYear.value - (awardsMenu?.value || 3)) {
                             if (!award.highlight && (showMinorAwards || _.isNull(showMinorAwards))) {
-                                formattedAward = <span key={award?.year + award?.eventName + award?.name + award?.person + team?.teamNumber + index} >{award.year} {_.findIndex(eventNamesCY[award.eventName]) >= 0 ? eventNamesCY[award.eventName] : award.eventName} : {award.name}{award.person ? ` : ${award.person}` : ""}<br /></span>
+                                formattedAward = <span key={award?.year + award?.eventCode + award?.name + award?.person + team?.teamNumber + index} >{award.year} {_.findIndex(eventNamesCY[award.eventCode]) >= 0 ? eventNamesCY[award.eventCode] : award?.eventName ? award?.eventName : award.code} : {award.name}{award.person ? ` : ${award.person}` : ""}<br /></span>
                             } else {
                                 if (award.highlight) {
-                                    formattedAward = <span key={award?.year + award?.eventName + award?.name + award?.person + team?.teamNumber + index} className={"awardHilight"}>{award.year} {_.findIndex(eventNamesCY[award.eventName]) >= 0 ? eventNamesCY[award.eventName] : award.eventName} : {award.name}{award.person ? ` : ${award.person}` : ""}<br /></span>
+                                    formattedAward = <span key={award?.year + award?.eventCode + award?.name + award?.person + team?.teamNumber + index} className={"awardHilight"}>{award.year} {_.findIndex(eventNamesCY[award.eventCode]) >= 0 ? eventNamesCY[award.eventCode] : award?.eventName ? award?.eventName : award.code} : {award.name}{award.person ? ` : ${award.person}` : ""}<br /></span>
                                 }
                             }
                         }

--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -1,11 +1,12 @@
 export const appUpdates = [
   {
-    date: "January 14, 2026",
+    date: "January 16, 2026",
     message: (
       <ul>
         <li>ALL PROGRAMS:</li>
         <ul>
           <li>Added button on Team List screento reset sponsors, robot names and optionally team notes for teams that have not been updated since the start of the season</li>
+          <li>Fixed a bug that prevented awards from displaying correctly on the Announce page</li>
         </ul>
       </ul>
     ),

--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -1,5 +1,15 @@
 export const appUpdates = [
   {
+    date: "January 14, 2026",
+    message: (
+      <ul>
+        <li>ALL PROGRAMS:</li>
+        <ul>
+          <li>Added button on Team List screento reset sponsors, robot names and optionally team notes for teams that have not been updated since the start of the season</li>
+        </ul>
+      </ul>
+    ),
+  },{
     date: "January 12, 2026",
     message: (
       <ul>

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -164,7 +164,9 @@ function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedY
         setLocalUpdates([]);
         await setLoadingCommunityUpdates(false);
         handleClose();
-        getCommunityUpdates(false, null);
+        // Refresh community updates from server, ignoring local updates to get pure server state
+        // This ensures the reset button can find teams again after deletion
+        getCommunityUpdates(false, null, true);
     }
 
     function handleClose() {


### PR DESCRIPTION
This adds a button to the Team Data screen to reset the robot names, Sponsors, and team notes for all teams at an event that have not had an update since the start of the current season. This date range is program dependent (Jan 1 for FRC, Sept 1 for FTC).
Users can make the global change locally and update later, if desired. Otherwise, they can upload the reset values to gatool Cloud during the reset.

It also fixes a display issue where awards were not including event names for the current season. 

Closes #513 
Closes #630 