### PR TITLE
Post-week0 fixes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1464,13 +1464,13 @@ function App() {
           match.scores = matchResults;
           match.scoreRedFinal = matchResults.alliances?.[1]?.totalPoints;
           match.scoreBlueFinal = matchResults.alliances?.[0]?.totalPoints;
-          // @ts-ignore
+          // @ts-ignore - FRC may use "BonusAchieved" or "Achieved" in key names for ranking points
           match.redRP = _.pickBy(matchResults.alliances[1], (value, key) => {
-            return key.endsWith("BonusAchieved") || key.endsWith("RP");
+            return key.endsWith("BonusAchieved") || key.endsWith("Achieved") || key.endsWith("RP");
           });
           // @ts-ignore
           match.blueRP = _.pickBy(matchResults.alliances[0], (value, key) => {
-            return key.endsWith("BonusAchieved") || key.endsWith("RP");
+            return key.endsWith("BonusAchieved") || key.endsWith("Achieved") || key.endsWith("RP");
           });
         }
       } else if (selectedEvent?.value?.type === "OffSeason") {
@@ -1480,13 +1480,13 @@ function App() {
         }
         if (match.scores?.alliances?.[1]) {
           match.redRP = _.pickBy(match.scores.alliances[1], (value, key) => {
-            return key.endsWith("BonusAchieved") || key.endsWith("RP");
+            return key.endsWith("BonusAchieved") || key.endsWith("Achieved") || key.endsWith("RP");
           });
         }
         // @ts-ignore
         if (match.scores?.alliances?.[0]) {
           match.blueRP = _.pickBy(match.scores.alliances[0], (value, key) => {
-            return key.endsWith("BonusAchieved") || key.endsWith("RP");
+            return key.endsWith("BonusAchieved") || key.endsWith("Achieved") || key.endsWith("RP");
           });
         }
       }
