### PR TITLE
Adding FIRST Champs to timeframe selector

### DIFF
--- a/public/help-wiki-manifest.json
+++ b/public/help-wiki-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-22T14:04:17.134Z",
+  "generatedAt": "2026-04-28T16:57:03.280Z",
   "rawBaseUrl": "https://raw.githubusercontent.com/wiki/arthurlockman/gatool-ui",
   "pages": [
     {

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -32,6 +32,7 @@ const filterTime = [
     { value: "week6", label: "Week 6" },
     { value: "week7", label: "Week 7" },
     { value: "week8", label: "Week 8" },
+    { value: "week9", label: "First Championships" },
 ]
 
 const filterTimeFTC = [


### PR DESCRIPTION
First Champs were not available via Week 8 timeframe filter. We added a FIRST Champs timeframe filter for FRC.