### PR TITLE
Filtering Kickoff events for FTC and UI fix for Alliance Selection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5605,6 +5605,23 @@ function App() {
           }
         }
 
+        // FTC: kickoff events are not competition events; omit from picker and type filters
+        if (ftcMode) {
+          result.events = _.filter(result?.events, (e) => {
+            const type = String(
+              _.get(e, "type") ?? _.get(e, "Type") ?? ""
+            )
+              .trim()
+              .toUpperCase();
+            const typeName = String(
+              _.get(e, "typeName") ?? _.get(e, "TypeName") ?? ""
+            )
+              .trim()
+              .toUpperCase();
+            return type !== "12" && typeName !== "KICKOFF";
+          });
+        }
+
         var regionCodes = [];
         var types = [];
         const events = result?.events.map((e) => {

--- a/src/components/AllianceSelection.jsx
+++ b/src/components/AllianceSelection.jsx
@@ -541,8 +541,6 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
         [show, isResetModalOpen]
     );
     
-    const currentRound = asArrays?.allianceSelectionOrder?.[asArrays.nextChoice]?.round || -1;
-    
     // Early return if not initialized yet - wait for useEffect to complete
     if (!allianceSelectionArrays || _.isEmpty(allianceSelectionArrays)) {
         return null;
@@ -622,6 +620,8 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
         //set up the Alliances
         alliances = asArrays.alliances;
     }
+
+    const currentRound = asArrays?.allianceSelectionOrder?.[asArrays.nextChoice]?.round || -1;
 
     const availCell = (team) => {
         const currentRound = asArrays?.allianceSelectionOrder?.[asArrays.nextChoice]?.round || -1;

--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -1,5 +1,19 @@
 export const appUpdates = [
   {
+    date: "April 7, 2026",
+    message: (
+      <ul>
+        <li>ALL PROGRAMS:</li>
+        <ul>
+          <li>Some patches</li>
+        </ul>
+        <li>FTC:</li>
+        <ul>
+          <li>We no longer display KICKOFF events in the event list.</li>
+        </ul>
+      </ul>
+    ),
+  },{
     date: "April 5, 2026",
     message: (
       <ul>

--- a/src/components/AppUpdates.jsx
+++ b/src/components/AppUpdates.jsx
@@ -5,7 +5,7 @@ export const appUpdates = [
       <ul>
         <li>ALL PROGRAMS:</li>
         <ul>
-          <li>Some patches</li>
+          <li>Alliance Selection screen now displays the correct title over the list of Alliances (Round 1 of 1, Round 1 of 2, etc. <i>Thank you Austin Jenchi for the fix!</i></li>
         </ul>
         <li>FTC:</li>
         <ul>

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -97,20 +97,29 @@ function SetupPage({ selectedEvent, setSelectedEvent, selectedYear, setSelectedY
 
     const ftcFiltersMenu = _.orderBy(ftcLeagues, "label", "asc")
 
-    const regionFiltersMenu = [...ftcTypes.map((/** @type {{ type: string; description: string; }} */ type) => {
+    const regionFiltersMenu = [..._.filter(ftcTypes, (/** @type {{ type: string }} */ type) => String(type?.type ?? "").trim().toUpperCase() !== "KICKOFF").map((/** @type {{ type: string; description: string; }} */ type) => {
         return { value: type.type, label: type.description }
     }), ..._.orderBy(ftcRegions.map((/** @type {{ regionCode: string; description: string; }} */ region) => {
         return { value: region.regionCode, label: region.description }
     }), "label", "asc")];
 
     function filterEvents(events) {
+        // FTC: hide kickoffs in the picker (covers persisted cache and any API shape quirks)
+        var working = ftcMode
+            ? _.filter(events, (o) => {
+                const t = String(_.get(o, "value.type") ?? "").trim().toUpperCase();
+                const tn = String(_.get(o, "value.typeName") ?? "").trim().toUpperCase();
+                return t !== "KICKOFF" && tn !== "KICKOFF";
+            })
+            : events;
+
         //filter the array
         var filters = [...eventFilters?.map((e) => { return e?.value }), ...regionFilters?.map((e) => { return e?.value })];
 
-        var filteredEvents = events;
+        var filteredEvents = working;
         //reduce the list by time, then additively include other filters
         if (timeFilter && (timeFilter?.value !== "all")) {
-            filteredEvents = _.filter(events, function (o) { return (_.indexOf(o?.filters, timeFilter.value) >= 0) });
+            filteredEvents = _.filter(filteredEvents, function (o) { return (_.indexOf(o?.filters, timeFilter.value) >= 0) });
         }
         var filterTemp = [];
         if (filters.length > 0) {


### PR DESCRIPTION
This adds event filtering for FTC that will remove the KICKOFF events from the event list.
Closes #719

It also fixes a UI bug in Alliance Selection where the current round and round count were not displaying correctly in the blue Alliances box
Closes #718 