### PR TITLE
fix(alliance-selection): Move calculation of currentRound to after asArrays is populated

### DIFF
--- a/src/components/AllianceSelection.jsx
+++ b/src/components/AllianceSelection.jsx
@@ -541,8 +541,6 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
         [show, isResetModalOpen]
     );
     
-    const currentRound = asArrays?.allianceSelectionOrder?.[asArrays.nextChoice]?.round || -1;
-    
     // Early return if not initialized yet - wait for useEffect to complete
     if (!allianceSelectionArrays || _.isEmpty(allianceSelectionArrays)) {
         return null;
@@ -622,6 +620,8 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
         //set up the Alliances
         alliances = asArrays.alliances;
     }
+
+    const currentRound = asArrays?.allianceSelectionOrder?.[asArrays.nextChoice]?.round || -1;
 
     const availCell = (team) => {
         const currentRound = asArrays?.allianceSelectionOrder?.[asArrays.nextChoice]?.round || -1;


### PR DESCRIPTION
Recreating #720 after some bad git commands broke history... 🏛️📜⌛

---

Resolves #718 

Currently, the variable `currentRound` (which backs a couple of items including the alliance selection heading) is populated near the start of the function (line 544), right after some hooks are created. Before that, `asArrays` is initialized to a default blank value on line 29.

https://github.com/arthurlockman/gatool-ui/blob/4b7a8eaffe3f942b5d04db78f011e5e6fa738aeb/src/components/AllianceSelection.jsx#L29-L40

https://github.com/arthurlockman/gatool-ui/blob/4b7a8eaffe3f942b5d04db78f011e5e6fa738aeb/src/components/AllianceSelection.jsx#L544

The actual values of `asArrays` aren't populated until line 570 from props, resulting in the calculated value of `currentRound` being incorrect, defaulting to -1.

https://github.com/arthurlockman/gatool-ui/blob/4b7a8eaffe3f942b5d04db78f011e5e6fa738aeb/src/components/AllianceSelection.jsx#L568-L571

Moving the instantiation of `currentRound` should make it so that it actually references the real alliance selection data when computing the value.

Tested using `npm run start` that the Round label properly appears after making the change.

<img width="1307" height="867" alt="image" src="https://github.com/user-attachments/assets/e75faa5e-3fd8-4b3a-9c81-e35c54a1095d" />
