### PR TITLE
Fixing FTC team avatar display

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5278,6 +5278,32 @@ function App() {
     }
   }, [ftcMode, manualOfflineMode, setManualOfflineMode]);
 
+  // Load FTC avatars composed CSS when in ftcMode (season+1 for next-season avatar styles)
+  useEffect(() => {
+    const linkId = "ftc-avatars-composed-css";
+    if (!ftcMode || !selectedYear?.value) {
+      const existing = document.getElementById(linkId);
+      if (existing) existing.remove();
+      return;
+    }
+    const seasonPlusOne = Number(selectedYear.value) + 1;
+    const href = `https://ftc-scoring.firstinspires.org/avatars/composed/${seasonPlusOne}.css`;
+    const existingLink = document.getElementById(linkId);
+    if (existingLink) {
+      if (existingLink.getAttribute("href") === href) return;
+      existingLink.remove();
+    }
+    const linkEl = document.createElement("link");
+    linkEl.id = linkId;
+    linkEl.rel = "stylesheet";
+    linkEl.href = href;
+    document.head.appendChild(linkEl);
+    return () => {
+      const el = document.getElementById(linkId);
+      if (el) el.remove();
+    };
+  }, [ftcMode, selectedYear?.value]);
+
   // Refresh team list when showBlueBanners is enabled to fetch blue banner data
   useEffect(() => {
     if (showBlueBanners === true && !ftcMode && selectedEvent && teamList?.teams?.length > 0 && isOnline) {

--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -1,5 +1,15 @@
 export const appUpdates = [
   {
+    date: "February 13, 2026",
+    message: (
+      <ul>
+        <li>FTC:</li>
+        <ul>
+          <li>Fixed a bug where team avatars were not displaying correctly on Team Data and Cheat Sheet pages</li>
+        </ul>
+      </ul>
+    ),
+  },{
     date: "February 2, 2026",
     message: (
       <ul>

--- a/src/pages/CheatsheetPage.jsx
+++ b/src/pages/CheatsheetPage.jsx
@@ -27,7 +27,7 @@ function CheatsheetPage({
       backHTML: "",
       style: { width: "500px", height: "300px" },
     };
-    var avatar = `<img src="${apiBaseUrl}${selectedYear.value}/avatars/team/${team?.teamNumber}/avatar.png" onerror="this.style.display='none'">&nbsp`;
+    var avatar = ftcMode?`<span class="team-avatar team-${team?.teamNumber}"></span>`:`<img src="${apiBaseUrl}${selectedYear.value}/avatars/team/${team?.teamNumber}/avatar.png" onerror="this.style.display='none'">&nbsp`;
     var robotImage = _.filter(robotImages, { teamNumber: team?.teamNumber })[0]
       ?.imageUrl
       ? `<img height="225px" src="${

--- a/src/pages/TeamDataPage.jsx
+++ b/src/pages/TeamDataPage.jsx
@@ -740,7 +740,7 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
      */
     const handleResetProceed = async () => {
         setShowResetConfirm(false);
-        
+
         // Clone local updates and remove sponsor and robot name fields
         var localUpdatesTemp = _.cloneDeep(localUpdates);
         // Don't modify communityUpdates - it represents server state
@@ -769,16 +769,16 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
         // by explicitly removing the sponsor/robot name fields
         teamsToReset.forEach((teamNumber) => {
             const existsInLocalUpdates = _.findIndex(localUpdatesTemp, { "teamNumber": teamNumber }) >= 0;
-            
+
             if (!existsInLocalUpdates) {
                 // Get the community update for this team
                 const communityUpdate = find(communityUpdates, { "teamNumber": teamNumber });
-                
+
                 if (communityUpdate && communityUpdate.updates) {
                     // Create a local update that removes the sponsor/robot name fields
                     // Start with a copy of the community update
                     const resetUpdate = _.cloneDeep(communityUpdate.updates);
-                    
+
                     // Remove sponsor/robot name fields
                     delete resetUpdate.topSponsorsLocal;
                     delete resetUpdate.topSponsorLocal;
@@ -788,7 +788,7 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
                         delete resetUpdate.teamNotes;
                     }
                     resetUpdate.lastUpdate = moment().format();
-                    
+
                     // Add to localUpdates so Setup page can detect it
                     localUpdatesTemp.push({
                         teamNumber: teamNumber,
@@ -1006,15 +1006,15 @@ function TeamDataPage({ selectedEvent, selectedYear, teamList, rankings, teamSor
                     <tbody>
                         {teamList && teamList?.teams && teamListExtended.map((team) => {
                             var cityState = `${team?.city}, ${team?.stateProv}${(team?.country !== "USA") ? ", " + team?.country : ""}`;
-                            var avatar = `<img src='${apiBaseUrl}${selectedYear.value}/avatars/team/${team?.teamNumber}/avatar.png' onerror="this.style.display='none'">&nbsp`;
+                            var avatar = ftcMode ? `<span class="team-avatar team-${team?.teamNumber}"></span>` : `<img src='${apiBaseUrl}${selectedYear.value}/avatars/team/${team?.teamNumber}/avatar.png' onerror="this.style.display='none'">&nbsp`;
                             var teamNameWithAvatar = team?.updates?.nameShortLocal ? team?.updates?.nameShortLocal : team?.nameShort;
-                            teamNameWithAvatar = !ftcMode ? avatar + "<br />" + teamNameWithAvatar : teamNameWithAvatar;
+                            teamNameWithAvatar = avatar + "<br />" + teamNameWithAvatar;
 
                             return <tr key={`teamDataRow${team?.teamNumber}`}>
                                 <TeamTimer team={team} lastVisit={lastVisit} monthsWarning={monthsWarning} handleShow={handleShow} currentTime={currentTime} />
                                 <td style={rankHighlight(team?.rank ? team?.rank : 100, allianceCount || { "count": 8 })}>{team?.rank}</td>
-                                {ftcMode && <td style={updateHighlight(team?.updates?.nameShortLocal)}>{teamNameWithAvatar}</td>}
-                                {!ftcMode && <td dangerouslySetInnerHTML={{ __html: teamNameWithAvatar }} style={updateHighlight(team?.updates?.nameShortLocal)}></td>}
+                                
+                                <td dangerouslySetInnerHTML={{ __html: teamNameWithAvatar }} style={updateHighlight(team?.updates?.nameShortLocal)}></td>
                                 <td style={updateHighlight(team?.updates?.cityStateLocal)}>{team?.updates?.cityStateLocal ? team?.updates?.cityStateLocal : cityState} </td>
                                 {(selectedEvent?.value?.type === "Championship" || selectedEvent?.value?.type === "ChampionshipDivision") ?
                                     <td style={updateHighlight(team?.updates?.topSponsorLocal)}>{team?.updates?.topSponsorLocal ? team?.updates?.topSponsorLocal : team?.topSponsor}</td> :


### PR DESCRIPTION
FRC has an API to retrieve avatars. FTC does not. Rather, it uses a CSS-based approach to ensuring that team Avatars display properly. We have updated the Team Data and Cheat Sheet page (with the flash cards) to properly display avatars for FTC teams. Closes #647