### PR TITLE
Reserve Team flow improvements

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -861,6 +861,53 @@ td {
   text-align: center;
 }
 
+.alliance-backup-modal-dialog {
+  max-width: min(960px, 96vw);
+}
+
+.alliance-backup-modal-body.backupDialog {
+  font-size: 22px;
+}
+
+.alliance-backup-modal-columns {
+  text-align: center;
+}
+
+.alliance-backup-modal-team-btn {
+  box-sizing: border-box;
+  padding: 12px 10px;
+  min-height: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.alliance-backup-modal-reserve-btn {
+  font-size: clamp(0.95rem, 2.8vw, 1.35rem);
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: normal;
+  -webkit-hyphens: auto;
+  hyphens: auto;
+}
+
+/* On-field teams in reserve modal: same look as before but not clickable */
+.alliance-backup-modal-field-display {
+  cursor: default;
+  pointer-events: none;
+}
+
+/* Add / Remove alliance actions: match RedReplace / BlueReplace tiles (not Bootstrap primary/danger) */
+button.alliance-backup-modal-alliance-action-btn {
+  cursor: pointer;
+  border: none;
+}
+
+button.alliance-backup-modal-alliance-action-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
 .navBarText {
   font-size: 12px;
   white-space: nowrap;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -275,9 +275,6 @@ function App() {
   }
   /** Drop stale getAlliances responses so an older fetch cannot overwrite newer alliance + overlay edits. */
   const getAlliancesEpochRef = useRef(0);
-  /** Per-alliance `round3` from the last raw API response (before local playoff edits merge). */
-  const [playoffAllianceRound3FromApi, setPlayoffAllianceRound3FromApi] =
-    useState({});
   const [teamRemappings, setTeamRemappings] = usePersistentState("cache:teamRemappings", null);
   const [communityUpdates, setCommunityUpdates] = usePersistentState(
     "cache:communityUpdates",
@@ -4629,39 +4626,18 @@ function App() {
       alliances.alliances = alliances.Alliances;
       delete alliances.Alliances;
     }
+    /** Reserve merge + prune must commit with setAlliances (same epoch) so stale fetches do not mutate edits without updating alliances. */
+    /** @type {{ code: string; pruneKeys: string[] } | null} */
+    let reserveEditsPruneForCommit = null;
     if (!allianceTemp && selectedEvent?.value?.code) {
       const code = selectedEvent.value.code;
-      const apiRound3Snapshot = {};
-      if (alliances?.alliances?.length) {
-        for (const a of alliances.alliances) {
-          if (a?.number === undefined || a?.number === null) continue;
-          const r3 = a.round3;
-          apiRound3Snapshot[String(a.number)] =
-            r3 !== undefined && r3 !== null && r3 !== "" ? r3 : null;
-        }
-      }
-      setPlayoffAllianceRound3FromApi(apiRound3Snapshot);
       const pruneKeys = applyPlayoffReserveEdits(
         alliances,
         code,
         playoffReserveEditsRef.current
       );
       if (pruneKeys.length > 0) {
-        setPlayoffReserveEdits((prev) => {
-          const forEv = compactReserveEditsForEvent({ ...(prev[code] || {}) });
-          for (const k of pruneKeys) {
-            delete forEv[k];
-          }
-          let next;
-          if (Object.keys(forEv).length === 0) {
-            const { [code]: _removed, ...rest } = prev;
-            next = rest;
-          } else {
-            next = { ...prev, [code]: forEv };
-          }
-          playoffReserveEditsRef.current = next;
-          return next;
-        });
+        reserveEditsPruneForCommit = { code, pruneKeys };
       }
     }
     var allianceLookup = {};
@@ -4736,6 +4712,24 @@ function App() {
     console.log(`${alliances?.alliances?.length} Alliances loaded.`);
     if (getAlliancesEpoch !== getAlliancesEpochRef.current) {
       return;
+    }
+    if (reserveEditsPruneForCommit) {
+      const { code, pruneKeys } = reserveEditsPruneForCommit;
+      setPlayoffReserveEdits((prev) => {
+        const forEv = compactReserveEditsForEvent({ ...(prev[code] || {}) });
+        for (const k of pruneKeys) {
+          delete forEv[k];
+        }
+        let next;
+        if (Object.keys(forEv).length === 0) {
+          const { [code]: _removed, ...rest } = prev;
+          next = rest;
+        } else {
+          next = { ...prev, [code]: forEv };
+        }
+        playoffReserveEditsRef.current = next;
+        return next;
+      });
     }
     setAlliances(alliances);
     if (alliances?.alliances?.length > 0) {
@@ -7181,7 +7175,7 @@ function App() {
                     }
                     upsertPlayoffReserveOverlay={upsertPlayoffReserveOverlay}
                     removePlayoffReserveOverlay={removePlayoffReserveOverlay}
-                    playoffAllianceRound3FromApi={playoffAllianceRound3FromApi}
+                    playoffReserveEdits={playoffReserveEdits}
                   />
                 }
               />
@@ -7249,7 +7243,7 @@ function App() {
                     useScrollMemory={useScrollMemory}
                     upsertPlayoffReserveOverlay={upsertPlayoffReserveOverlay}
                     removePlayoffReserveOverlay={removePlayoffReserveOverlay}
-                    playoffAllianceRound3FromApi={playoffAllianceRound3FromApi}
+                    playoffReserveEdits={playoffReserveEdits}
                   />
                 }
               />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,12 @@ import StatsPage from "./pages/StatsPage";
 import CheatsheetPage from "./pages/CheatsheetPage";
 import EmceePage from "./pages/EmceePage";
 import { useEffect, useState, useRef, useMemo } from "react";
+import {
+  applyPlayoffReserveEdits,
+  compactReserveEditsForEvent,
+  prunePlayoffReserveSetsAfterPostedMatches,
+} from "./utils/playoffReserveEdits";
+import { roundThreeOrReserveRoleLabel } from "./utils/allianceRoleLabels";
 import { UseAuthClient } from "./contextProviders/AuthClientContext";
 import { useAuth0 } from "@auth0/auth0-react";
 import { Blocks } from "react-loader-spinner";
@@ -253,6 +259,25 @@ function App() {
     null
   );
   const [alliances, setAlliances] = usePersistentState("cache:alliances", null);
+  /**
+   * Playoff reserve edits keyed only by event code then alliance **number** (string):
+   * { op: 'set', round3 } | legacy { op: 'set', backup, backupReplaced } | { op: 'clear' }.
+   */
+  const [playoffReserveEdits, setPlayoffReserveEdits] = usePersistentState(
+    "cache:playoffReserveEditsByAlliance",
+    {}
+  );
+  const playoffReserveEditsRef = useRef(playoffReserveEdits || {});
+  if (playoffReserveEdits && typeof playoffReserveEdits === "object") {
+    playoffReserveEditsRef.current = playoffReserveEdits;
+  } else {
+    playoffReserveEditsRef.current = {};
+  }
+  /** Drop stale getAlliances responses so an older fetch cannot overwrite newer alliance + overlay edits. */
+  const getAlliancesEpochRef = useRef(0);
+  /** Per-alliance `round3` from the last raw API response (before local playoff edits merge). */
+  const [playoffAllianceRound3FromApi, setPlayoffAllianceRound3FromApi] =
+    useState({});
   const [teamRemappings, setTeamRemappings] = usePersistentState("cache:teamRemappings", null);
   const [communityUpdates, setCommunityUpdates] = usePersistentState(
     "cache:communityUpdates",
@@ -414,6 +439,78 @@ function App() {
   ]);
   const [adHocMode, setAdHocMode] = useState(null);
   const [backupTeam, setBackupTeam] = useState(null);
+
+  function upsertPlayoffReserveOverlay({
+    allianceNumber,
+    round3,
+    pendingSourceMatch,
+  }) {
+    const code = selectedEvent?.value?.code;
+    if (
+      !code ||
+      allianceNumber === undefined ||
+      allianceNumber === null ||
+      allianceNumber === "" ||
+      round3 === undefined ||
+      round3 === null ||
+      round3 === ""
+    ) {
+      return;
+    }
+    const prev =
+      playoffReserveEditsRef.current &&
+      typeof playoffReserveEditsRef.current === "object"
+        ? playoffReserveEditsRef.current
+        : {};
+    const key = String(allianceNumber);
+    const forEv = compactReserveEditsForEvent({ ...(prev[code] || {}) });
+    const entry = { op: "set", round3 };
+    if (pendingSourceMatch && typeof pendingSourceMatch === "object") {
+      entry.pendingSourceMatch = {
+        tournamentLevel: pendingSourceMatch.tournamentLevel ?? null,
+        matchNumber:
+          pendingSourceMatch.matchNumber != null
+            ? Number(pendingSourceMatch.matchNumber)
+            : null,
+        originalMatchNumber:
+          pendingSourceMatch.originalMatchNumber != null
+            ? Number(pendingSourceMatch.originalMatchNumber)
+            : undefined,
+        series:
+          pendingSourceMatch.series != null
+            ? Number(pendingSourceMatch.series)
+            : undefined,
+      };
+    }
+    forEv[key] = entry;
+    const next = { ...prev, [code]: forEv };
+    playoffReserveEditsRef.current = next;
+    setPlayoffReserveEdits(next);
+  }
+
+  function removePlayoffReserveOverlay({ allianceNumber }) {
+    const code = selectedEvent?.value?.code;
+    if (
+      !code ||
+      allianceNumber === undefined ||
+      allianceNumber === null ||
+      allianceNumber === ""
+    ) {
+      return;
+    }
+    const prev =
+      playoffReserveEditsRef.current &&
+      typeof playoffReserveEditsRef.current === "object"
+        ? playoffReserveEditsRef.current
+        : {};
+    const key = String(allianceNumber);
+    const forEv = compactReserveEditsForEvent({ ...(prev[code] || {}) });
+    forEv[key] = { op: "clear" };
+    const next = { ...prev, [code]: forEv };
+    playoffReserveEditsRef.current = next;
+    setPlayoffReserveEdits(next);
+  }
+
   const [showReloaded, setShowReloaded] = usePersistentState(
     "cache:showReloaded",
     false
@@ -2028,6 +2125,25 @@ function App() {
     console.log(
       `There are ${playoffschedule?.schedule.length} playoff matches loaded.`
     );
+
+    const eventCodeForReservePrune = selectedEvent?.value?.code;
+    if (
+      eventCodeForReservePrune &&
+      Array.isArray(playoffschedule?.schedule) &&
+      playoffschedule.schedule.length > 0
+    ) {
+      const { nextRoot, prunedAllianceKeys } =
+        prunePlayoffReserveSetsAfterPostedMatches({
+          editsRoot: playoffReserveEditsRef.current,
+          eventCode: eventCodeForReservePrune,
+          playoffMatches: playoffschedule.schedule,
+          ftcMode: Boolean(ftcMode),
+        });
+      if (prunedAllianceKeys.length > 0) {
+        playoffReserveEditsRef.current = nextRoot;
+        setPlayoffReserveEdits(nextRoot);
+      }
+    }
 
     // For OFFLINE events, only update playoffSchedule if there's no uploaded schedule already
     if (!isOfflineEvent || !playoffSchedule || playoffSchedule?.schedule?.length === 0) {
@@ -4388,6 +4504,8 @@ function App() {
    */
   async function getAlliances(allianceTemp) {
     console.log("Getting Alliances");
+    getAlliancesEpochRef.current += 1;
+    const getAlliancesEpoch = getAlliancesEpochRef.current;
     var result = null;
     var alliances = allianceTemp || { Alliances: [] };
     if (
@@ -4511,6 +4629,41 @@ function App() {
       alliances.alliances = alliances.Alliances;
       delete alliances.Alliances;
     }
+    if (!allianceTemp && selectedEvent?.value?.code) {
+      const code = selectedEvent.value.code;
+      const apiRound3Snapshot = {};
+      if (alliances?.alliances?.length) {
+        for (const a of alliances.alliances) {
+          if (a?.number === undefined || a?.number === null) continue;
+          const r3 = a.round3;
+          apiRound3Snapshot[String(a.number)] =
+            r3 !== undefined && r3 !== null && r3 !== "" ? r3 : null;
+        }
+      }
+      setPlayoffAllianceRound3FromApi(apiRound3Snapshot);
+      const pruneKeys = applyPlayoffReserveEdits(
+        alliances,
+        code,
+        playoffReserveEditsRef.current
+      );
+      if (pruneKeys.length > 0) {
+        setPlayoffReserveEdits((prev) => {
+          const forEv = compactReserveEditsForEvent({ ...(prev[code] || {}) });
+          for (const k of pruneKeys) {
+            delete forEv[k];
+          }
+          let next;
+          if (Object.keys(forEv).length === 0) {
+            const { [code]: _removed, ...rest } = prev;
+            next = rest;
+          } else {
+            next = { ...prev, [code]: forEv };
+          }
+          playoffReserveEditsRef.current = next;
+          return next;
+        });
+      }
+    }
     var allianceLookup = {};
     if (alliances?.alliances) {
       alliances?.alliances.forEach((alliance) => {
@@ -4551,7 +4704,7 @@ function App() {
         }
         if (alliance.round3) {
           allianceLookup[`${alliance.round3}`] = {
-            role: `Round 3 Selection`,
+            role: roundThreeOrReserveRoleLabel(selectedEvent?.value),
             alliance: alliance.name,
             number: alliance.number,
             captain: alliance.captain,
@@ -4564,7 +4717,7 @@ function App() {
         }
         if (alliance.backup) {
           allianceLookup[`${alliance.backup}`] = {
-            role: `Backup for ${alliance.backupReplaced}`,
+            role: `Reserve team`,
             alliance: alliance.name,
             number: alliance.number,
             captain: alliance.captain,
@@ -4581,6 +4734,9 @@ function App() {
 
     alliances.lastUpdate = moment().format();
     console.log(`${alliances?.alliances?.length} Alliances loaded.`);
+    if (getAlliancesEpoch !== getAlliancesEpochRef.current) {
+      return;
+    }
     setAlliances(alliances);
     if (alliances?.alliances?.length > 0) {
       setPlayoffs(true);
@@ -4600,6 +4756,9 @@ function App() {
           // so we need to get the details now from this array of competing teams
           setHaveChampsTeams(true);
           await getTeamList(_.uniq(tempChampsTeamList));
+          if (getAlliancesEpoch !== getAlliancesEpochRef.current) {
+            return;
+          }
         }
       }
     }
@@ -7020,6 +7179,9 @@ function App() {
                     alliancePartnerConnectionsCache={
                       alliancePartnerConnectionsCache
                     }
+                    upsertPlayoffReserveOverlay={upsertPlayoffReserveOverlay}
+                    removePlayoffReserveOverlay={removePlayoffReserveOverlay}
+                    playoffAllianceRound3FromApi={playoffAllianceRound3FromApi}
                   />
                 }
               />
@@ -7085,6 +7247,9 @@ function App() {
                     remapNumberToString={remapNumberToString}
                     remapStringToNumber={remapStringToNumber}
                     useScrollMemory={useScrollMemory}
+                    upsertPlayoffReserveOverlay={upsertPlayoffReserveOverlay}
+                    removePlayoffReserveOverlay={removePlayoffReserveOverlay}
+                    playoffAllianceRound3FromApi={playoffAllianceRound3FromApi}
                   />
                 }
               />

--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -1,5 +1,16 @@
 export const appUpdates = [
   {
+    date: "March 23, 2026",
+    message: (
+      <ul>
+        <li>FRC:</li>
+        <ul>
+          <li>Refined the Reserve Team flow in Playoffs. Reserve teams can now be removed, and reserve teams will persist until a match completes.</li>
+          <li>Prior partnerships. In playoffs, we now display prior partnerships on Announce in the Playoffs.</li>
+        </ul>
+      </ul>
+    ),
+  },{
     date: "March 19, 2026",
     message: (
       <ul>
@@ -7,7 +18,7 @@ export const appUpdates = [
         <ul>
           <li>Added switch to enable Champs statistics visibility for District and Regional events</li>
           <li>Restored Blue Banner stats on team export spreadsheet</li>
-          <li>Fixed a bug that prevented District Champs stats from displaying in non-District Champs events when the option was enabled</li>
+          <li>Fixed a bug that prevented District Champs stats from displaying in Playoffs in non-District Champs events when the option was enabled</li>
         </ul>
       </ul>
     ),

--- a/src/components/TopButtons.jsx
+++ b/src/components/TopButtons.jsx
@@ -5,17 +5,167 @@ import Select from "react-select";
 import MatchClock from "../components/MatchClock";
 import _ from "lodash";
 import { useHotkeysContext } from "react-hotkeys-hook";
+import { roundThreeOrReserveRoleLabel } from "../utils/allianceRoleLabels";
+import { matchHasPostedResult } from "../utils/playoffReserveEdits";
 
-function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatchFromMenu, selectedEvent, matchDetails, timeFormat, alliances, setAlliances, rankings, inPlayoffs, backupTeam, setBackupTeam, teamList, adHocMatch, setAdHocMatch, adHocMode, swapScreen, playoffOnly, eventLabel, ftcMode }) {
+function apiSnapshotListsRound3ForAlliance(snapshot, allianceNumber) {
+    if (!snapshot || allianceNumber === undefined || allianceNumber === null) {
+        return false;
+    }
+    const v = snapshot[String(allianceNumber)];
+    return v !== undefined && v !== null && v !== "";
+}
+
+/** Same alliance row as in App.jsx getAlliances — keeps Lookup and alliance.* fields consistent after local round3 edits. */
+function sameAllianceRow(entry, allianceRow) {
+    if (!entry || !allianceRow) return false;
+    const num = allianceRow.number;
+    const name = allianceRow.name;
+    return (
+        (num !== undefined &&
+            num !== null &&
+            entry.number !== undefined &&
+            entry.number !== null &&
+            Number(entry.number) === Number(num)) ||
+        (name && entry.alliance === name)
+    );
+}
+
+function lookupTeamStillOnAllianceRoster(allianceRow, teamNum) {
+    if (teamNum == null || teamNum === "") return false;
+    const s = String(teamNum);
+    return (
+        String(allianceRow.captain) === s ||
+        String(allianceRow.round1) === s ||
+        String(allianceRow.round2) === s
+    );
+}
+
+function syncAllianceLookupRound3Entry(
+    alliancesTemp,
+    allianceRow,
+    prevRound3TeamNumber,
+    roundThreeRoleLabel
+) {
+    const lu = alliancesTemp?.Lookup;
+    if (!lu || !allianceRow) return;
+    const newR3 = allianceRow.round3;
+    if (
+        prevRound3TeamNumber != null &&
+        prevRound3TeamNumber !== "" &&
+        String(prevRound3TeamNumber) !== String(newR3 ?? "")
+    ) {
+        if (!lookupTeamStillOnAllianceRoster(allianceRow, prevRound3TeamNumber)) {
+            delete lu[String(prevRound3TeamNumber)];
+        }
+    }
+    for (const entry of Object.values(lu)) {
+        if (sameAllianceRow(entry, allianceRow)) {
+            entry.round3 = allianceRow.round3 ?? null;
+            entry.backup = null;
+            entry.backupReplaced = null;
+        }
+    }
+    const r3 = allianceRow.round3;
+    if (r3 != null && r3 !== "") {
+        lu[String(r3)] = {
+            role: roundThreeRoleLabel,
+            alliance: allianceRow.name,
+            number: allianceRow.number,
+            captain: allianceRow.captain,
+            round1: allianceRow.round1,
+            round2: allianceRow.round2,
+            round3: allianceRow.round3,
+            backup: null,
+            backupReplaced: null,
+        };
+    }
+}
+
+function clearAllianceLookupRound3(alliancesTemp, allianceRow, removedRound3) {
+    const lu = alliancesTemp?.Lookup;
+    if (!lu || !allianceRow) return;
+    if (removedRound3 != null && removedRound3 !== "") {
+        if (!lookupTeamStillOnAllianceRoster(allianceRow, removedRound3)) {
+            delete lu[String(removedRound3)];
+        }
+    }
+    for (const entry of Object.values(lu)) {
+        if (sameAllianceRow(entry, allianceRow)) {
+            entry.round3 = null;
+            entry.backup = null;
+            entry.backupReplaced = null;
+        }
+    }
+}
+
+function getAllianceIndexForMatchSide(side, matchDetails, alliancesTemp) {
+    const field = matchDetails?.teams?.find(
+        (t) =>
+            String(t.station || "").startsWith(side) &&
+            t.teamNumber != null &&
+            Number(t.teamNumber) > 0
+    );
+    if (!field) return null;
+    const lu = alliancesTemp?.Lookup?.[String(field.teamNumber)];
+    if (!lu?.alliance) return null;
+    const idx = _.findIndex(alliancesTemp?.alliances, { name: lu.alliance });
+    if (idx < 0) return null;
+    return { idx, allianceName: lu.alliance };
+}
+
+/**
+ * @param {'Red'|'Blue'} side
+ * @returns {null | { teamNumber: number|string, allianceName: string, allianceNumber: number|string, side: string, isPlayoffReserve: boolean }}
+ */
+function getPlayoffReserveForSide(side, matchDetails, alliances, inPlayoffs) {
+    if (!inPlayoffs || !matchDetails?.teams?.length || !alliances?.alliances?.length || !alliances?.Lookup) {
+        return null;
+    }
+    const matchNums = new Set(matchDetails.teams.map((t) => String(t.teamNumber)));
+    const namesOnField = new Set();
+    matchDetails.teams.forEach((t) => {
+        const lu = alliances.Lookup[String(t.teamNumber)];
+        if (lu?.alliance) namesOnField.add(lu.alliance);
+    });
+    for (const al of alliances.alliances) {
+        const reserveNum =
+            al.round3 !== undefined && al.round3 !== null && al.round3 !== ""
+                ? al.round3
+                : al.backup !== undefined && al.backup !== null && al.backup !== ""
+                  ? al.backup
+                  : null;
+        if (reserveNum == null) continue;
+        if (!namesOnField.has(al.name)) continue;
+        if (matchNums.has(String(reserveNum))) continue;
+        const fielded = matchDetails.teams.find(
+            (t) => alliances.Lookup[String(t.teamNumber)]?.alliance === al.name
+        );
+        const alSide = fielded?.station?.startsWith("Blue") ? "Blue" : "Red";
+        if (alSide !== side) continue;
+        return {
+            teamNumber: reserveNum,
+            allianceName: al.name,
+            allianceNumber: al.number,
+            side,
+            isPlayoffReserve: true,
+        };
+    }
+    return null;
+}
+
+function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatchFromMenu, selectedEvent, matchDetails, timeFormat, alliances, setAlliances, rankings, inPlayoffs, backupTeam, setBackupTeam, upsertPlayoffReserveOverlay, removePlayoffReserveOverlay, teamList, adHocMatch, setAdHocMatch, adHocMode, swapScreen, playoffOnly, eventLabel, ftcMode, playoffAllianceRound3FromApi = {} }) {
 
     const [show, setShow] = useState(null);
     const [showAdHoc, setAdHoc] = useState(null);
     const [teamSelected, setTeamSelected] = useState(null);
     const [confirmSelection, setConfirmSelection] = useState(false);
+    const [reserveAddSide, setReserveAddSide] = useState(/** @type {null | 'Red' | 'Blue'} */ (null));
     const { disableScope, enableScope } = useHotkeysContext();
 
     const handleShow = () => {
         setShow(true);
+        setReserveAddSide(null);
         disableScope('matchNavigation');
         disableScope('tabNavigation');
     }
@@ -36,18 +186,14 @@ function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatc
         setShow(false);
         setTeamSelected(null);
         setConfirmSelection(false);
+        setReserveAddSide(null);
         enableScope('matchNavigation');
         enableScope('tabNavigation');
     }
 
-    const teamToReplace = (/** @type {object} */ team) => {
-        setTeamSelected(team);
+    const handleBackupReconsider = () => {
         setConfirmSelection(false);
-    }
-
-    const handleBackupSelect = (/** @type {object} */ team) => {
-        setBackupTeam({ "backup": team.value, "replacing": teamSelected.teamNumber });
-        setConfirmSelection(true);
+        setBackupTeam(null);
     }
 
     const handleMatchSelection = (newMatch) => {
@@ -58,19 +204,107 @@ function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatc
     const selectRef = useRef(null)
 
     const handleBackupConfirm = () => {
-        //do the temporary work on the Allianes and team list
-
-        //patch alliance
         var alliancesTemp = _.cloneDeep(alliances);
-        var allianceToPatch = alliancesTemp?.Lookup[`${backupTeam?.replacing}`];
-        alliancesTemp.alliances[_.findIndex(alliancesTemp?.alliances, { "name": allianceToPatch?.alliance })].backup = backupTeam?.backup?.teamNumber;
-        alliancesTemp.alliances[_.findIndex(alliancesTemp?.alliances, { "name": allianceToPatch?.alliance })].backupReplaced = backupTeam?.replacing;
+        const side = reserveAddSide;
+        if (!side || !backupTeam?.backup?.teamNumber) {
+            return;
+        }
+        const meta = getAllianceIndexForMatchSide(side, matchDetails, alliancesTemp);
+        if (!meta) {
+            return;
+        }
+        const allianceIdx = meta.idx;
+        const prevRound3 = alliancesTemp.alliances[allianceIdx].round3;
+        alliancesTemp.alliances[allianceIdx].round3 = backupTeam.backup.teamNumber;
+        alliancesTemp.alliances[allianceIdx].backup = null;
+        alliancesTemp.alliances[allianceIdx].backupReplaced = null;
+        const allianceRow = alliancesTemp.alliances[allianceIdx];
+        syncAllianceLookupRound3Entry(
+            alliancesTemp,
+            allianceRow,
+            prevRound3,
+            roundThreeOrReserveRoleLabel(selectedEvent?.value)
+        );
+        let allianceNumber = allianceRow?.number;
+        if (allianceNumber === undefined || allianceNumber === null || allianceNumber === "") {
+            const nameStr = String(allianceRow?.name || meta.allianceName || "");
+            const m = nameStr.match(/(\d+)/);
+            if (m) allianceNumber = parseInt(m[1], 10);
+        }
+        if (
+            allianceNumber !== undefined &&
+            allianceNumber !== null &&
+            allianceNumber !== "" &&
+            !Number.isNaN(Number(allianceNumber))
+        ) {
+            const pendingSourceMatch =
+                matchDetails &&
+                (matchDetails.matchNumber != null ||
+                    matchDetails.originalMatchNumber != null)
+                    ? {
+                        tournamentLevel:
+                            matchDetails.tournamentLevel ||
+                            (inPlayoffs ? "Playoff" : null),
+                        matchNumber: matchDetails.matchNumber,
+                        originalMatchNumber: matchDetails.originalMatchNumber,
+                        series: matchDetails.series,
+                    }
+                    : undefined;
+            upsertPlayoffReserveOverlay?.({
+                allianceNumber,
+                round3: backupTeam.backup.teamNumber,
+                pendingSourceMatch,
+            });
+        }
         setAlliances(alliancesTemp);
 
         setShow(false);
         setBackupTeam(null);
         setTeamSelected(null);
         setConfirmSelection(false);
+        setReserveAddSide(null);
+        enableScope('matchNavigation');
+        enableScope('tabNavigation');
+    }
+
+    const handleRemoveReserveConfirm = () => {
+        const allianceName = teamSelected?.allianceName;
+        let allianceNumber = teamSelected?.allianceNumber;
+        if (allianceNumber === undefined || allianceNumber === null || allianceNumber === "") {
+            if (allianceName) {
+                const m = String(allianceName).match(/(\d+)/);
+                if (m) allianceNumber = parseInt(m[1], 10);
+            }
+        }
+        if (allianceNumber === undefined || allianceNumber === null || allianceNumber === "") {
+            handleClose();
+            return;
+        }
+        if (apiSnapshotListsRound3ForAlliance(playoffAllianceRound3FromApi, allianceNumber)) {
+            return;
+        }
+        var alliancesTemp = _.cloneDeep(alliances);
+        var idx = _.findIndex(
+            alliancesTemp?.alliances,
+            (a) => Number(a.number) === Number(allianceNumber)
+        );
+        if (idx < 0 && allianceName) {
+            idx = _.findIndex(alliancesTemp?.alliances, { name: allianceName });
+        }
+        if (idx >= 0) {
+            const removedRound3 = alliancesTemp.alliances[idx].round3;
+            alliancesTemp.alliances[idx].round3 = null;
+            alliancesTemp.alliances[idx].backup = null;
+            alliancesTemp.alliances[idx].backupReplaced = null;
+            clearAllianceLookupRound3(alliancesTemp, alliancesTemp.alliances[idx], removedRound3);
+        }
+        removePlayoffReserveOverlay?.({ allianceNumber });
+        setAlliances(alliancesTemp);
+        setShow(false);
+        setBackupTeam(null);
+        setTeamSelected(null);
+        setConfirmSelection(false);
+        setReserveAddSide(null);
         enableScope('matchNavigation');
         enableScope('tabNavigation');
     }
@@ -112,19 +346,147 @@ function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatc
     }
     
     if (inPlayoffs && alliances.alliances.length > 0) {
-        let availableTeamsTemp = [];
-        availableTeams.forEach(team => {
-            if (_.findIndex(alliances.alliances, { backup: team?.label }) < 0) {
-                availableTeamsTemp.push(team);
-            }
-        })
-        availableTeams = availableTeamsTemp;
-
+        availableTeams = availableTeams.filter((team) => {
+            const label = team?.label;
+            return !alliances.alliances.some(
+                (al) =>
+                    Number(al.round3) === Number(label) ||
+                    Number(al.backup) === Number(label)
+            );
+        });
     }
 
     availableTeams = _.orderBy(availableTeams, ["label"], "asc");
     const inPractice = matchDetails?.description.toLowerCase().includes("practice");
     const addBackupButton = !ftcMode && inPlayoffs && ((selectedEvent?.value?.champLevel !== "CHAMPS" && selectedEvent?.value?.champLevel !== "CMPDIV" && selectedEvent?.value?.champLevel !== "CMPSUB") || (selectedEvent?.value?.code === "OFFLINE" && !playoffOnly));
+
+    const fieldTeamsOnly = matchDetails?.teams || [];
+    const stationSortKeyField = (t) => {
+        const n = parseInt(String(t.station).replace(/\D/g, ""), 10);
+        return Number.isNaN(n) ? 5 : n;
+    };
+    const redFieldTeams = fieldTeamsOnly
+        .filter((t) => String(t.station || "").startsWith("Red"))
+        .sort((a, b) => stationSortKeyField(a) - stationSortKeyField(b));
+    const blueFieldTeams = fieldTeamsOnly
+        .filter((t) => String(t.station || "").startsWith("Blue"))
+        .sort((a, b) => stationSortKeyField(a) - stationSortKeyField(b));
+
+    /** Match Play-by-Play: Blue column left when not swapped; Red left when swapScreen is on. */
+    const blueAllianceColumnFirst = !swapScreen;
+    const leftColumnTeams = blueAllianceColumnFirst ? blueFieldTeams : redFieldTeams;
+    const rightColumnTeams = blueAllianceColumnFirst ? redFieldTeams : blueFieldTeams;
+    const leftColumnSide = blueAllianceColumnFirst ? "Blue" : "Red";
+    const rightColumnSide = blueAllianceColumnFirst ? "Red" : "Blue";
+
+    const redReserveCtx = getPlayoffReserveForSide("Red", matchDetails, alliances, inPlayoffs);
+    const blueReserveCtx = getPlayoffReserveForSide("Blue", matchDetails, alliances, inPlayoffs);
+    const reserveSlotUiLabel = roundThreeOrReserveRoleLabel(selectedEvent?.value);
+
+    const renderBackupModalFieldTile = (team, index) => {
+        const allianceColor = team?.station.slice(0, team.station?.length - 1);
+        const key = `Field${team?.station || team?.teamNumber || index}`;
+        return (
+            <div
+                key={key}
+                className={`btn w-100 ${allianceColor}Replace alliance-backup-modal-team-btn alliance-backup-modal-field-display`}
+            >
+                {team.teamNumber}
+            </div>
+        );
+    };
+
+    const renderAllianceReserveColumn = (/** @type {'Red'|'Blue'} */ side, teams) => {
+        const reserveCtx = side === "Red" ? redReserveCtx : blueReserveCtx;
+        const removeLockedByOfficialRound3 =
+            reserveCtx &&
+            apiSnapshotListsRound3ForAlliance(
+                playoffAllianceRound3FromApi,
+                reserveCtx.allianceNumber
+            );
+        return (
+            <Col xs={12} md={6} className="d-flex flex-column gap-2">
+                {teams.map((team, index) => renderBackupModalFieldTile(team, index))}
+                {reserveAddSide === side && !confirmSelection && (
+                    <>
+                        <div className="text-center small">
+                            Select the team to add as the <b>{reserveSlotUiLabel}</b> for this alliance.
+                        </div>
+                        <Select
+                            placeholder="Choose team…"
+                            options={availableTeams}
+                            onChange={(/** @type {{ value: object } | null} */ opt) => {
+                                if (opt?.value) {
+                                    setBackupTeam({ backup: opt.value });
+                                    setConfirmSelection(true);
+                                }
+                            }}
+                        />
+                        <Button
+                            variant="outline-secondary"
+                            onClick={() => {
+                                setReserveAddSide(null);
+                                setBackupTeam(null);
+                            }}
+                        >
+                            Back
+                        </Button>
+                    </>
+                )}
+                {(reserveAddSide !== side || confirmSelection) && (
+                    <>
+                        {reserveCtx ? (
+                            removeLockedByOfficialRound3 ? (
+                                renderBackupModalFieldTile(
+                                    { station: `${side}1`, teamNumber: reserveCtx.teamNumber },
+                                    `reserve${side}`
+                                )
+                            ) : (
+                                <button
+                                    type="button"
+                                    className={`btn w-100 ${side}Replace alliance-backup-modal-team-btn alliance-backup-modal-alliance-action-btn alliance-backup-modal-reserve-btn`}
+                                    onClick={() => {
+                                        setTeamSelected(reserveCtx);
+                                        setConfirmSelection(false);
+                                    }}
+                                >
+                                    Remove {reserveCtx.teamNumber} from {side} Alliance
+                                </button>
+                            )
+                        ) : (
+                            <button
+                                type="button"
+                                className={`btn w-100 ${side}Replace alliance-backup-modal-team-btn alliance-backup-modal-alliance-action-btn alliance-backup-modal-reserve-btn`}
+                                onClick={() => {
+                                    setReserveAddSide(side);
+                                    setConfirmSelection(false);
+                                    setBackupTeam(null);
+                                }}
+                            >
+                                Add team to {side} Alliance
+                            </button>
+                        )}
+                    </>
+                )}
+            </Col>
+        );
+    };
+
+    const removeReserveConfirmBlockedByApi =
+        Boolean(
+            teamSelected?.isPlayoffReserve &&
+            apiSnapshotListsRound3ForAlliance(
+                playoffAllianceRound3FromApi,
+                teamSelected.allianceNumber
+            )
+        );
+
+    const matchHasPosted = matchHasPostedResult(matchDetails);
+    const showTopBarAddTeamCol =
+        (addBackupButton || inPractice) && !matchHasPosted;
+    const showTopBarChangeTeamsCol = adHocMode || inPractice;
+    const topBarCenterColXs =
+        showTopBarAddTeamCol || showTopBarChangeTeamsCol ? "4" : "5";
 
     let eventTeams = teamList?.teams.map((team) => {
         return ({ "label": team.teamNumber, "value": team.teamNumber })
@@ -144,7 +506,7 @@ function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatc
                     {!adHocMode && <Button size="lg" variant="outline-success" className={"gatool-button buttonNoWrap"} onClick={previousMatch}>{inPractice ? <span><CaretLeftFill /> <CaretLeftFill /></span> : <><span className={"d-none d-lg-block"}><CaretLeftFill /> Previous Match</span><span className={"d-block d-lg-none"}><CaretLeftFill /> <CaretLeftFill /></span></>}</Button>}
                 </Col>
                 {!adHocMode && <MatchClock matchDetails={matchDetails} timeFormat={timeFormat} />}
-                <Col xs={addBackupButton || inPractice ? "4" : "5"} lg={!ftcMode && (inPlayoffs || inPractice) ? "3" : "4"}><b>{eventLabel?.replace("FIRST Championship - ", "").replace("FIRST In Texas District Championship - ", "").replace("FIRST Ontario Provincial Championship - ", "").replace("New England FIRST District Championship - ", "")}</b><br />
+                <Col xs={topBarCenterColXs} lg={!ftcMode && (inPlayoffs || inPractice) ? "3" : "4"}><b>{eventLabel?.replace("FIRST Championship - ", "").replace("FIRST In Texas District Championship - ", "").replace("FIRST Ontario Provincial Championship - ", "").replace("New England FIRST District Championship - ", "")}</b><br />
                     {!adHocMode && <Select options={matchMenu} value={currentMatch ? matchMenu[currentMatch - 1] : matchMenu[0]} onChange={handleMatchSelection} styles={{
                         // @ts-ignore
                         option: (styles, { data }) => {
@@ -157,33 +519,60 @@ function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatc
                     }} ref={selectRef} />}
                     {adHocMode && <span className="announceOrganization">TEST MATCH</span>}
                 </Col>
-                {(addBackupButton || inPractice ) && <Col className="promoteBackup" xs={1} onClick={handleShow}>+<ArrowUpSquareFill />+<br />Add Team</Col>}
-                {(adHocMode || inPractice) && <Col className="promoteBackup" xs={1} onClick={handleAdHoc}>Change<br />Teams</Col>}
+                {showTopBarAddTeamCol && <Col className="promoteBackup" xs={1} onClick={handleShow}>+<ArrowUpSquareFill />+<br />Add Team</Col>}
+                {showTopBarChangeTeamsCol && <Col className="promoteBackup" xs={1} onClick={handleAdHoc}>Change<br />Teams</Col>}
                 <Col xs={"2"} lg={"3"}>
                     {!adHocMode && <Button size="lg" variant="outline-success" className={"gatool-button buttonNoWrap"} onClick={nextMatch}>{inPractice ? <span><CaretRightFill /> <CaretRightFill /></span> : <><span className={"d-none d-lg-block"}>Next Match <CaretRightFill /></span><span className={"d-block d-lg-none"}><CaretRightFill /> <CaretRightFill /></span></>}</Button>}
                 </Col>
-                <Modal centered={true} show={show} onHide={handleClose}>
+                <Modal centered={true} show={show} onHide={handleClose} size="lg" dialogClassName="alliance-backup-modal-dialog">
                     <Modal.Header className={"promoteBackup"} closeButton closeVariant="white">
-                        <Modal.Title>Alliance Backup</Modal.Title>
+                        <Modal.Title>Call up reserve team</Modal.Title>
                     </Modal.Header>
-                    <Modal.Body className={"backupDialog"}>
+                    <Modal.Body className={"backupDialog alliance-backup-modal-body"}>
                         <Container fluid>
-                            {!teamSelected && <><Row>
-                                <Col>Select the team(s) not playing in this match. The new team will become a permanent member of the Alliance.</Col></Row>
-                                <Row>
-                                    {matchDetails?.teams.map((team, index) => {
-                                        var allianceColor = team?.station.slice(0, team.station?.length - 1);
-                                        return (<div className={`btn ${allianceColor}Replace`} key={`Replace${team?.teamNumber || index}`} onClick={() => { teamToReplace(team) }}>{team?.teamNumber}</div>)
-                                    })}
+                            {confirmSelection && backupTeam && reserveAddSide && !teamSelected && (
+                                <>
+                                    <Row>
+                                        <Col>Add team {backupTeam.backup.teamNumber} as the <b>{reserveSlotUiLabel}</b> for the {reserveAddSide} Alliance?</Col>
+                                    </Row>
+                                    <Row className="mt-2">
+                                        <Col>
+                                            <Button className="me-2" variant="success" onClick={handleBackupConfirm}>Yes</Button>
+                                            <Button variant="outline-secondary" onClick={handleBackupReconsider}>No, they reconsidered</Button>
+                                        </Col>
+                                    </Row>
+                                </>
+                            )}
+
+                            {teamSelected?.isPlayoffReserve && <><Row>
+                                <Col>Remove team {teamSelected?.teamNumber} from the {teamSelected?.side} Alliance (<b>{reserveSlotUiLabel}</b>)? This clears the change in gatool until the match posts to FIRST (or you add a reserve again).</Col>
+                            </Row>
+                                <Row className="mt-2">
+                                    <Col>
+                                        <Button
+                                            className="me-2"
+                                            variant="danger"
+                                            disabled={removeReserveConfirmBlockedByApi}
+                                            title={
+                                                removeReserveConfirmBlockedByApi
+                                                    ? "FIRST already lists a round 3 team for this alliance; remove is disabled."
+                                                    : undefined
+                                            }
+                                            onClick={handleRemoveReserveConfirm}
+                                        >
+                                            Remove reserve
+                                        </Button>
+                                        <Button variant="outline-secondary" onClick={() => { setTeamSelected(null) }}>Back</Button>
+                                    </Col>
                                 </Row></>}
 
-                            {teamSelected && !confirmSelection && <><Row><Col>Select a team to replace {teamSelected?.teamNumber} in this match:</Col></Row>
-                                <Row> <Col><Select options={availableTeams} onChange={handleBackupSelect} /></Col>
-                                </Row></>}
-
-                            {teamSelected && confirmSelection && <><Row><Col>Are you sure you want to replace team {teamSelected?.teamNumber} with {backupTeam?.backup?.teamNumber}?</Col></Row>
-                                <Row> <Col><Button onClick={handleBackupConfirm}>Yes</Button></Col>
-                                </Row></>}
+                            {!teamSelected && !(confirmSelection && backupTeam && reserveAddSide) && <><Row>
+                                <Col>Use <b>Add team to Alliance</b> to add the <b>{reserveSlotUiLabel}</b> for that alliance. They become a permanent alliance member after the match completes.</Col></Row>
+                                <Row className="mt-3 g-3 alliance-backup-modal-columns">
+                                    {renderAllianceReserveColumn(leftColumnSide, leftColumnTeams)}
+                                    {renderAllianceReserveColumn(rightColumnSide, rightColumnTeams)}
+                                </Row>
+                            </>}
                         </Container>
                     </Modal.Body>
                 </Modal>

--- a/src/components/TopButtons.jsx
+++ b/src/components/TopButtons.jsx
@@ -6,14 +6,37 @@ import MatchClock from "../components/MatchClock";
 import _ from "lodash";
 import { useHotkeysContext } from "react-hotkeys-hook";
 import { roundThreeOrReserveRoleLabel } from "../utils/allianceRoleLabels";
-import { matchHasPostedResult } from "../utils/playoffReserveEdits";
+import {
+    compactReserveEditsForEvent,
+    matchHasPostedResult,
+} from "../utils/playoffReserveEdits";
 
-function apiSnapshotListsRound3ForAlliance(snapshot, allianceNumber) {
-    if (!snapshot || allianceNumber === undefined || allianceNumber === null) {
+/**
+ * True when this alliance has a persisted `op: 'set'` overlay (user-added reserve / round3 in gatool).
+ * Merged `alliances` alone mixes API + overlay; comparing to overrides on each render decides if Remove is allowed.
+ */
+function hasLocalPlayoffReserveSetOverride(playoffReserveEdits, eventCode, allianceNumber) {
+    if (
+        !eventCode ||
+        allianceNumber === undefined ||
+        allianceNumber === null ||
+        allianceNumber === ""
+    ) {
         return false;
     }
-    const v = snapshot[String(allianceNumber)];
-    return v !== undefined && v !== null && v !== "";
+    const raw = playoffReserveEdits?.[eventCode];
+    if (!raw || typeof raw !== "object") {
+        return false;
+    }
+    const e = compactReserveEditsForEvent(raw)[String(allianceNumber)];
+    if (!e || e.op !== "set") {
+        return false;
+    }
+    const hasRound3 =
+        e.round3 !== undefined && e.round3 !== null && e.round3 !== "";
+    const hasBackup =
+        e.backup !== undefined && e.backup !== null && e.backup !== "";
+    return hasRound3 || hasBackup;
 }
 
 /** Same alliance row as in App.jsx getAlliances — keeps Lookup and alliance.* fields consistent after local round3 edits. */
@@ -123,10 +146,16 @@ function getPlayoffReserveForSide(side, matchDetails, alliances, inPlayoffs) {
         return null;
     }
     const matchNums = new Set(matchDetails.teams.map((t) => String(t.teamNumber)));
-    const namesOnField = new Set();
+    /** Prefer alliance id from Lookup — name strings from API vs schedule can drift. */
+    const allianceNumbersOnField = new Set();
     matchDetails.teams.forEach((t) => {
         const lu = alliances.Lookup[String(t.teamNumber)];
-        if (lu?.alliance) namesOnField.add(lu.alliance);
+        if (lu?.number !== undefined && lu?.number !== null && lu?.number !== "") {
+            const n = Number(lu.number);
+            if (Number.isFinite(n)) {
+                allianceNumbersOnField.add(n);
+            }
+        }
     });
     for (const al of alliances.alliances) {
         const reserveNum =
@@ -136,10 +165,11 @@ function getPlayoffReserveForSide(side, matchDetails, alliances, inPlayoffs) {
                   ? al.backup
                   : null;
         if (reserveNum == null) continue;
-        if (!namesOnField.has(al.name)) continue;
+        const alNum = Number(al.number);
+        if (!Number.isFinite(alNum) || !allianceNumbersOnField.has(alNum)) continue;
         if (matchNums.has(String(reserveNum))) continue;
         const fielded = matchDetails.teams.find(
-            (t) => alliances.Lookup[String(t.teamNumber)]?.alliance === al.name
+            (t) => Number(alliances.Lookup[String(t.teamNumber)]?.number) === alNum
         );
         const alSide = fielded?.station?.startsWith("Blue") ? "Blue" : "Red";
         if (alSide !== side) continue;
@@ -154,7 +184,7 @@ function getPlayoffReserveForSide(side, matchDetails, alliances, inPlayoffs) {
     return null;
 }
 
-function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatchFromMenu, selectedEvent, matchDetails, timeFormat, alliances, setAlliances, rankings, inPlayoffs, backupTeam, setBackupTeam, upsertPlayoffReserveOverlay, removePlayoffReserveOverlay, teamList, adHocMatch, setAdHocMatch, adHocMode, swapScreen, playoffOnly, eventLabel, ftcMode, playoffAllianceRound3FromApi = {} }) {
+function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatchFromMenu, selectedEvent, matchDetails, timeFormat, alliances, setAlliances, rankings, inPlayoffs, backupTeam, setBackupTeam, upsertPlayoffReserveOverlay, removePlayoffReserveOverlay, playoffReserveEdits, teamList, adHocMatch, setAdHocMatch, adHocMode, swapScreen, playoffOnly, eventLabel, ftcMode }) {
 
     const [show, setShow] = useState(null);
     const [showAdHoc, setAdHoc] = useState(null);
@@ -280,7 +310,9 @@ function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatc
             handleClose();
             return;
         }
-        if (apiSnapshotListsRound3ForAlliance(playoffAllianceRound3FromApi, allianceNumber)) {
+        const eventCode = selectedEvent?.value?.code;
+        if (!hasLocalPlayoffReserveSetOverride(playoffReserveEdits, eventCode, allianceNumber)) {
+            handleClose();
             return;
         }
         var alliancesTemp = _.cloneDeep(alliances);
@@ -381,6 +413,7 @@ function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatc
 
     const redReserveCtx = getPlayoffReserveForSide("Red", matchDetails, alliances, inPlayoffs);
     const blueReserveCtx = getPlayoffReserveForSide("Blue", matchDetails, alliances, inPlayoffs);
+    const eventCodeForReserve = selectedEvent?.value?.code;
     const reserveSlotUiLabel = roundThreeOrReserveRoleLabel(selectedEvent?.value);
 
     const renderBackupModalFieldTile = (team, index) => {
@@ -398,10 +431,11 @@ function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatc
 
     const renderAllianceReserveColumn = (/** @type {'Red'|'Blue'} */ side, teams) => {
         const reserveCtx = side === "Red" ? redReserveCtx : blueReserveCtx;
-        const removeLockedByOfficialRound3 =
+        const reserveShownFromApiOnly =
             reserveCtx &&
-            apiSnapshotListsRound3ForAlliance(
-                playoffAllianceRound3FromApi,
+            !hasLocalPlayoffReserveSetOverride(
+                playoffReserveEdits,
+                eventCodeForReserve,
                 reserveCtx.allianceNumber
             );
         return (
@@ -436,7 +470,7 @@ function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatc
                 {(reserveAddSide !== side || confirmSelection) && (
                     <>
                         {reserveCtx ? (
-                            removeLockedByOfficialRound3 ? (
+                            reserveShownFromApiOnly ? (
                                 renderBackupModalFieldTile(
                                     { station: `${side}1`, teamNumber: reserveCtx.teamNumber },
                                     `reserve${side}`
@@ -475,8 +509,9 @@ function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatc
     const removeReserveConfirmBlockedByApi =
         Boolean(
             teamSelected?.isPlayoffReserve &&
-            apiSnapshotListsRound3ForAlliance(
-                playoffAllianceRound3FromApi,
+            !hasLocalPlayoffReserveSetOverride(
+                playoffReserveEdits,
+                eventCodeForReserve,
                 teamSelected.allianceNumber
             )
         );
@@ -526,7 +561,7 @@ function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatc
                 </Col>
                 <Modal centered={true} show={show} onHide={handleClose} size="lg" dialogClassName="alliance-backup-modal-dialog">
                     <Modal.Header className={"promoteBackup"} closeButton closeVariant="white">
-                        <Modal.Title>Call up reserve team</Modal.Title>
+                        <Modal.Title>{teamSelected?.isPlayoffReserve ? "Remove reserve team" : "Call up reserve team"}</Modal.Title>
                     </Modal.Header>
                     <Modal.Body className={"backupDialog alliance-backup-modal-body"}>
                         <Container fluid>
@@ -545,7 +580,7 @@ function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatc
                             )}
 
                             {teamSelected?.isPlayoffReserve && <><Row>
-                                <Col>Remove team {teamSelected?.teamNumber} from the {teamSelected?.side} Alliance (<b>{reserveSlotUiLabel}</b>)? This clears the change in gatool until the match posts to FIRST (or you add a reserve again).</Col>
+                                <Col>Remove team {teamSelected?.teamNumber} from the {teamSelected?.side} Alliance?</Col>
                             </Row>
                                 <Row className="mt-2">
                                     <Col>

--- a/src/pages/AnnouncePage.jsx
+++ b/src/pages/AnnouncePage.jsx
@@ -50,6 +50,7 @@ function AnnouncePage({
   setBackupTeam,
   upsertPlayoffReserveOverlay,
   removePlayoffReserveOverlay,
+  playoffReserveEdits,
   nextMatch,
   previousMatch,
   setMatchFromMenu,
@@ -87,7 +88,6 @@ function AnnouncePage({
   remapStringToNumber,
   useScrollMemory,
   alliancePartnerConnectionsCache,
-  playoffAllianceRound3FromApi,
 }) {
   // Remember scroll position for Announce page
   useScrollPosition('announce', true, false, useScrollMemory);
@@ -612,7 +612,7 @@ function AnnouncePage({
               setBackupTeam={setBackupTeam}
               upsertPlayoffReserveOverlay={upsertPlayoffReserveOverlay}
               removePlayoffReserveOverlay={removePlayoffReserveOverlay}
-              playoffAllianceRound3FromApi={playoffAllianceRound3FromApi}
+              playoffReserveEdits={playoffReserveEdits}
               teamList={teamList}
               adHocMatch={adHocMatch}
               setAdHocMatch={setAdHocMatch}

--- a/src/pages/AnnouncePage.jsx
+++ b/src/pages/AnnouncePage.jsx
@@ -48,6 +48,8 @@ function AnnouncePage({
   eventHighScores,
   backupTeam,
   setBackupTeam,
+  upsertPlayoffReserveOverlay,
+  removePlayoffReserveOverlay,
   nextMatch,
   previousMatch,
   setMatchFromMenu,
@@ -85,6 +87,7 @@ function AnnouncePage({
   remapStringToNumber,
   useScrollMemory,
   alliancePartnerConnectionsCache,
+  playoffAllianceRound3FromApi,
 }) {
   // Remember scroll position for Announce page
   useScrollPosition('announce', true, false, useScrollMemory);
@@ -607,6 +610,9 @@ function AnnouncePage({
               rankings={rankings}
               backupTeam={backupTeam}
               setBackupTeam={setBackupTeam}
+              upsertPlayoffReserveOverlay={upsertPlayoffReserveOverlay}
+              removePlayoffReserveOverlay={removePlayoffReserveOverlay}
+              playoffAllianceRound3FromApi={playoffAllianceRound3FromApi}
               teamList={teamList}
               adHocMatch={adHocMatch}
               setAdHocMatch={setAdHocMatch}

--- a/src/pages/PlayByPlayPage.jsx
+++ b/src/pages/PlayByPlayPage.jsx
@@ -42,6 +42,8 @@ function PlayByPlayPage({
   eventHighScores,
   backupTeam,
   setBackupTeam,
+  upsertPlayoffReserveOverlay,
+  removePlayoffReserveOverlay,
   nextMatch,
   previousMatch,
   setMatchFromMenu,
@@ -73,6 +75,7 @@ function PlayByPlayPage({
   remapNumberToString,
   remapStringToNumber,
   useScrollMemory,
+  playoffAllianceRound3FromApi,
 }) {
   // Remember scroll position for Play by play page
   useScrollPosition('playbyplay', true, false, useScrollMemory);
@@ -543,6 +546,9 @@ function PlayByPlayPage({
               rankings={rankings}
               backupTeam={backupTeam}
               setBackupTeam={setBackupTeam}
+              upsertPlayoffReserveOverlay={upsertPlayoffReserveOverlay}
+              removePlayoffReserveOverlay={removePlayoffReserveOverlay}
+              playoffAllianceRound3FromApi={playoffAllianceRound3FromApi}
               teamList={teamList}
               adHocMatch={adHocMatch}
               setAdHocMatch={setAdHocMatch}

--- a/src/pages/PlayByPlayPage.jsx
+++ b/src/pages/PlayByPlayPage.jsx
@@ -44,6 +44,7 @@ function PlayByPlayPage({
   setBackupTeam,
   upsertPlayoffReserveOverlay,
   removePlayoffReserveOverlay,
+  playoffReserveEdits,
   nextMatch,
   previousMatch,
   setMatchFromMenu,
@@ -75,7 +76,6 @@ function PlayByPlayPage({
   remapNumberToString,
   remapStringToNumber,
   useScrollMemory,
-  playoffAllianceRound3FromApi,
 }) {
   // Remember scroll position for Play by play page
   useScrollPosition('playbyplay', true, false, useScrollMemory);
@@ -548,7 +548,7 @@ function PlayByPlayPage({
               setBackupTeam={setBackupTeam}
               upsertPlayoffReserveOverlay={upsertPlayoffReserveOverlay}
               removePlayoffReserveOverlay={removePlayoffReserveOverlay}
-              playoffAllianceRound3FromApi={playoffAllianceRound3FromApi}
+              playoffReserveEdits={playoffReserveEdits}
               teamList={teamList}
               adHocMatch={adHocMatch}
               setAdHocMatch={setAdHocMatch}

--- a/src/utils/allianceRoleLabels.js
+++ b/src/utils/allianceRoleLabels.js
@@ -1,0 +1,20 @@
+/**
+ * World Championship and its division events use FIRST’s “Round 3 Selection” wording;
+ * all other events use “Reserve Team” in the UI for the same alliance slot.
+ *
+ * @param {{ champLevel?: string } | null | undefined} eventValue selectedEvent.value
+ */
+export function isWorldChampsOrDivisionEvent(eventValue) {
+  const cl = eventValue?.champLevel;
+  return cl === "CHAMPS" || cl === "CMPDIV" || cl === "CMPSUB";
+}
+
+/**
+ * Label for alliances.Lookup[].role (and matching UI copy) for the round-3 / reserve slot.
+ * @param {{ champLevel?: string } | null | undefined} eventValue selectedEvent.value
+ */
+export function roundThreeOrReserveRoleLabel(eventValue) {
+  return isWorldChampsOrDivisionEvent(eventValue)
+    ? "Round 3 Selection"
+    : "Reserve Team";
+}

--- a/src/utils/playoffReserveEdits.js
+++ b/src/utils/playoffReserveEdits.js
@@ -1,0 +1,144 @@
+/**
+ * @param {string|number|null|undefined} n
+ * @returns {string|number|null}
+ */
+export function normalizeAllianceTeamNumber(n) {
+  if (n === undefined || n === null || n === "") return null;
+  const num = Number(n);
+  return Number.isNaN(num) ? String(n) : num;
+}
+
+/** Keep only valid per-alliance edits: keys must be numeric alliance ids. */
+export function compactReserveEditsForEvent(forEvent) {
+  const out = {};
+  if (!forEvent || typeof forEvent !== "object") return out;
+  for (const [k, v] of Object.entries(forEvent)) {
+    if (
+      /^\d+$/.test(String(k)) &&
+      v &&
+      typeof v === "object" &&
+      (v.op === "set" || v.op === "clear")
+    ) {
+      out[String(k)] = v;
+    }
+  }
+  return out;
+}
+
+/**
+ * Apply persisted reserve edits after each alliances fetch.
+ * Storage: editsRoot[eventCode][allianceNumberString] =
+ *   { op: 'set', round3 } | legacy { op: 'set', backup, backupReplaced } | { op: 'clear' }
+ *
+ * @returns {string[]} Edit keys to drop when a stored `clear` is redundant (API agrees).
+ */
+export function applyPlayoffReserveEdits(alliancesData, eventCode, editsRoot) {
+  if (!alliancesData?.alliances?.length || !eventCode) return [];
+  const raw = editsRoot?.[eventCode];
+  const edits = compactReserveEditsForEvent(raw);
+  if (Object.keys(edits).length === 0) return [];
+
+  const pruneKeys = [];
+
+  for (const alliance of alliancesData.alliances) {
+    if (alliance.number === undefined || alliance.number === null) continue;
+    const key = String(alliance.number);
+    const e = edits[key];
+    if (e === undefined) continue;
+
+    if (e.op === "clear") {
+      const apiR3 = normalizeAllianceTeamNumber(alliance.round3);
+      const apiB = normalizeAllianceTeamNumber(alliance.backup);
+      if (apiR3 == null && apiB == null) {
+        pruneKeys.push(key);
+      }
+      alliance.round3 = null;
+      alliance.backup = null;
+      alliance.backupReplaced = null;
+    } else if (e.op === "set") {
+      const hasRound3 =
+        e.round3 !== undefined && e.round3 !== null && e.round3 !== "";
+      if (hasRound3) {
+        alliance.round3 = e.round3;
+        alliance.backup = null;
+        alliance.backupReplaced = null;
+      } else {
+        alliance.backup = e.backup ?? null;
+        alliance.backupReplaced = e.backupReplaced ?? null;
+      }
+    }
+  }
+
+  return [...new Set(pruneKeys)];
+}
+
+/** True when the schedule row has a committed result (FMS / hybrid feed). */
+export function matchHasPostedResult(m) {
+  if (!m || typeof m !== "object") return false;
+  if (m.postResultTime != null && m.postResultTime !== "") return true;
+  if (m.scoreRedFinal != null && m.scoreBlueFinal != null) return true;
+  return false;
+}
+
+/**
+ * @param {object} m Schedule match row
+ * @param {object} pending From reserve edit `pendingSourceMatch`
+ * @param {boolean} ftcMode
+ */
+function scheduleMatchMatchesPending(m, pending, ftcMode) {
+  if (!m || !pending || typeof pending !== "object") return false;
+  const tl1 = String(m.tournamentLevel || "").toLowerCase();
+  const tl2 = String(pending.tournamentLevel || "").toLowerCase();
+  if (tl1 !== tl2) return false;
+  if (ftcMode) {
+    const pSer = pending.series;
+    const mSer = m.series;
+    if (pSer != null && mSer != null && Number(pSer) !== Number(mSer)) {
+      return false;
+    }
+    const mNum = m.originalMatchNumber ?? m.matchNumber;
+    const pNum = pending.originalMatchNumber ?? pending.matchNumber;
+    return Number(mNum) === Number(pNum);
+  }
+  return Number(m.matchNumber) === Number(pending.matchNumber);
+}
+
+/**
+ * Drop `op: 'set'` reserve overlays when the playoff match they were tied to has posted.
+ * @returns {{ nextRoot: object, prunedAllianceKeys: string[] }}
+ */
+export function prunePlayoffReserveSetsAfterPostedMatches({
+  editsRoot,
+  eventCode,
+  playoffMatches,
+  ftcMode,
+}) {
+  const empty = { nextRoot: editsRoot, prunedAllianceKeys: [] };
+  if (!eventCode || !editsRoot?.[eventCode] || !playoffMatches?.length) {
+    return empty;
+  }
+  const raw = editsRoot[eventCode];
+  const forEv = compactReserveEditsForEvent({ ...raw });
+  const prunedAllianceKeys = [];
+  for (const [allianceKey, edit] of Object.entries(forEv)) {
+    if (edit?.op !== "set" || !edit.pendingSourceMatch) continue;
+    const posted = playoffMatches.some(
+      (m) =>
+        scheduleMatchMatchesPending(m, edit.pendingSourceMatch, ftcMode) &&
+        matchHasPostedResult(m)
+    );
+    if (posted) {
+      prunedAllianceKeys.push(allianceKey);
+      delete forEv[allianceKey];
+    }
+  }
+  if (prunedAllianceKeys.length === 0) return empty;
+  let nextRoot;
+  if (Object.keys(forEv).length === 0) {
+    const { [eventCode]: _removed, ...rest } = editsRoot;
+    nextRoot = rest;
+  } else {
+    nextRoot = { ...editsRoot, [eventCode]: forEv };
+  }
+  return { nextRoot, prunedAllianceKeys };
+}

--- a/src/utils/playoffReserveEdits.js
+++ b/src/utils/playoffReserveEdits.js
@@ -72,12 +72,22 @@ export function applyPlayoffReserveEdits(alliancesData, eventCode, editsRoot) {
   return [...new Set(pruneKeys)];
 }
 
-/** True when the schedule row has a committed result (FMS / hybrid feed). */
+/**
+ * True when the schedule row has a committed / meaningful result for gating UI and reserve overlays.
+ * Do not treat `0–0` with both scores non-null as posted — hybrid feeds often expose placeholders before
+ * FMS commits, which incorrectly pruned local reserve edits and hid Remove after changing matches.
+ */
 export function matchHasPostedResult(m) {
   if (!m || typeof m !== "object") return false;
   if (m.postResultTime != null && m.postResultTime !== "") return true;
-  if (m.scoreRedFinal != null && m.scoreBlueFinal != null) return true;
-  return false;
+  const red = m.scoreRedFinal;
+  const blue = m.scoreBlueFinal;
+  if (red == null || blue == null) return false;
+  const r = Number(red);
+  const b = Number(blue);
+  if (Number.isNaN(r) || Number.isNaN(b)) return false;
+  // Non-zero total indicates a played match when postResultTime is missing (e.g. some secondary feeds).
+  return r !== 0 || b !== 0;
 }
 
 /**


### PR DESCRIPTION
## Reserve Team flow improvements
The backup team flow has become long in the tooth as **_FIRST_** has changed how reserve teams work. We have modernized it to rename Backup teams as Reserve Teams. Additionally, users can now:
- The UI now shows two columns: one each for Red and Blue Alliances.
- <img width="1666" height="1126" alt="Screenshot_3_23_26__4_50 PM" src="https://github.com/user-attachments/assets/a96e7d46-7896-4604-9953-fd8b492293e2" />
- Add a Reserve team to an Alliance
- Remove a reserve team from an Alliance before the match results commit
- <img width="1666" height="1126" alt="Screenshot_3_23_26__5_00 PM" src="https://github.com/user-attachments/assets/70fc9592-a626-4bfd-b590-a8d7dbe85a64" />
- Team will persist until the match in which they were added posts results, so there is no risk of losing the reserve team if the schedule refreshes. The team will be added to the Alliance permanently in the API after the match posts.
- Reserve teams will be identified as Reserve Teams for non-Champs events, where they are Round 3 selections.



The new flow also hides the option to add a team when a match has already completed, and hides the option to add a reserve team if the Alliance already has one.