### PR TITLE
Winners still not propagating in Playoffs in FTC and new high score category

### DIFF
--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -1,5 +1,20 @@
 export const appUpdates = [
   {
+    date: "February 28, 2026",
+    message: (
+      <ul>
+        <li>ALL PROGRAMS:</li>
+        <ul>
+          <li>Introducing a new high score category: <b>score minus penalties,</b> which shows the Alliance's contribution to the finalscore.</li>
+        </ul>
+        <li>FTC:</li>
+        <ul>
+          <li>Updated Playoffs Brackets to properly display Alliances in future matches, based on results from previous matches</li>
+          <li>Restoring scores for finals matches in 6-Alliance Brackets</li>
+        </ul>
+      </ul>
+    ),
+  },{
     date: "February 26, 2026",
     message: (
       <ul>

--- a/src/components/HighScoresSummary.jsx
+++ b/src/components/HighScoresSummary.jsx
@@ -41,7 +41,7 @@ function HighScoresSummary({
 
   const sections = [];
 
-  // World: two results (penalty-free best, overall best)
+  // World: penalty-free best, overall best, alliance contribution
   if (worldStats?.highscores && year) {
     const penaltyFree = bestOfQualPlayoff(
       worldStats.highscores,
@@ -53,12 +53,18 @@ function HighScoresSummary({
       `${year}overallqual`,
       `${year}overallplayoff`
     );
-    if (penaltyFree || overall) {
+    const allianceContribution = bestOfQualPlayoff(
+      worldStats.highscores,
+      `${year}allianceContributionqual`,
+      `${year}allianceContributionplayoff`
+    );
+    if (penaltyFree || overall || allianceContribution) {
       sections.push({
         label: "World",
         bg: "#f2dede",
         penaltyFree,
         overall,
+        allianceContribution,
       });
     }
   }
@@ -75,12 +81,18 @@ function HighScoresSummary({
       "overallqual",
       "overallplayoff"
     );
-    if (penaltyFree || overall) {
+    const allianceContribution = bestOfQualPlayoff(
+      ftcRegionHighScores.highscores,
+      "allianceContributionqual",
+      "allianceContributionplayoff"
+    );
+    if (penaltyFree || overall || allianceContribution) {
       sections.push({
         label: regionCode ? `Region ${regionCode}` : "Region",
         bg: "#fff5ce",
         penaltyFree,
         overall,
+        allianceContribution,
       });
     }
   }
@@ -97,7 +109,12 @@ function HighScoresSummary({
       "overallqual",
       "overallplayoff"
     );
-    if (penaltyFree || overall) {
+    const allianceContribution = bestOfQualPlayoff(
+      ftcLeagueHighScores.highscores,
+      "allianceContributionqual",
+      "allianceContributionplayoff"
+    );
+    if (penaltyFree || overall || allianceContribution) {
       const leagueOption = _.find(ftcLeagues || [], { value: leagueCode });
       const leagueLabel = leagueOption?.label || `League ${leagueCode}`;
       sections.push({
@@ -105,6 +122,7 @@ function HighScoresSummary({
         bg: "#eff9ee",
         penaltyFree,
         overall,
+        allianceContribution,
       });
     }
   }
@@ -122,7 +140,12 @@ function HighScoresSummary({
       `${prefix}overallqual`,
       `${prefix}overallplayoff`
     );
-    if (penaltyFree || overall) {
+    const allianceContribution = bestOfQualPlayoff(
+      worldStats.highscores,
+      `${prefix}allianceContributionqual`,
+      `${prefix}allianceContributionplayoff`
+    );
+    if (penaltyFree || overall || allianceContribution) {
       const districtOption = _.filter(districts || [], {
         value: districtCode,
       })[0];
@@ -132,6 +155,7 @@ function HighScoresSummary({
         bg: "#fff5ce",
         penaltyFree,
         overall,
+        allianceContribution,
       });
     }
   }
@@ -170,16 +194,18 @@ function HighScoresSummary({
         {renderEntry(sec.penaltyFree)}
         <div className="text-muted small">Incl. penalties</div>
         {renderEntry(sec.overall)}
+        <div className="text-muted small">Score minus penalties</div>
+        {renderEntry(sec.allianceContribution)}
       </div>
     </Col>
   );
 
-  // FRC Regionals (World only): show as two columns (No penalties to winner | Incl. penalties)
+  // FRC Regionals (World only): show as three columns (No penalties to winner | Incl. penalties | Score minus penalties)
   if (isFRCRegionalOnly) {
     const sec = sections[0];
     return (
       <Row className="mb-2">
-        <Col xs={12} md={6}>
+        <Col xs={12} md={4}>
           <div
             className="border rounded p-2 h-100"
             style={{ fontSize: "0.9rem", backgroundColor: sec.bg }}
@@ -188,13 +214,22 @@ function HighScoresSummary({
             {renderEntry(sec.penaltyFree)}
           </div>
         </Col>
-        <Col xs={12} md={6}>
+        <Col xs={12} md={4}>
           <div
             className="border rounded p-2 h-100"
             style={{ fontSize: "0.9rem", backgroundColor: sec.bg }}
           >
             <div className="fw-bold mb-2">{sec.label} — Incl. penalties</div>
             {renderEntry(sec.overall)}
+          </div>
+        </Col>
+        <Col xs={12} md={4}>
+          <div
+            className="border rounded p-2 h-100"
+            style={{ fontSize: "0.9rem", backgroundColor: sec.bg }}
+          >
+            <div className="fw-bold mb-2">{sec.label} — Score minus penalties</div>
+            {renderEntry(sec.allianceContribution)}
           </div>
         </Col>
       </Row>

--- a/src/components/HighScoresSummary.jsx
+++ b/src/components/HighScoresSummary.jsx
@@ -183,6 +183,16 @@ function HighScoresSummary({
 
   const isFRCRegionalOnly = !isFTC && !districtCode && sections.length === 1;
   const colSize = sections.length > 0 ? Math.floor(12 / sections.length) : 12;
+  const borderColor = (bg) => {
+    if (bg === "#f2dede") return "rgba(169, 68, 66, 0.6)";
+    if (bg === "#fff5ce") return "rgba(193, 154, 65, 0.6)";
+    if (bg === "#eff9ee") return "rgba(76, 134, 73, 0.5)";
+    return "rgba(0, 0, 0, 0.15)";
+  };
+
+  const scoreBlockStyle = (sec, isFirst) =>
+    isFirst ? {} : { borderTop: "2px solid " + borderColor(sec.bg), paddingTop: "0.5rem", marginTop: "0.5rem" };
+
   const renderColumn = (sec) => (
     <Col key={sec.label} xs={12} md={colSize}>
       <div
@@ -190,12 +200,18 @@ function HighScoresSummary({
         style={{ fontSize: "0.9rem", backgroundColor: sec.bg }}
       >
         <div className="fw-bold mb-2">{sec.label}</div>
-        <div className="text-muted small">No penalties to winner</div>
-        {renderEntry(sec.penaltyFree)}
-        <div className="text-muted small">Incl. penalties</div>
-        {renderEntry(sec.overall)}
-        <div className="text-muted small">Score minus penalties</div>
-        {renderEntry(sec.allianceContribution)}
+        <div style={scoreBlockStyle(sec, true)}>
+          <div className="text-muted small">No penalties to winner</div>
+          {renderEntry(sec.penaltyFree)}
+        </div>
+        <div style={scoreBlockStyle(sec, false)}>
+          <div className="text-muted small">Incl. penalties</div>
+          {renderEntry(sec.overall)}
+        </div>
+        <div style={scoreBlockStyle(sec, false)}>
+          <div className="text-muted small">Score minus penalties</div>
+          {renderEntry(sec.allianceContribution)}
+        </div>
       </div>
     </Col>
   );

--- a/src/pages/StatsPage.jsx
+++ b/src/pages/StatsPage.jsx
@@ -139,6 +139,22 @@ function StatsPage({
                       tableType={"world"}
                     />
                   </tr>
+                  <tr>
+                    <StatsMatch
+                      highScores={worldStats?.highscores}
+                      matchType={`${selectedYear.value}allianceContributionqual`}
+                      matchName={"Score minus penalties"}
+                      eventNamesCY={eventNamesCY}
+                      tableType={"world"}
+                    />
+                    <StatsMatch
+                      highScores={worldStats?.highscores}
+                      matchType={`${selectedYear.value}allianceContributionplayoff`}
+                      matchName={"Score minus penalties"}
+                      eventNamesCY={eventNamesCY}
+                      tableType={"world"}
+                    />
+                  </tr>
                 </tbody>
               </table>
             </Col>}
@@ -222,6 +238,22 @@ function StatsPage({
                         tableType={"district"}
                       />
                     </tr>
+                    <tr>
+                      <StatsMatch
+                        highScores={worldStats?.highscores}
+                        matchType={`${selectedYear.value}District${selectedEvent?.value?.districtCode}allianceContributionqual`}
+                        matchName={"Score minus penalties"}
+                        eventNamesCY={eventNamesCY}
+                        tableType={"district"}
+                      />
+                      <StatsMatch
+                        highScores={worldStats?.highscores}
+                        matchType={`${selectedYear.value}District${selectedEvent?.value?.districtCode}allianceContributionplayoff`}
+                        matchName={"Score minus penalties"}
+                        eventNamesCY={eventNamesCY}
+                        tableType={"district"}
+                      />
+                    </tr>
                   </tbody>
                 </table>
               </Col>
@@ -277,6 +309,10 @@ function StatsPage({
                     <tr>
                       <StatsMatch highScores={ftcRegionOrLeagueScores?.highscores} matchType={"overallqual"} matchName={"Incl. penalties"} eventNamesCY={eventNamesCY} tableType={"district"} backgroundColorOverride={ftcRegionOrLeagueHeaderBg} />
                       <StatsMatch highScores={ftcRegionOrLeagueScores?.highscores} matchType={"overallplayoff"} matchName={"Incl. penalties"} eventNamesCY={eventNamesCY} tableType={"district"} backgroundColorOverride={ftcRegionOrLeagueHeaderBg} />
+                    </tr>
+                    <tr>
+                      <StatsMatch highScores={ftcRegionOrLeagueScores?.highscores} matchType={"allianceContributionqual"} matchName={"Score minus penalties"} eventNamesCY={eventNamesCY} tableType={"district"} backgroundColorOverride={ftcRegionOrLeagueHeaderBg} />
+                      <StatsMatch highScores={ftcRegionOrLeagueScores?.highscores} matchType={"allianceContributionplayoff"} matchName={"Score minus penalties"} eventNamesCY={eventNamesCY} tableType={"district"} backgroundColorOverride={ftcRegionOrLeagueHeaderBg} />
                     </tr>
                   </tbody>
                 </table>
@@ -365,6 +401,22 @@ function StatsPage({
                       highScores={eventHighScores?.highscores}
                       matchType={"overallplayoff"}
                       matchName={"Incl. penalties"}
+                      eventNamesCY={eventNamesCY}
+                      tableType={"event"}
+                    />
+                  </tr>
+                  <tr>
+                    <StatsMatch
+                      highScores={eventHighScores?.highscores}
+                      matchType={"allianceContributionqual"}
+                      matchName={"Score minus penalties"}
+                      eventNamesCY={eventNamesCY}
+                      tableType={"event"}
+                    />
+                    <StatsMatch
+                      highScores={eventHighScores?.highscores}
+                      matchType={"allianceContributionplayoff"}
+                      matchName={"Score minus penalties"}
                       eventNamesCY={eventNamesCY}
                       tableType={"event"}
                     />


### PR DESCRIPTION
This fixes an issue that prevented new partially populated matches from being created. Adds a new high score category: score minus penalties. This highlights the highest score that an Alliance made on its own, rather than including the points they earned from penalties. This takes into account the differences between how FRC and FTC report penalties.