### PR TITLE
Fixing a display issue which caused TIMS-sourced robot names not to show properly.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4237,9 +4237,26 @@ function App() {
     );
 
     if (result.status === 200) {
-      // @ts-ignore
-      var notifications = await result.json();
-      return notifications;
+      // Check if there's content before trying to parse JSON
+      // result might be a Response object or a plain object, so check for headers
+      if ('headers' in result && result.headers) {
+        const contentLength = result.headers.get('content-length');
+        if (contentLength === '0' || contentLength === null) {
+          // No content, return empty array
+          return [];
+        }
+      }
+      try {
+        // @ts-ignore
+        var notifications = await result.json();
+        return notifications;
+      } catch (e) {
+        // If JSON parsing fails (e.g., empty body), return empty array
+        return [];
+      }
+    } else if (result.status === 204) {
+      // No Content status, return empty array
+      return [];
     } else if (result.status === 404) {
       return [
         {

--- a/src/components/PlayByPlay.jsx
+++ b/src/components/PlayByPlay.jsx
@@ -36,7 +36,7 @@ function PlayByPlay({ station, team, inPlayoffs, selectedEvent, showNotes, showM
                 {team?.teamNumber && (team?.teamNumber !== 0) &&
                     <>
                         <p className={`playByPlayTeamName ${(inPlayoffs && showQualsStats) ? "playByPlayTeamNameStats" : ""} ${team?.updates?.nameShortLocal ? (team?.updates?.nameShortLocal?.length > 60 ? " narrowFont" : "") : (team?.nameShort?.length > 60 ? " narrowFont" : "")}`}>{team?.updates?.nameShortLocal ? team?.updates?.nameShortLocal : team?.nameShort}</p>
-                        <p className={"playByPlayRobotName"}>{team?.updates?.robotNameLocal}</p>
+                        <p className={"playByPlayRobotName"}>{team?.updates?.robotNameLocal ? team?.updates?.robotNameLocal : team?.robotName}</p>
                         {((!inPlayoffs && (_.isNull(showQualsStatsQuals) || showQualsStatsQuals)) || (inPlayoffs && showQualsStats)) && team?.rank &&
                             <div className={"playByPlayWinLossTie text-center"}>
                                 <table className={"wltTable"}>


### PR DESCRIPTION
Fixing an error condition when we read the event notifications and there are none. 
Robot names now display properly.
Closes #635