### PR TITLE
Background data refresh switch

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -431,6 +431,14 @@ function App() {
     "setting:screenModeSyncFrequency",
     10
   ); // Frequency in seconds (5-10)
+  const [backgroundDataRefresh, setBackgroundDataRefresh] = usePersistentState(
+    "setting:backgroundDataRefresh",
+    false
+  );
+  const [backgroundDataRefreshFrequency, setBackgroundDataRefreshFrequency] = usePersistentState(
+    "setting:backgroundDataRefreshFrequency",
+    15
+  ); // Frequency in seconds (5-60)
   const [screenModeStatus, setScreenModeStatus] = useState(null); // null = unknown, true = valid data, false = invalid/malformed
 
   // Enforce mutual exclusivity between syncEvent and screenMode
@@ -1147,13 +1155,15 @@ function App() {
    * @async
    * @function getSchedule
    * @param loadingEvent Boolean to set the current match to the last match played when loading an event
+   * @param {object} [options] Options for the schedule fetch.
+   * @param {boolean} [options.updateCurrentMatch=true] If false, schedule/rankings are refreshed but current match is not updated (for background refresh).
    * @param selectedEvent The currently selected event, which is a persistent state variable
    * @param selectedYear The currently selected year, which is a persistent state variable
    *
    * @return Sets the event high scores, qual schedule and playoff
    */
   // @ts-ignore
-  async function getSchedule(loadingEvent) {
+  async function getSchedule(loadingEvent, options = {}) {
     console.log(`Fetching schedule for ${selectedEvent?.value?.name}...`);
 
     /**
@@ -1921,7 +1931,7 @@ function App() {
     if (playoffschedule?.completedMatchCount > 0) {
       lastMatchPlayed += playoffschedule?.completedMatchCount;
     }
-    if ((loadingEvent && autoAdvance) || autoUpdate) {
+    if (options.updateCurrentMatch !== false && ((loadingEvent && autoAdvance) || autoUpdate)) {
       if (
         lastMatchPlayed === qualschedule?.schedule.length + 1 ||
         lastMatchPlayed ===
@@ -5891,19 +5901,22 @@ function App() {
 
 
   // Timer to autmatically refresh event data
-  // This will run every refreshRate seconds, which is set in the settings.
-  // It will fetch the schedule, world stats, event stats, system messages and event messages
-  // It will also check if the event is online or offline, and fetch the schedule accordingly
+  // Runs at refreshRate (autoUpdate) or backgroundDataRefreshFrequency (background only); when both are on, uses the faster rate.
+  const effectiveRefreshSeconds = (autoUpdate && backgroundDataRefresh)
+    ? Math.min(refreshRate, backgroundDataRefreshFrequency)
+    : (autoUpdate ? refreshRate : backgroundDataRefreshFrequency);
+  const intervalDelayMs = (autoUpdate || backgroundDataRefresh) ? effectiveRefreshSeconds * 1000 : 999999;
 
   const { start, stop } = useInterval(
     () => {
       console.log("fetching event data now");
+      const updateCurrentMatch = !backgroundDataRefresh;
       if (!selectedEvent?.value?.code.includes("OFFLINE")) {
         console.log("Online event. Getting schedule and ranks");
         if (!ftcMode && useCheesyArena) {
           getCheesyStatus();
         }
-        getSchedule();
+        getSchedule(undefined, { updateCurrentMatch });
       } else {
         console.log("Offline event. Just get the world stats if you can");
       }
@@ -5919,7 +5932,7 @@ function App() {
         }
       }
     },
-    refreshRate * 1000,
+    intervalDelayMs,
     {
       autoStart: true,
       immediate: false,
@@ -5930,14 +5943,14 @@ function App() {
     }
   );
 
-  // Automatically keep event details up to date. Checks every 15 seconds if active.
+  // Automatically keep event details up to date when autoUpdate or backgroundDataRefresh is on.
   useEffect(() => {
-    if (autoUpdate) {
+    if (autoUpdate || backgroundDataRefresh) {
       start();
     } else {
       stop();
     }
-  }, [autoUpdate, start, stop]);
+  }, [autoUpdate, backgroundDataRefresh, backgroundDataRefreshFrequency, start, stop]);
 
   // Track last event code we attempted to sync in Screen Mode
   // This prevents reloading the same event when React state hasn't updated yet
@@ -6690,6 +6703,10 @@ function App() {
                     setScreenMode={setScreenMode}
                     screenModeSyncFrequency={screenModeSyncFrequency}
                     setScreenModeSyncFrequency={setScreenModeSyncFrequency}
+                    backgroundDataRefresh={backgroundDataRefresh}
+                    setBackgroundDataRefresh={setBackgroundDataRefresh}
+                    backgroundDataRefreshFrequency={backgroundDataRefreshFrequency}
+                    setBackgroundDataRefreshFrequency={setBackgroundDataRefreshFrequency}
                     eventLabel={eventLabel}
                     setEventLabel={setEventLabel}
                     showInspection={showInspection}

--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -1,5 +1,15 @@
 export const appUpdates = [
   {
+    date: "March 10, 2026",
+    message: (
+      <ul>
+        <li>ALL PROGRAMS:</li>
+        <ul>
+          <li>Added support for background data refresh. When enabled, schedule, scores and rankings are updated periodically without changing the current match or your view.</li>
+        </ul>
+      </ul>
+    ),
+  },{
     date: "March 8, 2026",
     message: (
       <ul>

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -76,7 +76,7 @@ const ftcModeOptions = [
 
 
 
-function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedYear, eventList, teamList, qualSchedule, playoffSchedule, rankings, eventFilters, setEventFilters, regionFilters, setRegionFilters, districts, timeFilter, setTimeFilter, timeFormat, setTimeFormat, showSponsors, setShowSponsors, showAwards, setShowAwards, showNotes, setShowNotes, showNotesAnnounce, setShowNotesAnnounce, showMottoes, setShowMottoes, showChampsStats, setShowChampsStats, swapScreen, setSwapScreen, autoAdvance, setAutoAdvance, autoUpdate, setAutoUpdate, getSchedule, awardsMenu, setAwardsMenu, showQualsStats, setShowQualsStats, showQualsStatsQuals, setShowQualsStatsQuals, teamReduction, setTeamReduction, playoffCountOverride, setPlayoffCountOverride, allianceCount, localUpdates, setLocalUpdates, putTeamData, getCommunityUpdates, reverseEmcee, setReverseEmcee, showDistrictChampsStats, setShowDistrictChampsStats, monthsWarning, setMonthsWarning, user, isAuthenticated, adHocMode, setAdHocMode, supportedYears, FTCSupportedYears, reloadPage, autoHideSponsors, setAutoHideSponsors, setLoadingCommunityUpdates, hidePracticeSchedule, setHidePracticeSchedule, systemMessage, setTeamListLoading, getTeamList, getAlliances, setHaveChampsTeams, appUpdates, usePullDownToUpdate, setUsePullDownToUpdate, useSwipe, setUseSwipe, eventLabel, setEventLabel, showInspection, setShowInspection, showWorldAndStatsOnAnnouncePlayByPlay, setShowWorldAndStatsOnAnnouncePlayByPlay, showMinorAwards, setShowMinorAwards, highScoreMode, setHighScoreMode, systemBell, setSystemBell, eventBell, setEventBell, eventMessage, setEventMessage, putEventNotifications, useCheesyArena, setUseCheesyArena, useFourTeamAlliances, setUseFourTeamAlliances, ftcLeagues, ftcRegions, ftcMode, setFTCMode, ftcTypes, useFTCOffline, setUseFTCOffline, FTCServerURL, setFTCServerURL, FTCKey, requestFTCKey, checkFTCKey, FTCOfflineAvailable, getFTCOfflineStatus, getCheesyStatus, showBlueBanners, setShowBlueBanners, manualOfflineMode, setManualOfflineMode, useScrollMemory, setUseScrollMemory, syncEvent, setSyncEvent, screenMode, setScreenMode, screenModeSyncFrequency, setScreenModeSyncFrequency }) {
+function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedYear, eventList, teamList, qualSchedule, playoffSchedule, rankings, eventFilters, setEventFilters, regionFilters, setRegionFilters, districts, timeFilter, setTimeFilter, timeFormat, setTimeFormat, showSponsors, setShowSponsors, showAwards, setShowAwards, showNotes, setShowNotes, showNotesAnnounce, setShowNotesAnnounce, showMottoes, setShowMottoes, showChampsStats, setShowChampsStats, swapScreen, setSwapScreen, autoAdvance, setAutoAdvance, autoUpdate, setAutoUpdate, getSchedule, awardsMenu, setAwardsMenu, showQualsStats, setShowQualsStats, showQualsStatsQuals, setShowQualsStatsQuals, teamReduction, setTeamReduction, playoffCountOverride, setPlayoffCountOverride, allianceCount, localUpdates, setLocalUpdates, putTeamData, getCommunityUpdates, reverseEmcee, setReverseEmcee, showDistrictChampsStats, setShowDistrictChampsStats, monthsWarning, setMonthsWarning, user, isAuthenticated, adHocMode, setAdHocMode, supportedYears, FTCSupportedYears, reloadPage, autoHideSponsors, setAutoHideSponsors, setLoadingCommunityUpdates, hidePracticeSchedule, setHidePracticeSchedule, systemMessage, setTeamListLoading, getTeamList, getAlliances, setHaveChampsTeams, appUpdates, usePullDownToUpdate, setUsePullDownToUpdate, useSwipe, setUseSwipe, eventLabel, setEventLabel, showInspection, setShowInspection, showWorldAndStatsOnAnnouncePlayByPlay, setShowWorldAndStatsOnAnnouncePlayByPlay, showMinorAwards, setShowMinorAwards, highScoreMode, setHighScoreMode, systemBell, setSystemBell, eventBell, setEventBell, eventMessage, setEventMessage, putEventNotifications, useCheesyArena, setUseCheesyArena, useFourTeamAlliances, setUseFourTeamAlliances, ftcLeagues, ftcRegions, ftcMode, setFTCMode, ftcTypes, useFTCOffline, setUseFTCOffline, FTCServerURL, setFTCServerURL, FTCKey, requestFTCKey, checkFTCKey, FTCOfflineAvailable, getFTCOfflineStatus, getCheesyStatus, showBlueBanners, setShowBlueBanners, manualOfflineMode, setManualOfflineMode, useScrollMemory, setUseScrollMemory, syncEvent, setSyncEvent, screenMode, setScreenMode, screenModeSyncFrequency, setScreenModeSyncFrequency, backgroundDataRefresh, setBackgroundDataRefresh, backgroundDataRefreshFrequency, setBackgroundDataRefreshFrequency }) {
     const isOnline = useOnlineStatus();
     const PWASupported = (isChrome && Number(browserVersion) >= 76) || (isSafari && Number(browserVersion) >= 15 && Number(fullBrowserVersion.split(".")[1]) >= 4);
 
@@ -615,6 +615,85 @@ function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedY
                                             <b>Automatically track event progress, refreshing every 15 seconds <i style={{ "color": "red" }}>(will advance matches on all screens)</i></b>
                                         </td>
                                     </tr>
+                                    <tr className={"UISettings"}>
+                                        <td>
+                                            <Switch checked={backgroundDataRefresh === null ? false : backgroundDataRefresh} onChange={setBackgroundDataRefresh} />
+                                        </td>
+                                        <td>
+                                            <b>Refresh schedule, scores and rankings in background</b><br />
+                                            <i>When enabled, schedule, scores and rankings are updated periodically without changing the current match or your view. Use this to get ranking updates during matches while staying on the same match.</i>
+                                        </td>
+                                    </tr>
+                                    {backgroundDataRefresh && (
+                                        <tr className={"UISettings"}>
+                                            <td>
+                                            </td>
+                                            <td>
+                                                <b>Background refresh frequency</b><br />
+                                                <div style={{ padding: "5px 10px", display: "flex", alignItems: "center", gap: "10px" }}>
+                                                    <span style={{ fontSize: "28px" }}>🐇&nbsp;</span>
+                                                    <Range
+                                                        values={[backgroundDataRefreshFrequency || 15]}
+                                                        step={1}
+                                                        min={5}
+                                                        max={60}
+                                                        onChange={(values) => setBackgroundDataRefreshFrequency(values[0])}
+                                                        renderTrack={({ props, children }) => (
+                                                            <div
+                                                                {...props}
+                                                                style={{
+                                                                    ...props.style,
+                                                                    height: '6px',
+                                                                    width: '100%',
+                                                                    backgroundColor: '#ccc',
+                                                                    borderRadius: '3px'
+                                                                }}
+                                                            >
+                                                                {children}
+                                                            </div>
+                                                        )}
+                                                        renderThumb={({ props, isDragged }) => (
+                                                            <div
+                                                                {...props}
+                                                                style={{
+                                                                    ...props.style,
+                                                                    height: '24px',
+                                                                    width: '24px',
+                                                                    backgroundColor: '#007bff',
+                                                                    borderRadius: '50%',
+                                                                    display: 'flex',
+                                                                    alignItems: 'center',
+                                                                    justifyContent: 'center',
+                                                                    boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
+                                                                    outline: 'none'
+                                                                }}
+                                                            >
+                                                                {isDragged && (
+                                                                    <div
+                                                                        style={{
+                                                                            position: 'absolute',
+                                                                            top: '-28px',
+                                                                            color: '#007bff',
+                                                                            fontWeight: 'bold',
+                                                                            fontSize: '12px',
+                                                                            backgroundColor: 'white',
+                                                                            padding: '2px 6px',
+                                                                            borderRadius: '4px',
+                                                                            whiteSpace: 'nowrap',
+                                                                            boxShadow: '0 1px 3px rgba(0,0,0,0.2)'
+                                                                        }}
+                                                                    >
+                                                                        {backgroundDataRefreshFrequency || 15}s
+                                                                    </div>
+                                                                )}
+                                                            </div>
+                                                        )}
+                                                    />
+                                                    <span style={{ fontSize: "28px" }}>🐢</span>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    )}
                                     <tr className={"UISettings"}>
                                         <td>
                                             <Switch checked={(_.isNull(hidePracticeSchedule) || _.isUndefined(hidePracticeSchedule)) ? false : hidePracticeSchedule} onChange={setHidePracticeSchedule} />


### PR DESCRIPTION
Adds a switch to the Setup page to enable users to activate periodic match result, schedule and ranking updates. This can be very helpful in Playoffs.

Closes #675