@@ -3886,8 +3886,9 @@ function App() {
 
       const redScore = match.scoreRedFinal || 0;
       const blueScore = match.scoreBlueFinal || 0;
-      const redFoul = match.scoreRedFoul || 0;
-      const blueFoul = match.scoreBlueFoul || 0;
+      // FTC uses fouls to represent points commmitted, not earned, by each Alliance.
+      const redFoul = ftcMode ? match.scoreBlueFoul : match.scoreRedFoul || 0;
+      const blueFoul = ftcMode ? match.scoreRedFoul : match.scoreBlueFoul || 0;
 
       // Determine which alliance has the high score
       const highScoreAlliance = redScore >= blueScore ? "red" : "blue";
@@ -4022,7 +4023,7 @@ function App() {
       highscores.forEach((score) => {
         if (score?.matchData?.match) {
           var details = {};
-          if (!_.isEmpty(eventnames[worldStats?.year])) {
+          if (eventnames[year] && !_.isEmpty(eventnames[year])) {
             details.eventName = eventnames[year][code] || code;
           } else {
             details.eventName = code;

--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -1,5 +1,19 @@
 export const appUpdates = [
   {
+    date: "February 22, 2026",
+    message: (
+      <ul>
+        <li>ALL PROGRAMS:</li>
+        <ul>
+          <li>Fixed a bug which crashed the app when displaying score details on the Schedule page</li>
+        </ul>
+        <li>FTC:</li>
+        <ul>
+          <li>Added World High Scores to Stats page</li>
+        </ul>
+      </ul>
+    ),
+  },{
     date: "February 18, 2026",
     message: (
       <ul>

--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -9,7 +9,9 @@ export const appUpdates = [
         </ul>
         <li>FTC:</li>
         <ul>
-          <li>Added World High Scores to Stats page</li>
+          <li>Added World and Regional High Scores to Stats page</li>
+          <li>Fixed a bug which caused the event high score (no penalties to winner) to be displayed incorrectly on the Stats page</li>
+          <li>Updated Playoffs Brackets to properly display Alliances in future matches, based on results from previous matches</li>
         </ul>
       </ul>
     ),

--- a/src/components/Bracket.jsx
+++ b/src/components/Bracket.jsx
@@ -872,6 +872,8 @@ function Bracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule, currentMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Loser of M11"
+							bluePlaceHolder="Winner of M12"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -886,6 +888,8 @@ function Bracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule, currentMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Winner of M10"
+							bluePlaceHolder="Winner of M9"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -900,6 +904,8 @@ function Bracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule, currentMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Winner of M7"
+							bluePlaceHolder="Winner of M8"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -914,6 +920,8 @@ function Bracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule, currentMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Loser of M8"
+							bluePlaceHolder="Winner of M5"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -928,6 +936,8 @@ function Bracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule, currentMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Loser of M7"
+							bluePlaceHolder="Winner of M6"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -942,6 +952,8 @@ function Bracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule, currentMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Winner of M3"
+							bluePlaceHolder="Winner of M4"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -956,6 +968,8 @@ function Bracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule, currentMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Winner of M1"
+							bluePlaceHolder="Winner of M2"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -970,6 +984,8 @@ function Bracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule, currentMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Loser of M3"
+							bluePlaceHolder="Loser of M4"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -984,6 +1000,8 @@ function Bracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule, currentMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Winner of M1"
+							bluePlaceHolder="Winner of M2"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -998,6 +1016,8 @@ function Bracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule, currentMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Alliance 3"
+							bluePlaceHolder="Alliance 6"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -1012,6 +1032,8 @@ function Bracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule, currentMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Alliance 2"
+							bluePlaceHolder="Alliance 7"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -1026,6 +1048,8 @@ function Bracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule, currentMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Alliance 4"
+							bluePlaceHolder="Alliance 5"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -1040,6 +1064,8 @@ function Bracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule, currentMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Alliance 1"
+							bluePlaceHolder="Alliance 8"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>

--- a/src/components/FourAllianceBracket.jsx
+++ b/src/components/FourAllianceBracket.jsx
@@ -447,6 +447,8 @@ function FourAllianceBracket({ currentMatch, qualsLength, nextMatch, previousMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Loser of M4"
+							bluePlaceHolder="Winner of M3"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -461,6 +463,8 @@ function FourAllianceBracket({ currentMatch, qualsLength, nextMatch, previousMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Loser of M1"
+							bluePlaceHolder="Loser of M2"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -475,6 +479,8 @@ function FourAllianceBracket({ currentMatch, qualsLength, nextMatch, previousMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Winner of M1"
+							bluePlaceHolder="Winner of M2"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -489,6 +495,8 @@ function FourAllianceBracket({ currentMatch, qualsLength, nextMatch, previousMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Alliance 2"
+							bluePlaceHolder="Alliance 3"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -503,6 +511,8 @@ function FourAllianceBracket({ currentMatch, qualsLength, nextMatch, previousMat
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Alliance 1"
+							bluePlaceHolder="Alliance 4"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>

--- a/src/components/FourAllianceBracketFTC.jsx
+++ b/src/components/FourAllianceBracketFTC.jsx
@@ -786,6 +786,8 @@ function FourAllianceBracketFTC({ currentMatch, qualsLength, nextMatch, previous
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Loser of M4"
+							bluePlaceHolder="Winner of M3"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -801,6 +803,8 @@ function FourAllianceBracketFTC({ currentMatch, qualsLength, nextMatch, previous
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Loser of M1"
+							bluePlaceHolder="Loser of M2"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -816,6 +820,8 @@ function FourAllianceBracketFTC({ currentMatch, qualsLength, nextMatch, previous
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Winner of M1"
+							bluePlaceHolder="Winner of M2"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -830,6 +836,8 @@ function FourAllianceBracketFTC({ currentMatch, qualsLength, nextMatch, previous
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Alliance 2"
+							bluePlaceHolder="Alliance 3"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -844,6 +852,8 @@ function FourAllianceBracketFTC({ currentMatch, qualsLength, nextMatch, previous
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Alliance 1"
+							bluePlaceHolder="Alliance 4"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>

--- a/src/components/Match.jsx
+++ b/src/components/Match.jsx
@@ -13,6 +13,8 @@ function Match({
 	getAllianceNumbersForDisplay,
 	getMatchWinnerForDisplay,
 	getMatchScoreForDisplay,
+	redPlaceHolder = "Red Alliance",
+	bluePlaceHolder = "Blue Alliance",
 	colors = {
 		RED: "#FF0000",
 		BLUE: "#0000FF",
@@ -127,7 +129,7 @@ function Match({
 				{/* Red alliance name and numbers */}
 				<text transform={`matrix(0.9941 0 0 1 ${allianceTextX} ${redAllianceTextY})`} textAnchor="middle">
 					<tspan x="0" y="0" fill="#FFFFFF" fontFamily="'myriad-pro'" fontWeight={bold} fontStyle="normal" fontSize="12.1471px">
-						{getAllianceNameForDisplay(matchNumber, "red") || `Alliance ${matchNumber}`}
+						{getAllianceNameForDisplay(matchNumber, "red") || `${redPlaceHolder}`}
 					</tspan>
 					<tspan x="0" y="14.58" fill="#FFFFFF" fontFamily={getAllianceNumbersForDisplay(matchNumber, "red").length > 20 ? "'myriad-pro-condensed'" : "'myriad-pro'"} fontWeight={bold} fontStyle="normal" fontSize="12.1471px">
 						{getAllianceNumbersForDisplay(matchNumber, "red")}
@@ -136,7 +138,7 @@ function Match({
 				{/* Blue alliance name and numbers */}
 				<text transform={`matrix(0.9941 0 0 1 ${allianceTextX} ${blueAllianceTextY})`} textAnchor="middle">
 					<tspan x="0" y="0" fill="#FFFFFF" fontFamily="'myriad-pro'" fontWeight={bold} fontStyle="normal" fontSize="12.1471px">
-						{getAllianceNameForDisplay(matchNumber, "blue") || `Alliance ${matchNumber}`}
+						{getAllianceNameForDisplay(matchNumber, "blue") || `${bluePlaceHolder}`}
 					</tspan>
 					<tspan x="0" y="14.58" fill="#FFFFFF" fontFamily={getAllianceNumbersForDisplay(matchNumber, "blue").length > 20 ? "'myriad-pro-condensed'" : "'myriad-pro'"} fontWeight={bold} fontStyle="normal" fontSize="12.1471px">
 						{getAllianceNumbersForDisplay(matchNumber, "blue")}

--- a/src/components/SixAllianceBracket.jsx
+++ b/src/components/SixAllianceBracket.jsx
@@ -870,6 +870,8 @@ function SixAllianceBracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule,
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Loser of M7"
+							bluePlaceHolder="Winner of M8"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -884,6 +886,8 @@ function SixAllianceBracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule,
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Winner of M6"
+							bluePlaceHolder="Winner of M5"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -898,6 +902,8 @@ function SixAllianceBracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule,
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Winner of M3"
+							bluePlaceHolder="Winner of M4"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -912,6 +918,8 @@ function SixAllianceBracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule,
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Loser of M4"
+							bluePlaceHolder="Loser of M1"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -926,6 +934,8 @@ function SixAllianceBracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule,
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Loser of M3"
+							bluePlaceHolder="Loser of M2"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -940,6 +950,8 @@ function SixAllianceBracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule,
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Alliance 2"
+							bluePlaceHolder="Winner of M2"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -954,6 +966,8 @@ function SixAllianceBracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule,
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Alliance 1"
+							bluePlaceHolder="Winner of M1"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -968,6 +982,8 @@ function SixAllianceBracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule,
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Alliance 3"
+							bluePlaceHolder="Alliance 6"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>
@@ -982,6 +998,8 @@ function SixAllianceBracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule,
 							getAllianceNumbersForDisplay={getAllianceNumbersForDisplay}
 							getMatchWinnerForDisplay={getMatchWinnerForDisplay}
 							getMatchScoreForDisplay={getMatchScoreForDisplay}
+							redPlaceHolder="Alliance 4"
+							bluePlaceHolder="Alliance 5"
 							colors={{ RED, BLUE, GOLD, GREEN, BLACK, WHITE }}
 							fontWeights={{ bold }}
 						/>

--- a/src/pages/SchedulePage.jsx
+++ b/src/pages/SchedulePage.jsx
@@ -716,8 +716,14 @@ function SchedulePage({
   const rankPointDisplay = (rankPoints) => {
     var pointsDisplay = [];
     _.forEach(rankPoints, (value, key) => {
+      // FRC uses "BonusAchieved" or "Achieved" in key names; prefer stripping BonusAchieved first, then Achieved
+      const name = key.endsWith("BonusAchieved")
+        ? key.slice(0, -"BonusAchieved".length)
+        : key.endsWith("Achieved")
+          ? key.slice(0, -"Achieved".length)
+          : key;
       pointsDisplay.push({
-        bonus: _.startCase(key.replace("BonusAchieved", "")),
+        bonus: _.startCase(name),
         earned: value,
       });
     });
@@ -774,13 +780,13 @@ function SchedulePage({
     });
   };
 
-  const scoresRow = (key) => {
+  const scoresRow = (key, rowKey) => {
     const redAlliance = scoresMatch?.scores?.alliances?.[1];
     const blueAlliance = scoresMatch?.scores?.alliances?.[0];
     const redVal = redAlliance?.[key.key];
     const blueVal = blueAlliance?.[key.key];
     return (
-      <tr>
+      <tr key={rowKey}>
         <td>
           <b>{key.key}</b>
         </td>
@@ -1975,15 +1981,19 @@ function SchedulePage({
                     addScoreType(scoresMatch.scores.alliances[0]),
                     ["type", "key"],
                     ["asc", "asc"]
-                  ).map((key) => {
+                  ).map((key, keyIndex) => {
+                    const rowKey = `score-row-${key?.type ?? ""}-${key?.key ?? ""}-${keyIndex}`;
                     if (
                       typeof scoresMatch?.scores?.alliances?.[0]?.[key.key] ===
                       "object"
                     ) {
-                      return expandScoresRow(key);
-                      // return null
+                      return (
+                        <React.Fragment key={rowKey}>
+                          {expandScoresRow(key)}
+                        </React.Fragment>
+                      );
                     } else {
-                      return scoresRow(key);
+                      return scoresRow(key, rowKey);
                     }
                   })
                 ) : (

--- a/src/pages/SchedulePage.jsx
+++ b/src/pages/SchedulePage.jsx
@@ -750,6 +750,9 @@ function SchedulePage({
   };
 
   const addScoreType = (scores) => {
+    if (scores == null || typeof scores !== "object" || Array.isArray(scores)) {
+      return [];
+    }
     return Object.keys(scores).map((key) => {
       if (key.toLowerCase().includes("alliance")) return { type: 1, key: key };
       else if (
@@ -772,29 +775,36 @@ function SchedulePage({
   };
 
   const scoresRow = (key) => {
+    const redAlliance = scoresMatch?.scores?.alliances?.[1];
+    const blueAlliance = scoresMatch?.scores?.alliances?.[0];
+    const redVal = redAlliance?.[key.key];
+    const blueVal = blueAlliance?.[key.key];
     return (
       <tr>
         <td>
           <b>{key.key}</b>
         </td>
         <td className="scheduleTablered">
-          {typeof scoresMatch?.scores.alliances[1][key.key] === "boolean"
-            ? scoreAchieved(scoresMatch?.scores.alliances[1][key.key])
-            : scoresMatch?.scores.alliances[1][key.key]}
+          {typeof redVal === "boolean"
+            ? scoreAchieved(redVal)
+            : redVal}
         </td>
-
         <td className="scheduleTableblue">
-          {typeof scoresMatch?.scores.alliances[1][key.key] === "boolean"
-            ? scoreAchieved(scoresMatch?.scores.alliances[0][key.key])
-            : scoresMatch?.scores.alliances[0][key.key]}
+          {typeof blueVal === "boolean"
+            ? scoreAchieved(blueVal)
+            : blueVal}
         </td>
       </tr>
     );
   };
 
   const expandScoresRow = (key) => {
-    const redRow = scoresMatch?.scores.alliances[1][key.key];
-    const blueRow = scoresMatch?.scores.alliances[0][key.key];
+    const redAlliance = scoresMatch?.scores?.alliances?.[1];
+    const blueAlliance = scoresMatch?.scores?.alliances?.[0];
+    const redRow = redAlliance?.[key.key];
+    const blueRow = blueAlliance?.[key.key];
+    const safeRedRow = redRow != null && typeof redRow === "object" && !Array.isArray(redRow) ? redRow : {};
+    const safeBlueRow = blueRow != null && typeof blueRow === "object" && !Array.isArray(blueRow) ? blueRow : {};
     return (
       <>
         <tr>
@@ -805,9 +815,11 @@ function SchedulePage({
           <td className="scheduleTableblue"></td>
         </tr>
 
-        {Object.keys(redRow).map((itemKey, itemIndex) => {
-          if (typeof redRow[itemKey] === "object") {
-            const redRowKeys = Object.keys(redRow[itemKey]);
+        {Object.keys(safeRedRow).map((itemKey, itemIndex) => {
+          const redItem = safeRedRow[itemKey];
+          const blueItem = safeBlueRow[itemKey];
+          if (redItem != null && typeof redItem === "object" && !Array.isArray(redItem)) {
+            const redRowKeys = Object.keys(redItem);
             return (
               <React.Fragment key={`redrow-${itemKey}-${itemIndex}`}>
                 <tr>
@@ -834,10 +846,11 @@ function SchedulePage({
                         </tr>
                         <tr>
                           {redRowKeys.map((score, scoreIndex) => {
+                            const redVal = redItem[score];
                             const writingMode =
-                              typeof redRow[itemKey][score] === "string"
+                              typeof redVal === "string"
                                 ? "vertical-rl"
-                                : Array.isArray(redRow[itemKey][score])
+                                : Array.isArray(redVal)
                                 ? "vertical-rl"
                                 : "horizontal-tb";
                             return (
@@ -848,11 +861,11 @@ function SchedulePage({
                                   padding: "5px 0px 0px 5px",
                                 }}
                               >
-                                {typeof redRow[itemKey][score] === "string"
-                                  ? redRow[itemKey][score]
-                                  : Array.isArray(redRow[itemKey][score])
-                                  ? redRow[itemKey][score].join(",")
-                                  : scoreAchieved(redRow[itemKey][score])}
+                                {typeof redVal === "string"
+                                  ? redVal
+                                  : Array.isArray(redVal)
+                                  ? redVal.join(",")
+                                  : scoreAchieved(redVal)}
                               </td>
                             );
                           })}
@@ -880,10 +893,11 @@ function SchedulePage({
                         </tr>
                         <tr>
                           {redRowKeys.map((score, scoreIndex) => {
+                            const blueVal = (blueItem != null && typeof blueItem === "object") ? blueItem[score] : undefined;
                             const writingMode =
-                              typeof redRow[itemKey][score] === "string"
+                              typeof blueVal === "string"
                                 ? "vertical-rl"
-                                : Array.isArray(redRow[itemKey][score])
+                                : Array.isArray(blueVal)
                                 ? "vertical-rl"
                                 : "horizontal-tb";
                             return (
@@ -894,11 +908,11 @@ function SchedulePage({
                                   padding: "5px 0px 0px 5px",
                                 }}
                               >
-                                {typeof blueRow[itemKey][score] === "string"
-                                  ? blueRow[itemKey][score]
-                                  : Array.isArray(blueRow[itemKey][score])
-                                  ? blueRow[itemKey][score].join(",")
-                                  : scoreAchieved(blueRow[itemKey][score])}
+                                {typeof blueVal === "string"
+                                  ? blueVal
+                                  : Array.isArray(blueVal)
+                                  ? blueVal.join(",")
+                                  : scoreAchieved(blueVal)}
                               </td>
                             );
                           })}
@@ -915,8 +929,8 @@ function SchedulePage({
                 <td>
                   <b>     {itemKey}</b>
                 </td>
-                <td className="scheduleTablered">{redRow[itemKey]}</td>
-                <td className="scheduleTableblue">{blueRow[itemKey]}</td>
+                <td className="scheduleTablered">{redItem}</td>
+                <td className="scheduleTableblue">{safeBlueRow[itemKey]}</td>
               </tr>
             );
           }
@@ -1784,7 +1798,7 @@ function SchedulePage({
                   <Col>Round 2</Col>
                   <Col>Round 3</Col>
                 </Row>
-                {formData?.alliances.map((alliance, allianceIndex) => {
+                {(Array.isArray(formData?.alliances) ? formData.alliances : []).map((alliance, allianceIndex) => {
                   return (
                     <Row key={`alliance-${alliance.number}-${allianceIndex}`}>
                       <Col>{alliance.number}</Col>
@@ -1906,25 +1920,25 @@ function SchedulePage({
                 <tr>
                   <td>Winner:</td>
                   <td colSpan={2}>
-                    {scoresMatch?.winner.winner === "red" ? (
+                    {scoresMatch?.winner?.winner === "red" ? (
                       <span style={{ color: "red" }}>
                         <b>Red Alliance</b>
                       </span>
-                    ) : scoresMatch?.winner.winner === "blue" ? (
+                    ) : scoresMatch?.winner?.winner === "blue" ? (
                       <span style={{ color: "blue" }}>
                         <b>Blue Alliance</b>
                       </span>
-                    ) : scoresMatch?.winner.tieWinner === "red" ? (
+                    ) : scoresMatch?.winner?.tieWinner === "red" ? (
                       <span style={{ color: "red" }}>
-                        <b>{scoresMatch?.winner.tieDetail}</b>
+                        <b>{scoresMatch?.winner?.tieDetail}</b>
                       </span>
-                    ) : scoresMatch?.winner.tieWinner === "blue" ? (
+                    ) : scoresMatch?.winner?.tieWinner === "blue" ? (
                       <span style={{ color: "blue" }}>
-                        <b>{scoresMatch?.winner.tieDetail}</b>
+                        <b>{scoresMatch?.winner?.tieDetail}</b>
                       </span>
-                    ) : scoresMatch?.winner.tieWinner === "tie" ? (
+                    ) : scoresMatch?.winner?.tieWinner === "tie" ? (
                       <span style={{ color: "green" }}>
-                        <b>{scoresMatch?.winner.tieDetail}</b>
+                        <b>{scoresMatch?.winner?.tieDetail}</b>
                       </span>
                     ) : (
                       <span style={{ color: "green" }}>
@@ -1939,7 +1953,7 @@ function SchedulePage({
                     <Handshake
                       result={
                         scoresMatch?.scores?.coopertitionBonusAchieved ||
-                        scoresMatch?.scores.alliances[0]
+                        scoresMatch?.scores?.alliances?.[0]
                           ?.coopertitionCriteriaMet
                       }
                     />
@@ -1956,14 +1970,14 @@ function SchedulePage({
                     <b>Blue Alliance Results</b>
                   </td>
                 </tr>
-                {scoresMatch?.scores.alliances[0] ? (
+                {(scoresMatch?.scores?.alliances?.[0] != null && typeof scoresMatch.scores.alliances[0] === "object") ? (
                   _.orderBy(
-                    addScoreType(scoresMatch?.scores.alliances[0]),
+                    addScoreType(scoresMatch.scores.alliances[0]),
                     ["type", "key"],
                     ["asc", "asc"]
                   ).map((key) => {
                     if (
-                      typeof scoresMatch?.scores.alliances[0][key.key] ===
+                      typeof scoresMatch?.scores?.alliances?.[0]?.[key.key] ===
                       "object"
                     ) {
                       return expandScoresRow(key);

--- a/src/pages/StatsPage.jsx
+++ b/src/pages/StatsPage.jsx
@@ -10,10 +10,21 @@ function StatsPage({
   eventLabel,
   districts,
   selectedYear,
+  ftcMode,
+  ftcRegionHighScores,
 }) {
   const eventDistrict = _.filter(districts, {
     value: selectedEvent?.value?.districtCode,
   })[0];
+  const hasAnyStats =
+    worldStats ||
+    eventHighScores ||
+    ftcRegionHighScores;
+  const isFTC = !!ftcMode;
+  const ftcRegionLabel = selectedEvent?.value?.regionCode
+    ? `Region ${selectedEvent.value.regionCode}`
+    : "Region";
+
   return (
     <Container fluid>
       {!selectedEvent && (
@@ -23,7 +34,7 @@ function StatsPage({
           </Alert>
         </div>
       )}
-      {selectedEvent && !worldStats && !eventHighScores && (
+      {selectedEvent && !hasAnyStats && (
         <div>
           <Alert variant="warning">
             <Alert variant="warning">
@@ -35,10 +46,11 @@ function StatsPage({
           </Alert>
         </div>
       )}
-      {selectedEvent && (worldStats || eventHighScores) && (
+      {selectedEvent && hasAnyStats && (
         <Container fluid>
           <Row>
-            {worldStats && <Col xs={"12"} sm={selectedEvent?.value?.districtCode ? "4" : "6"}>
+            {/* World High Scores (FRC and FTC use same endpoint: {{apiBase}}/{{season}}/highscores) */}
+            {worldStats && <Col xs={"12"} sm={((selectedEvent?.value?.districtCode && !isFTC) || (isFTC && ftcRegionHighScores)) ? "4" : "6"}>
               <table className="table table-condensed gatool-highScores-Table gatool-worldHighScores">
                 <thead>
                   <tr>
@@ -119,7 +131,8 @@ function StatsPage({
                 </tbody>
               </table>
             </Col>}
-            {selectedEvent?.value?.districtCode && (
+            {/* FRC District High Scores */}
+            {selectedEvent?.value?.districtCode && !isFTC && (
               <Col xs={"12"} sm={"4"}>
                 <table className="table table-condensed gatool-highScores-Table gatool-districtHighScores">
                   <thead>
@@ -202,7 +215,52 @@ function StatsPage({
                 </table>
               </Col>
             )}
-            <Col xs={"12"} sm={selectedEvent?.value?.districtCode && worldStats ? "4" : worldStats ? "6" : "12"}>
+            {/* FTC Region High Scores */}
+            {ftcRegionHighScores && isFTC && (
+              <Col xs={"12"} sm={"4"}>
+                <table className="table table-condensed gatool-highScores-Table gatool-districtHighScores">
+                  <thead>
+                    <tr>
+                      <td className={"statsMatchHeader"} colSpan={2} style={{ backgroundColor: "#fff5ce" }}>
+                        {ftcRegionLabel} High Scores {ftcRegionHighScores?.year}
+                      </td>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td style={{ backgroundColor: "#fff5ce" }}>Qualification</td>
+                      <td style={{ backgroundColor: "#fff5ce" }}>Playoff</td>
+                    </tr>
+                    <tr>
+                      <StatsMatch highScores={ftcRegionHighScores?.highscores} matchType={"penaltyFreequal"} matchName={"No penalties in match"} eventNamesCY={eventNamesCY} tableType={"district"} />
+                      <StatsMatch highScores={ftcRegionHighScores?.highscores} matchType={"penaltyFreeplayoff"} matchName={"No penalties in match"} eventNamesCY={eventNamesCY} tableType={"district"} />
+                    </tr>
+                    <tr>
+                      <StatsMatch highScores={ftcRegionHighScores?.highscores} matchType={"TBAPenaltyFreequal"} matchName={"No penalties to winner"} eventNamesCY={eventNamesCY} tableType={"district"} />
+                      <StatsMatch highScores={ftcRegionHighScores?.highscores} matchType={"TBAPenaltyFreeplayoff"} matchName={"No penalties to winner"} eventNamesCY={eventNamesCY} tableType={"district"} />
+                    </tr>
+                    <tr>
+                      <StatsMatch highScores={ftcRegionHighScores?.highscores} matchType={"offsettingqual"} matchName={"Offsetting penalties"} eventNamesCY={eventNamesCY} tableType={"district"} />
+                      <StatsMatch highScores={ftcRegionHighScores?.highscores} matchType={"offsettingplayoff"} matchName={"Offsetting penalties"} eventNamesCY={eventNamesCY} tableType={"district"} />
+                    </tr>
+                    <tr>
+                      <StatsMatch highScores={ftcRegionHighScores?.highscores} matchType={"overallqual"} matchName={"Incl. penalties"} eventNamesCY={eventNamesCY} tableType={"district"} />
+                      <StatsMatch highScores={ftcRegionHighScores?.highscores} matchType={"overallplayoff"} matchName={"Incl. penalties"} eventNamesCY={eventNamesCY} tableType={"district"} />
+                    </tr>
+                  </tbody>
+                </table>
+              </Col>
+            )}
+            <Col
+              xs={"12"}
+              sm={
+                (isFTC && (worldStats || ftcRegionHighScores)) || (!isFTC && selectedEvent?.value?.districtCode && worldStats)
+                  ? "4"
+                  : worldStats
+                  ? "6"
+                  : "12"
+              }
+            >
               <table className="table table-condensed gatool-highScores-Table gatool-eventHighScores">
                 <thead>
                   <tr>


### PR DESCRIPTION
Fixing a bug on the Schedule page that caused the app to crash when loading results from Week0
Added World and Region high scores for FTC
Restored placeholder text in the playoff brackets

Closes #656 
Closes #657 
Closes #659 