### PR TITLE
Improving offseason test match mode and playoffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ yarn-error.log*
 
 .env
 .idea
+/.cursor

--- a/public/help-wiki-manifest.json
+++ b/public/help-wiki-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-10T17:43:01.764Z",
+  "generatedAt": "2026-06-03T23:44:50.033Z",
   "rawBaseUrl": "https://raw.githubusercontent.com/wiki/arthurlockman/gatool-ui",
   "pages": [
     {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -303,6 +303,7 @@ function App() {
     rankingsOverride, setRankingsOverride,
     allianceCount, setAllianceCount,
     playoffCountOverride, setPlayoffCountOverride,
+    allianceSelectionRoundOrder, setAllianceSelectionRoundOrder,
     // Multi-screen sync
     syncEvent, setSyncEvent,
     screenMode, setScreenMode,
@@ -336,6 +337,8 @@ function App() {
   );
   // Live data: changes after every match; do not persist
   const [regionalEventDetail, setRegionalEventDetail] = useState(null);
+  const [adHocRedAlliance, setAdHocRedAlliance] = useState(null);
+  const [adHocBlueAlliance, setAdHocBlueAlliance] = useState(null);
   const [adHocMatch, setAdHocMatch] = useState([
     { teamNumber: null, station: "Red1", surrogate: false, dq: false },
     { teamNumber: null, station: "Red2", surrogate: false, dq: false },
@@ -1047,6 +1050,7 @@ function App() {
       if (!shouldPreserveOfflineData) {
         await setTeamReduction(null);
         await setPlayoffCountOverride(null);
+        await setAllianceSelectionRoundOrder(null);
         setAllianceSelectionArrays({});
         setAllianceSelection(false);
       } else {
@@ -1076,6 +1080,8 @@ function App() {
           setPlayoffStationOrderEdits(nextStation);
         }
       }
+      setAdHocRedAlliance(null);
+      setAdHocBlueAlliance(null);
       setAdHocMatch([
         { teamNumber: null, station: "Red1", surrogate: false, dq: false },
         { teamNumber: null, station: "Red2", surrogate: false, dq: false },
@@ -2545,6 +2551,10 @@ function App() {
                     adHocMatch={adHocMatch}
                     setAdHocMatch={setAdHocMatch}
                     adHocMode={adHocMode}
+                    adHocRedAlliance={adHocRedAlliance}
+                    setAdHocRedAlliance={setAdHocRedAlliance}
+                    adHocBlueAlliance={adHocBlueAlliance}
+                    setAdHocBlueAlliance={setAdHocBlueAlliance}
                     qualsLength={qualsLength}
                     playoffOnly={playoffOnly}
                     eventMessage={eventMessage}
@@ -2559,6 +2569,7 @@ function App() {
                     playoffStationOrderEdits={playoffStationOrderEdits}
                     upsertPlayoffStationOrderOverlay={upsertPlayoffStationOrderOverlay}
                     removePlayoffStationOrderOverlay={removePlayoffStationOrderOverlay}
+                    allianceSelectionArrays={allianceSelectionArrays}
                   />
                 }
               />
@@ -2581,6 +2592,10 @@ function App() {
                     adHocMatch={adHocMatch}
                     setAdHocMatch={setAdHocMatch}
                     adHocMode={adHocMode}
+                    adHocRedAlliance={adHocRedAlliance}
+                    setAdHocRedAlliance={setAdHocRedAlliance}
+                    adHocBlueAlliance={adHocBlueAlliance}
+                    setAdHocBlueAlliance={setAdHocBlueAlliance}
                     qualsLength={qualsLength}
                     playoffOnly={playoffOnly}
                     eventMessage={eventMessage}
@@ -2592,6 +2607,7 @@ function App() {
                     playoffStationOrderEdits={playoffStationOrderEdits}
                     upsertPlayoffStationOrderOverlay={upsertPlayoffStationOrderOverlay}
                     removePlayoffStationOrderOverlay={removePlayoffStationOrderOverlay}
+                    allianceSelectionArrays={allianceSelectionArrays}
                   />
                 }
               />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -303,7 +303,7 @@ function App() {
     rankingsOverride, setRankingsOverride,
     allianceCount, setAllianceCount,
     playoffCountOverride, setPlayoffCountOverride,
-    allianceSelectionRoundOrder, setAllianceSelectionRoundOrder,
+    _allianceSelectionRoundOrder, setAllianceSelectionRoundOrder,
     // Multi-screen sync
     syncEvent, setSyncEvent,
     screenMode, setScreenMode,

--- a/src/components/AdHocMatchModal.jsx
+++ b/src/components/AdHocMatchModal.jsx
@@ -1,30 +1,64 @@
-import { Row, Col, Modal, Container, Table } from "react-bootstrap";
+import { Row, Col, Modal, Container } from "react-bootstrap";
 import Select from "react-select";
 import _ from "lodash";
 import { useSettings } from "../contexts/SettingsContext";
 
-function adHocStation(adHocMatch, station, teamNumber, onStationChange) {
+function adHocStation(adHocMatch, station, teamNumber, onStationChange, useFourTeamAlliances) {
     var adHocMatchNew = _.cloneDeep(adHocMatch);
     if (_.isNull(adHocMatchNew)) {
-        adHocMatchNew = [
-            { teamNumber: null, station: "Red1", surrogate: false, dq: false },
-            { teamNumber: null, station: "Red2", surrogate: false, dq: false },
-            { teamNumber: null, station: "Red3", surrogate: false, dq: false },
-            { teamNumber: null, station: "Blue1", surrogate: false, dq: false },
-            { teamNumber: null, station: "Blue2", surrogate: false, dq: false },
-            { teamNumber: null, station: "Blue3", surrogate: false, dq: false },
-        ];
+        adHocMatchNew = useFourTeamAlliances
+            ? [
+                { teamNumber: null, station: "Red1", surrogate: false, dq: false },
+                { teamNumber: null, station: "Red2", surrogate: false, dq: false },
+                { teamNumber: null, station: "Red3", surrogate: false, dq: false },
+                { teamNumber: null, station: "Red4", surrogate: false, dq: false },
+                { teamNumber: null, station: "Blue1", surrogate: false, dq: false },
+                { teamNumber: null, station: "Blue2", surrogate: false, dq: false },
+                { teamNumber: null, station: "Blue3", surrogate: false, dq: false },
+                { teamNumber: null, station: "Blue4", surrogate: false, dq: false },
+            ]
+            : [
+                { teamNumber: null, station: "Red1", surrogate: false, dq: false },
+                { teamNumber: null, station: "Red2", surrogate: false, dq: false },
+                { teamNumber: null, station: "Red3", surrogate: false, dq: false },
+                { teamNumber: null, station: "Blue1", surrogate: false, dq: false },
+                { teamNumber: null, station: "Blue2", surrogate: false, dq: false },
+                { teamNumber: null, station: "Blue3", surrogate: false, dq: false },
+            ];
     }
-    adHocMatchNew[_.findIndex(adHocMatchNew, { station: station })].teamNumber = teamNumber;
+    const idx = _.findIndex(adHocMatchNew, { station: station });
+    if (idx === -1) {
+        adHocMatchNew.push({ teamNumber: teamNumber, station: station, surrogate: false, dq: false });
+    } else {
+        adHocMatchNew[idx].teamNumber = teamNumber;
+    }
     onStationChange(adHocMatchNew);
 }
 
 function AdHocMatchModal({ show, onHide, adHocMatch, onStationChange, eventTeams }) {
-    const { swapScreen } = useSettings();
+    const { swapScreen, useFourTeamAlliances } = useSettings();
 
     const handleChange = (station, e) => {
-        adHocStation(adHocMatch, station, e.value, onStationChange);
+        adHocStation(adHocMatch, station, e.value, onStationChange, useFourTeamAlliances);
     };
+
+    const stationValue = (station) => {
+        const entry = adHocMatch?.find((t) => t.station === station);
+        return entry?.teamNumber ? { value: entry.teamNumber, label: entry.teamNumber } : "";
+    };
+
+    const stationSelect = (label, station, tabIndex, bgColor) => (
+        <div style={{ backgroundColor: bgColor }}>
+            <b>{label}</b>{" "}
+            <Select
+                classNamePrefix="gatool-rs"
+                options={eventTeams}
+                tabIndex={tabIndex}
+                value={stationValue(station)}
+                onChange={(e) => { handleChange(station, e); }}
+            />
+        </div>
+    );
 
     return (
         <Modal centered={true} show={show} onHide={onHide}>
@@ -38,216 +72,80 @@ function AdHocMatchModal({ show, onHide, adHocMatch, onStationChange, eventTeams
                         <div className="gatool-awaiting-inline">Awaiting match data...</div>
                     )}
                     {!swapScreen && adHocMatch && (
-                        <Table>
+                        <div>
                             <Row>
                                 <Col className="blueAlliance">
-                                    <div style={{ backgroundColor: "#98B4F4" }}>
-                                        <b>Blue 1</b>{" "}
-                                        <Select
-                                            classNamePrefix="gatool-rs"
-                                            options={eventTeams}
-                                            tabIndex={4}
-                                            value={
-                                                adHocMatch[3]?.teamNumber
-                                                    ? { value: adHocMatch[3]?.teamNumber, label: adHocMatch[3]?.teamNumber }
-                                                    : ""
-                                            }
-                                            onChange={(e) => { handleChange("Blue1", e); }}
-                                        />
-                                    </div>
+                                    {stationSelect("Blue 1", "Blue1", 4, "#98B4F4")}
                                 </Col>
                                 <Col className="redAlliance">
-                                    <div style={{ backgroundColor: "#F7B3B4" }}>
-                                        <b>Red 3</b>{" "}
-                                        <Select
-                                            classNamePrefix="gatool-rs"
-                                            options={eventTeams}
-                                            tabIndex={3}
-                                            value={
-                                                adHocMatch[2]?.teamNumber
-                                                    ? { value: adHocMatch[2]?.teamNumber, label: adHocMatch[2]?.teamNumber }
-                                                    : ""
-                                            }
-                                            onChange={(e) => { handleChange("Red3", e); }}
-                                        />
-                                    </div>
+                                    {stationSelect("Red 3", "Red3", 3, "#F7B3B4")}
                                 </Col>
                             </Row>
                             <Row>
                                 <Col className="blueAlliance">
-                                    <div style={{ backgroundColor: "#98B4F4" }}>
-                                        <b>Blue 2</b>{" "}
-                                        <Select
-                                            classNamePrefix="gatool-rs"
-                                            options={eventTeams}
-                                            tabIndex={5}
-                                            value={
-                                                adHocMatch[4]?.teamNumber
-                                                    ? { value: adHocMatch[4]?.teamNumber, label: adHocMatch[4]?.teamNumber }
-                                                    : ""
-                                            }
-                                            onChange={(e) => { handleChange("Blue2", e); }}
-                                        />
-                                    </div>
+                                    {stationSelect("Blue 2", "Blue2", 5, "#98B4F4")}
                                 </Col>
                                 <Col className="redAlliance">
-                                    <div style={{ backgroundColor: "#F7B3B4" }}>
-                                        <b>Red 2</b>{" "}
-                                        <Select
-                                            classNamePrefix="gatool-rs"
-                                            options={eventTeams}
-                                            tabIndex={2}
-                                            value={
-                                                adHocMatch[1]?.teamNumber
-                                                    ? { value: adHocMatch[1]?.teamNumber, label: adHocMatch[1]?.teamNumber }
-                                                    : ""
-                                            }
-                                            onChange={(e) => { handleChange("Red2", e); }}
-                                        />
-                                    </div>
+                                    {stationSelect("Red 2", "Red2", 2, "#F7B3B4")}
                                 </Col>
                             </Row>
                             <Row>
                                 <Col className="blueAlliance">
-                                    <div style={{ backgroundColor: "#98B4F4" }}>
-                                        <b>Blue 3</b>{" "}
-                                        <Select
-                                            classNamePrefix="gatool-rs"
-                                            options={eventTeams}
-                                            tabIndex={6}
-                                            value={
-                                                adHocMatch[5]?.teamNumber
-                                                    ? { value: adHocMatch[5]?.teamNumber, label: adHocMatch[5]?.teamNumber }
-                                                    : ""
-                                            }
-                                            onChange={(e) => { handleChange("Blue3", e); }}
-                                        />
-                                    </div>
+                                    {stationSelect("Blue 3", "Blue3", 6, "#98B4F4")}
                                 </Col>
                                 <Col className="redAlliance">
-                                    <div style={{ backgroundColor: "#F7B3B4" }}>
-                                        <b>Red 1</b>
-                                        <Select
-                                            classNamePrefix="gatool-rs"
-                                            options={eventTeams}
-                                            tabIndex={1}
-                                            value={
-                                                adHocMatch[0]?.teamNumber
-                                                    ? { value: adHocMatch[0]?.teamNumber, label: adHocMatch[0]?.teamNumber }
-                                                    : ""
-                                            }
-                                            onChange={(e) => { handleChange("Red1", e); }}
-                                        />
-                                    </div>
+                                    {stationSelect("Red 1", "Red1", 1, "#F7B3B4")}
                                 </Col>
                             </Row>
-                        </Table>
+                            {useFourTeamAlliances && (
+                                <Row>
+                                    <Col className="blueAlliance">
+                                        {stationSelect("Blue 4", "Blue4", 7, "#98B4F4")}
+                                    </Col>
+                                    <Col className="redAlliance">
+                                        {stationSelect("Red 4", "Red4", 8, "#F7B3B4")}
+                                    </Col>
+                                </Row>
+                            )}
+                        </div>
                     )}
                     {swapScreen && adHocMatch && (
-                        <Table>
+                        <div>
                             <Row>
                                 <Col className="redAlliance">
-                                    <div style={{ backgroundColor: "#F7B3B4" }}>
-                                        <b>Red 3</b>{" "}
-                                        <Select
-                                            classNamePrefix="gatool-rs"
-                                            options={eventTeams}
-                                            tabIndex={4}
-                                            value={
-                                                adHocMatch[2]?.teamNumber
-                                                    ? { value: adHocMatch[2]?.teamNumber, label: adHocMatch[2]?.teamNumber }
-                                                    : ""
-                                            }
-                                            onChange={(e) => { handleChange("Red3", e); }}
-                                        />
-                                    </div>
+                                    {stationSelect("Red 3", "Red3", 4, "#F7B3B4")}
                                 </Col>
                                 <Col className="blueAlliance">
-                                    <div style={{ backgroundColor: "#98B4F4" }}>
-                                        <b>Blue 1</b>{" "}
-                                        <Select
-                                            classNamePrefix="gatool-rs"
-                                            options={eventTeams}
-                                            tabIndex={3}
-                                            value={
-                                                adHocMatch[3]?.teamNumber
-                                                    ? { value: adHocMatch[3]?.teamNumber, label: adHocMatch[3]?.teamNumber }
-                                                    : ""
-                                            }
-                                            onChange={(e) => { handleChange("Blue1", e); }}
-                                        />
-                                    </div>
+                                    {stationSelect("Blue 1", "Blue1", 3, "#98B4F4")}
                                 </Col>
                             </Row>
                             <Row>
                                 <Col className="redAlliance">
-                                    <div style={{ backgroundColor: "#F7B3B4" }}>
-                                        <b>Red 2</b>{" "}
-                                        <Select
-                                            classNamePrefix="gatool-rs"
-                                            options={eventTeams}
-                                            tabIndex={5}
-                                            value={
-                                                adHocMatch[1]?.teamNumber
-                                                    ? { value: adHocMatch[1]?.teamNumber, label: adHocMatch[1]?.teamNumber }
-                                                    : ""
-                                            }
-                                            onChange={(e) => { handleChange("Red2", e); }}
-                                        />
-                                    </div>
+                                    {stationSelect("Red 2", "Red2", 5, "#F7B3B4")}
                                 </Col>
                                 <Col className="blueAlliance">
-                                    <div style={{ backgroundColor: "#98B4F4" }}>
-                                        <b>Blue 2</b>{" "}
-                                        <Select
-                                            classNamePrefix="gatool-rs"
-                                            options={eventTeams}
-                                            tabIndex={2}
-                                            value={
-                                                adHocMatch[4]?.teamNumber
-                                                    ? { value: adHocMatch[4]?.teamNumber, label: adHocMatch[4]?.teamNumber }
-                                                    : ""
-                                            }
-                                            onChange={(e) => { handleChange("Blue2", e); }}
-                                        />
-                                    </div>
+                                    {stationSelect("Blue 2", "Blue2", 2, "#98B4F4")}
                                 </Col>
                             </Row>
                             <Row>
                                 <Col className="redAlliance">
-                                    <div style={{ backgroundColor: "#F7B3B4" }}>
-                                        <b>Red 1</b>
-                                        <Select
-                                            classNamePrefix="gatool-rs"
-                                            options={eventTeams}
-                                            tabIndex={6}
-                                            value={
-                                                adHocMatch[0]?.teamNumber
-                                                    ? { value: adHocMatch[0]?.teamNumber, label: adHocMatch[0]?.teamNumber }
-                                                    : ""
-                                            }
-                                            onChange={(e) => { handleChange("Red1", e); }}
-                                        />
-                                    </div>
+                                    {stationSelect("Red 1", "Red1", 6, "#F7B3B4")}
                                 </Col>
                                 <Col className="blueAlliance">
-                                    <div style={{ backgroundColor: "#98B4F4" }}>
-                                        <b>Blue 3</b>{" "}
-                                        <Select
-                                            classNamePrefix="gatool-rs"
-                                            options={eventTeams}
-                                            tabIndex={1}
-                                            value={
-                                                adHocMatch[5]?.teamNumber
-                                                    ? { value: adHocMatch[5]?.teamNumber, label: adHocMatch[5]?.teamNumber }
-                                                    : ""
-                                            }
-                                            onChange={(e) => { handleChange("Blue3", e); }}
-                                        />
-                                    </div>
+                                    {stationSelect("Blue 3", "Blue3", 1, "#98B4F4")}
                                 </Col>
                             </Row>
-                        </Table>
+                            {useFourTeamAlliances && (
+                                <Row>
+                                    <Col className="redAlliance">
+                                        {stationSelect("Red 4", "Red4", 8, "#F7B3B4")}
+                                    </Col>
+                                    <Col className="blueAlliance">
+                                        {stationSelect("Blue 4", "Blue4", 7, "#98B4F4")}
+                                    </Col>
+                                </Row>
+                            )}
+                        </div>
                     )}
                 </Container>
             </Modal.Body>

--- a/src/components/AdHocMatchModal.jsx
+++ b/src/components/AdHocMatchModal.jsx
@@ -1,7 +1,60 @@
+import { useState, useEffect } from "react";
 import { Row, Col, Modal, Container } from "react-bootstrap";
 import Select from "react-select";
 import _ from "lodash";
+import { GripVertical } from "react-bootstrap-icons";
 import { useSettings } from "../contexts/SettingsContext";
+import {
+    DndContext,
+    closestCenter,
+    PointerSensor,
+    TouchSensor,
+    useSensor,
+    useSensors,
+} from "@dnd-kit/core";
+import {
+    arrayMove,
+    SortableContext,
+    useSortable,
+    verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+// ─── Sortable team row ────────────────────────────────────────────────────────
+
+function SortableAllianceMember({ id, teamNumber, role, stationLabel, color }) {
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+        useSortable({ id });
+    const bgColor = color === "Red" ? "#F7B3B4" : "#98B4F4";
+    const borderColor = color === "Red" ? "#c08080" : "#8090c8";
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.55 : 1,
+        backgroundColor: bgColor,
+        border: `1px solid ${borderColor}`,
+        borderRadius: "4px",
+        padding: "6px 10px",
+        marginBottom: "6px",
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+    };
+    return (
+        <div ref={setNodeRef} style={style}>
+            <span style={{ cursor: "grab", color: "#555", flexShrink: 0 }} {...attributes} {...listeners}>
+                <GripVertical size={16} />
+            </span>
+            <div style={{ minWidth: 0 }}>
+                <small className="text-muted d-block">{stationLabel}</small>
+                <strong>Team {teamNumber}</strong>
+                <small className="d-block text-muted">{role}</small>
+            </div>
+        </div>
+    );
+}
+
+// ─── adHocStation helper ──────────────────────────────────────────────────────
 
 function adHocStation(adHocMatch, station, teamNumber, onStationChange, useFourTeamAlliances) {
     var adHocMatchNew = _.cloneDeep(adHocMatch);
@@ -35,8 +88,189 @@ function adHocStation(adHocMatch, station, teamNumber, onStationChange, useFourT
     onStationChange(adHocMatchNew);
 }
 
-function AdHocMatchModal({ show, onHide, adHocMatch, onStationChange, eventTeams }) {
+// ─── Main component ───────────────────────────────────────────────────────────
+
+function AdHocMatchModal({ show, onHide, adHocMatch, onStationChange, eventTeams, allianceSelectionArrays, alliances, selectedRedAlliance, setSelectedRedAlliance, selectedBlueAlliance, setSelectedBlueAlliance }) {
     const { swapScreen, useFourTeamAlliances } = useSettings();
+
+    const [redSortItems, setRedSortItems] = useState([]);
+    const [blueSortItems, setBlueSortItems] = useState([]);
+
+    // DnD sensors — must always be called (hooks rules)
+    const sensors = useSensors(
+        useSensor(PointerSensor),
+        useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } })
+    );
+
+    // Normalize API alliance format (raw numbers) to tool format ({ teamNumber: N } objects)
+    const normalizeApiAlliance = (a) => ({
+        number: a.number,
+        name: a.name || `Alliance ${a.number}`,
+        captain: a.captain != null ? { teamNumber: Number(a.captain) } : null,
+        round1: a.round1 != null ? { teamNumber: Number(a.round1) } : null,
+        round2: a.round2 != null ? { teamNumber: Number(a.round2) } : null,
+        round3: a.round3 != null ? { teamNumber: Number(a.round3) } : null,
+    });
+
+    const rawAlliances = (allianceSelectionArrays?.alliances?.length > 0)
+        ? allianceSelectionArrays.alliances
+        : (alliances?.alliances || []).map(normalizeApiAlliance);
+
+    const qualifiedAlliances = rawAlliances.filter(
+        (a) => a.captain?.teamNumber && a.round1?.teamNumber && a.round2?.teamNumber
+    );
+    const hasAlliances = qualifiedAlliances.length > 0;
+
+    // Build a role map for an alliance: teamNumber → role label
+    const buildRoleMap = (alliance) => {
+        if (!alliance) return {};
+        const map = {};
+        if (alliance.captain?.teamNumber) map[alliance.captain.teamNumber] = "Captain";
+        if (alliance.round1?.teamNumber) map[alliance.round1.teamNumber] = "Round 1 Selection";
+        if (alliance.round2?.teamNumber) map[alliance.round2.teamNumber] = "Round 2 Selection";
+        if (alliance.round3?.teamNumber) map[alliance.round3.teamNumber] = "Round 3 Selection";
+        return map;
+    };
+
+    // Build sort items for a color by reading current station assignments from adHocMatch
+    const buildSortItems = (color, allianceNumber, currentMatch) => {
+        const alliance = qualifiedAlliances.find((a) => a.number === allianceNumber);
+        if (!alliance) return [];
+        const roles = buildRoleMap(alliance);
+        // Red physical field order: Station 3 (top) → Station 2 → Station 1 (bottom) → Reserve
+        const stations = color === "Red"
+            ? ["Red3", "Red2", "Red1", "Red4"]
+            : ["Blue1", "Blue2", "Blue3", "Blue4"];
+        return stations
+            .map((station) => {
+                const entry = currentMatch?.find((t) => t.station === station);
+                if (!entry?.teamNumber) return null;
+                return {
+                    id: _.uniqueId(`${color.toLowerCase()}_`),
+                    teamNumber: entry.teamNumber,
+                    role: roles[entry.teamNumber] || "Member",
+                };
+            })
+            .filter(Boolean);
+    };
+
+    // Re-sync sort items when modal is re-opened with a saved alliance selection
+    useEffect(() => {
+        if (show) {
+            if (selectedRedAlliance) {
+                setRedSortItems(buildSortItems("Red", selectedRedAlliance, adHocMatch));
+            }
+            if (selectedBlueAlliance) {
+                setBlueSortItems(buildSortItems("Blue", selectedBlueAlliance, adHocMatch));
+            }
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [show]);
+
+    // Alliance dropdown options, excluding the alliance chosen on the other side
+    const buildAllianceOptions = (excludeAllianceNumber) => [
+        { value: null, label: "No Alliance" },
+        ...qualifiedAlliances
+            .filter((a) => a.number !== excludeAllianceNumber)
+            .map((a) => {
+                const members = [a.captain?.teamNumber, a.round1?.teamNumber, a.round2?.teamNumber];
+                if (useFourTeamAlliances && a.round3?.teamNumber) members.push(a.round3.teamNumber);
+                return { value: a.number, label: `${a.name}: ${members.join(", ")}` };
+            }),
+    ];
+
+    // Apply an alliance to a color in adHocMatch, returning the new match array
+    const applyAllianceToColor = (color, allianceNumber, currentMatch) => {
+        const alliance = qualifiedAlliances.find((a) => a.number === allianceNumber);
+        let newMatch = _.cloneDeep(currentMatch);
+        if (!newMatch) {
+            newMatch = useFourTeamAlliances
+                ? [
+                    { teamNumber: null, station: "Red1", surrogate: false, dq: false },
+                    { teamNumber: null, station: "Red2", surrogate: false, dq: false },
+                    { teamNumber: null, station: "Red3", surrogate: false, dq: false },
+                    { teamNumber: null, station: "Red4", surrogate: false, dq: false },
+                    { teamNumber: null, station: "Blue1", surrogate: false, dq: false },
+                    { teamNumber: null, station: "Blue2", surrogate: false, dq: false },
+                    { teamNumber: null, station: "Blue3", surrogate: false, dq: false },
+                    { teamNumber: null, station: "Blue4", surrogate: false, dq: false },
+                ]
+                : [
+                    { teamNumber: null, station: "Red1", surrogate: false, dq: false },
+                    { teamNumber: null, station: "Red2", surrogate: false, dq: false },
+                    { teamNumber: null, station: "Red3", surrogate: false, dq: false },
+                    { teamNumber: null, station: "Blue1", surrogate: false, dq: false },
+                    { teamNumber: null, station: "Blue2", surrogate: false, dq: false },
+                    { teamNumber: null, station: "Blue3", surrogate: false, dq: false },
+                ];
+        }
+        const stations = color === "Red"
+            ? ["Red1", "Red2", "Red3", "Red4"]
+            : ["Blue1", "Blue2", "Blue3", "Blue4"];
+        const members = alliance
+            ? [
+                alliance.captain?.teamNumber || null,
+                alliance.round1?.teamNumber || null,
+                alliance.round2?.teamNumber || null,
+                useFourTeamAlliances ? (alliance.round3?.teamNumber || null) : null,
+            ]
+            : [null, null, null, null];
+        stations.forEach((station, i) => {
+            const teamNumber = members[i] || null;
+            const idx = _.findIndex(newMatch, { station });
+            if (idx === -1) {
+                if (teamNumber) newMatch.push({ teamNumber, station, surrogate: false, dq: false });
+            } else {
+                newMatch[idx].teamNumber = teamNumber;
+            }
+        });
+        return newMatch;
+    };
+
+    const handleAllianceChange = (color, opt) => {
+        const allianceNumber = opt?.value ?? null;
+        if (color === "Red") setSelectedRedAlliance(allianceNumber);
+        else setSelectedBlueAlliance(allianceNumber);
+
+        const newMatch = applyAllianceToColor(color, allianceNumber, adHocMatch);
+        onStationChange(newMatch);
+
+        if (allianceNumber) {
+            const items = buildSortItems(color, allianceNumber, newMatch);
+            if (color === "Red") setRedSortItems(items);
+            else setBlueSortItems(items);
+        } else {
+            if (color === "Red") setRedSortItems([]);
+            else setBlueSortItems([]);
+        }
+    };
+
+    const handleDragEnd = (color) => (event) => {
+        const { active, over } = event;
+        if (!over || active.id === over.id) return;
+        const items = color === "Red" ? redSortItems : blueSortItems;
+        const oldIndex = items.findIndex((i) => i.id === active.id);
+        const newIndex = items.findIndex((i) => i.id === over.id);
+        const newItems = arrayMove(items, oldIndex, newIndex);
+        if (color === "Red") setRedSortItems(newItems);
+        else setBlueSortItems(newItems);
+
+        // Write reordered team numbers back to adHocMatch (Red uses reversed physical order)
+        const stations = color === "Red"
+            ? ["Red3", "Red2", "Red1", "Red4"]
+            : ["Blue1", "Blue2", "Blue3", "Blue4"];
+        const newMatch = _.cloneDeep(adHocMatch);
+        newItems.forEach((item, index) => {
+            const idx = _.findIndex(newMatch, { station: stations[index] });
+            if (idx >= 0) newMatch[idx].teamNumber = item.teamNumber;
+        });
+        // Clear stations beyond the sorted items count
+        for (let i = newItems.length; i < stations.length; i++) {
+            const idx = _.findIndex(newMatch, { station: stations[i] });
+            if (idx >= 0) newMatch[idx].teamNumber = null;
+        }
+        onStationChange(newMatch);
+    };
 
     const handleChange = (station, e) => {
         adHocStation(adHocMatch, station, e.value, onStationChange, useFourTeamAlliances);
@@ -60,6 +294,80 @@ function AdHocMatchModal({ show, onHide, adHocMatch, onStationChange, eventTeams
         </div>
     );
 
+    const allianceDropdown = (color, bgColor) => {
+        const isRed = color === "Red";
+        const selected = isRed ? selectedRedAlliance : selectedBlueAlliance;
+        const exclude = isRed ? selectedBlueAlliance : selectedRedAlliance;
+        const options = buildAllianceOptions(exclude);
+        const currentValue = options.find((o) => o.value === selected) || options[0];
+        return (
+            <div style={{ backgroundColor: bgColor, marginBottom: "8px" }}>
+                <b>{color} Alliance</b>{" "}
+                <Select
+                    classNamePrefix="gatool-rs"
+                    options={options}
+                    value={currentValue}
+                    onChange={(opt) => handleAllianceChange(color, opt)}
+                />
+            </div>
+        );
+    };
+
+    // A column's team UI: reorder list when alliance chosen, individual selects otherwise
+    const stationSelects = (color, bgColor, stations) => {
+        const isRed = color === "Red";
+        const selectedAlliance = isRed ? selectedRedAlliance : selectedBlueAlliance;
+        const sortItems = isRed ? redSortItems : blueSortItems;
+
+        if (selectedAlliance && sortItems.length > 0) {
+            const stationLabels = isRed
+                ? ["Station 3", "Station 2", "Station 1", "Reserve team"]
+                : ["Station 1", "Station 2", "Station 3", "Reserve team"];
+            return (
+                <DndContext
+                    sensors={sensors}
+                    collisionDetection={closestCenter}
+                    onDragEnd={handleDragEnd(color)}
+                >
+                    <SortableContext
+                        items={sortItems.map((i) => i.id)}
+                        strategy={verticalListSortingStrategy}
+                    >
+                        {sortItems.map((item, index) => (
+                            <SortableAllianceMember
+                                key={item.id}
+                                id={item.id}
+                                teamNumber={item.teamNumber}
+                                role={item.role}
+                                stationLabel={stationLabels[index]}
+                                color={color}
+                            />
+                        ))}
+                    </SortableContext>
+                </DndContext>
+            );
+        }
+
+        return stations.map(([label, station, tabIndex]) =>
+            stationSelect(label, station, tabIndex, bgColor)
+        );
+    };
+
+    // Station order definitions (label, station name, tabIndex)
+    // Red is reversed to match physical field layout: Station 3 (top) → Station 2 → Station 1 → Reserve team
+    const blueStations = [
+        ["Blue 1", "Blue1", 4],
+        ["Blue 2", "Blue2", 5],
+        ["Blue 3", "Blue3", 6],
+        ...(useFourTeamAlliances ? [["Reserve team", "Blue4", 7]] : []),
+    ];
+    const redStations = [
+        ["Red 3", "Red3", 3],
+        ["Red 2", "Red2", 2],
+        ["Red 1", "Red1", 1],
+        ...(useFourTeamAlliances ? [["Reserve team", "Red4", 8]] : []),
+    ];
+
     return (
         <Modal centered={true} show={show} onHide={onHide}>
             <Modal.Header className={"promoteBackup"} closeButton closeVariant="white">
@@ -67,85 +375,29 @@ function AdHocMatchModal({ show, onHide, adHocMatch, onStationChange, eventTeams
             </Modal.Header>
             <Modal.Body>
                 <Container>
-                    {adHocMatch && <div>Select teams for each station below.</div>}
+                    {adHocMatch && <div style={{ marginBottom: "8px" }}>Select teams for each station below.</div>}
                     {!adHocMatch && (
                         <div className="gatool-awaiting-inline">Awaiting match data...</div>
                     )}
-                    {!swapScreen && adHocMatch && (
-                        <div>
-                            <Row>
-                                <Col className="blueAlliance">
-                                    {stationSelect("Blue 1", "Blue1", 4, "#98B4F4")}
-                                </Col>
-                                <Col className="redAlliance">
-                                    {stationSelect("Red 3", "Red3", 3, "#F7B3B4")}
-                                </Col>
-                            </Row>
-                            <Row>
-                                <Col className="blueAlliance">
-                                    {stationSelect("Blue 2", "Blue2", 5, "#98B4F4")}
-                                </Col>
-                                <Col className="redAlliance">
-                                    {stationSelect("Red 2", "Red2", 2, "#F7B3B4")}
-                                </Col>
-                            </Row>
-                            <Row>
-                                <Col className="blueAlliance">
-                                    {stationSelect("Blue 3", "Blue3", 6, "#98B4F4")}
-                                </Col>
-                                <Col className="redAlliance">
-                                    {stationSelect("Red 1", "Red1", 1, "#F7B3B4")}
-                                </Col>
-                            </Row>
-                            {useFourTeamAlliances && (
-                                <Row>
-                                    <Col className="blueAlliance">
-                                        {stationSelect("Blue 4", "Blue4", 7, "#98B4F4")}
-                                    </Col>
-                                    <Col className="redAlliance">
-                                        {stationSelect("Red 4", "Red4", 8, "#F7B3B4")}
-                                    </Col>
-                                </Row>
-                            )}
-                        </div>
-                    )}
-                    {swapScreen && adHocMatch && (
-                        <div>
-                            <Row>
-                                <Col className="redAlliance">
-                                    {stationSelect("Red 3", "Red3", 4, "#F7B3B4")}
-                                </Col>
-                                <Col className="blueAlliance">
-                                    {stationSelect("Blue 1", "Blue1", 3, "#98B4F4")}
-                                </Col>
-                            </Row>
-                            <Row>
-                                <Col className="redAlliance">
-                                    {stationSelect("Red 2", "Red2", 5, "#F7B3B4")}
-                                </Col>
-                                <Col className="blueAlliance">
-                                    {stationSelect("Blue 2", "Blue2", 2, "#98B4F4")}
-                                </Col>
-                            </Row>
-                            <Row>
-                                <Col className="redAlliance">
-                                    {stationSelect("Red 1", "Red1", 6, "#F7B3B4")}
-                                </Col>
-                                <Col className="blueAlliance">
-                                    {stationSelect("Blue 3", "Blue3", 1, "#98B4F4")}
-                                </Col>
-                            </Row>
-                            {useFourTeamAlliances && (
-                                <Row>
-                                    <Col className="redAlliance">
-                                        {stationSelect("Red 4", "Red4", 8, "#F7B3B4")}
-                                    </Col>
-                                    <Col className="blueAlliance">
-                                        {stationSelect("Blue 4", "Blue4", 7, "#98B4F4")}
-                                    </Col>
-                                </Row>
-                            )}
-                        </div>
+                    {adHocMatch && (
+                        <Row>
+                            <Col className={`${swapScreen ? "redAlliance" : "blueAlliance"}`}>
+                                {hasAlliances && allianceDropdown(swapScreen ? "Red" : "Blue", swapScreen ? "#F7B3B4" : "#98B4F4")}
+                                {stationSelects(
+                                    swapScreen ? "Red" : "Blue",
+                                    swapScreen ? "#F7B3B4" : "#98B4F4",
+                                    swapScreen ? redStations : blueStations
+                                )}
+                            </Col>
+                            <Col className={`${swapScreen ? "blueAlliance" : "redAlliance"}`}>
+                                {hasAlliances && allianceDropdown(swapScreen ? "Blue" : "Red", swapScreen ? "#98B4F4" : "#F7B3B4")}
+                                {stationSelects(
+                                    swapScreen ? "Blue" : "Red",
+                                    swapScreen ? "#98B4F4" : "#F7B3B4",
+                                    swapScreen ? blueStations : redStations
+                                )}
+                            </Col>
+                        </Row>
                     )}
                 </Container>
             </Modal.Body>

--- a/src/components/AdHocMatchModal.jsx
+++ b/src/components/AdHocMatchModal.jsx
@@ -349,7 +349,7 @@ function AdHocMatchModal({ show, onHide, adHocMatch, onStationChange, eventTeams
         }
 
         return stations.map(([label, station, tabIndex]) =>
-            stationSelect(label, station, tabIndex, bgColor)
+            <div key={station}>{stationSelect(label, station, tabIndex, bgColor)}</div>
         );
     };
 

--- a/src/components/AdHocMatchModal.test.jsx
+++ b/src/components/AdHocMatchModal.test.jsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import AdHocMatchModal from "./AdHocMatchModal";
+
+// Stub out SettingsContext so the component doesn't need a full provider
+vi.mock("../contexts/SettingsContext", () => ({
+    useSettings: () => ({ swapScreen: false, useFourTeamAlliances: false }),
+}));
+
+// ─── Fixture builders ─────────────────────────────────────────────────────────
+
+function makeMatch() {
+    return [
+        { teamNumber: 1234, station: "Red1", surrogate: false, dq: false },
+        { teamNumber: 2345, station: "Red2", surrogate: false, dq: false },
+        { teamNumber: 3456, station: "Red3", surrogate: false, dq: false },
+        { teamNumber: 4567, station: "Blue1", surrogate: false, dq: false },
+        { teamNumber: 5678, station: "Blue2", surrogate: false, dq: false },
+        { teamNumber: 6789, station: "Blue3", surrogate: false, dq: false },
+    ];
+}
+
+/** API alliance format — members are raw numbers (as returned by useRankingsAlliances) */
+function makeApiAlliances() {
+    return {
+        alliances: [
+            { number: 1, name: "Alliance 1", captain: 1234, round1: 2345, round2: 3456, round3: null },
+            { number: 2, name: "Alliance 2", captain: 4567, round1: 5678, round2: 6789, round3: null },
+        ],
+    };
+}
+
+/** Tool alliance format — members are objects with teamNumber property */
+function makeToolAlliances() {
+    return {
+        alliances: [
+            {
+                number: 1,
+                name: "Alliance 1",
+                captain: { teamNumber: 1234 },
+                round1: { teamNumber: 2345 },
+                round2: { teamNumber: 3456 },
+            },
+            {
+                number: 2,
+                name: "Alliance 2",
+                captain: { teamNumber: 4567 },
+                round1: { teamNumber: 5678 },
+                round2: { teamNumber: 6789 },
+            },
+        ],
+    };
+}
+
+function baseProps(overrides = {}) {
+    return {
+        show: true,
+        onHide: vi.fn(),
+        adHocMatch: makeMatch(),
+        onStationChange: vi.fn(),
+        eventTeams: [],
+        allianceSelectionArrays: {},
+        alliances: null,
+        selectedRedAlliance: null,
+        setSelectedRedAlliance: vi.fn(),
+        selectedBlueAlliance: null,
+        setSelectedBlueAlliance: vi.fn(),
+        ...overrides,
+    };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("AdHocMatchModal – alliance dropdown visibility", () => {
+    it("shows alliance dropdowns when API alliances are present and tool alliances are absent", () => {
+        render(<AdHocMatchModal {...baseProps({ alliances: makeApiAlliances() })} />);
+        expect(screen.getByText("Red Alliance")).toBeInTheDocument();
+        expect(screen.getByText("Blue Alliance")).toBeInTheDocument();
+    });
+
+    it("shows alliance dropdowns when tool allianceSelectionArrays are present", () => {
+        render(<AdHocMatchModal {...baseProps({ allianceSelectionArrays: makeToolAlliances() })} />);
+        expect(screen.getByText("Red Alliance")).toBeInTheDocument();
+        expect(screen.getByText("Blue Alliance")).toBeInTheDocument();
+    });
+
+    it("hides alliance dropdowns when no alliances are available", () => {
+        render(<AdHocMatchModal {...baseProps()} />);
+        expect(screen.queryByText("Red Alliance")).not.toBeInTheDocument();
+        expect(screen.queryByText("Blue Alliance")).not.toBeInTheDocument();
+    });
+
+    it("prefers tool alliances over API alliances when both are provided", () => {
+        // When tool alliances are present, they take priority. Verify dropdown appears.
+        const toolAlliances = {
+            alliances: [
+                {
+                    number: 1,
+                    name: "Tool Alliance 1",
+                    captain: { teamNumber: 1234 },
+                    round1: { teamNumber: 2345 },
+                    round2: { teamNumber: 3456 },
+                },
+            ],
+        };
+        const apiAlliances = makeApiAlliances();
+        render(
+            <AdHocMatchModal
+                {...baseProps({ allianceSelectionArrays: toolAlliances, alliances: apiAlliances })}
+            />
+        );
+        expect(screen.getByText("Red Alliance")).toBeInTheDocument();
+        expect(screen.getByText("Blue Alliance")).toBeInTheDocument();
+    });
+
+    it("hides alliance dropdowns when API alliances are incomplete (missing round2)", () => {
+        const incompleteApiAlliances = {
+            alliances: [
+                { number: 1, name: "Alliance 1", captain: 1234, round1: 2345, round2: null },
+            ],
+        };
+        render(<AdHocMatchModal {...baseProps({ alliances: incompleteApiAlliances })} />);
+        expect(screen.queryByText("Red Alliance")).not.toBeInTheDocument();
+    });
+
+    it("hides alliance dropdowns when API alliances array is empty", () => {
+        render(<AdHocMatchModal {...baseProps({ alliances: { alliances: [] } })} />);
+        expect(screen.queryByText("Red Alliance")).not.toBeInTheDocument();
+    });
+});
+
+describe("AdHocMatchModal – API alliance normalization", () => {
+    it("normalizes string team numbers from API to integers", () => {
+        const apiAlliancesWithStrings = {
+            alliances: [
+                { number: 1, name: "Alliance 1", captain: "1234", round1: "2345", round2: "3456" },
+                { number: 2, name: "Alliance 2", captain: "4567", round1: "5678", round2: "6789" },
+            ],
+        };
+        render(<AdHocMatchModal {...baseProps({ alliances: apiAlliancesWithStrings })} />);
+        // If normalization works, alliances are qualified and dropdowns appear
+        expect(screen.getByText("Red Alliance")).toBeInTheDocument();
+    });
+
+    it("uses fallback name 'Alliance N' when API alliance has no name", () => {
+        // An alliance without a name field should still qualify and show the dropdown
+        const unnamedApiAlliances = {
+            alliances: [
+                { number: 3, captain: 1234, round1: 2345, round2: 3456 },
+            ],
+        };
+        render(<AdHocMatchModal {...baseProps({ alliances: unnamedApiAlliances })} />);
+        expect(screen.getByText("Red Alliance")).toBeInTheDocument();
+        expect(screen.getByText("Blue Alliance")).toBeInTheDocument();
+    });
+
+    it("does not crash when alliances prop is null", () => {
+        expect(() =>
+            render(<AdHocMatchModal {...baseProps({ alliances: null })} />)
+        ).not.toThrow();
+    });
+
+    it("does not crash when alliances.alliances is undefined", () => {
+        expect(() =>
+            render(<AdHocMatchModal {...baseProps({ alliances: {} })} />)
+        ).not.toThrow();
+    });
+});
+
+describe("AdHocMatchModal – match data rendering", () => {
+    it("shows 'Awaiting match data' when adHocMatch is null", () => {
+        render(<AdHocMatchModal {...baseProps({ adHocMatch: null })} />);
+        expect(screen.getByText(/Awaiting match data/i)).toBeInTheDocument();
+    });
+
+    it("shows station instruction text when adHocMatch is provided", () => {
+        render(<AdHocMatchModal {...baseProps()} />);
+        expect(screen.getByText(/Select teams for each station/i)).toBeInTheDocument();
+    });
+});

--- a/src/components/AdHocMatchModal.test.jsx
+++ b/src/components/AdHocMatchModal.test.jsx
@@ -167,6 +167,88 @@ describe("AdHocMatchModal – API alliance normalization", () => {
     });
 });
 
+describe("AdHocMatchModal – API alliance normalization (round3)", () => {
+    it("normalizes a non-null round3 from API format", () => {
+        const apiAlliancesWithRound3 = {
+            alliances: [
+                { number: 1, name: "Alliance 1", captain: 1234, round1: 2345, round2: 3456, round3: 9999 },
+            ],
+        };
+        render(<AdHocMatchModal {...baseProps({ alliances: apiAlliancesWithRound3 })} />);
+        expect(screen.getByText("Red Alliance")).toBeInTheDocument();
+    });
+});
+
+describe("AdHocMatchModal – reorder mode (alliance selected)", () => {
+    it("renders sortable team rows when red alliance is pre-selected", () => {
+        // When selectedRedAlliance is set, buildSortItems and buildRoleMap are invoked
+        // via the useEffect on show, and SortableAllianceMember rows render.
+        const toolAlliances = makeToolAlliances();
+        render(
+            <AdHocMatchModal
+                {...baseProps({
+                    allianceSelectionArrays: toolAlliances,
+                    selectedRedAlliance: 1,
+                })}
+            />
+        );
+        // In reorder mode, team numbers appear as "Team XXXX"
+        expect(screen.getByText("Team 1234")).toBeInTheDocument();
+        expect(screen.getByText("Captain")).toBeInTheDocument();
+        expect(screen.getByText("Team 2345")).toBeInTheDocument();
+        expect(screen.getByText("Round 1 Selection")).toBeInTheDocument();
+        expect(screen.getByText("Team 3456")).toBeInTheDocument();
+        expect(screen.getByText("Round 2 Selection")).toBeInTheDocument();
+    });
+
+    it("renders sortable team rows when blue alliance is pre-selected", () => {
+        const toolAlliances = makeToolAlliances();
+        render(
+            <AdHocMatchModal
+                {...baseProps({
+                    allianceSelectionArrays: toolAlliances,
+                    selectedBlueAlliance: 2,
+                })}
+            />
+        );
+        expect(screen.getByText("Team 4567")).toBeInTheDocument();
+        expect(screen.getByText("Team 5678")).toBeInTheDocument();
+        expect(screen.getByText("Team 6789")).toBeInTheDocument();
+    });
+
+    it("renders reorder mode with round3 team when four-team alliances are configured", () => {
+        // Override useSettings to enable useFourTeamAlliances
+        // We can't re-mock here, so use an alliance with round3 and verify non-crash + team shown
+        const toolAlliancesWithRound3 = {
+            alliances: [
+                {
+                    number: 1,
+                    name: "Alliance 1",
+                    captain: { teamNumber: 1234 },
+                    round1: { teamNumber: 2345 },
+                    round2: { teamNumber: 3456 },
+                    round3: { teamNumber: 7890 },
+                },
+            ],
+        };
+        const matchWithReserve = [
+            ...makeMatch(),
+            { teamNumber: 7890, station: "Red4", surrogate: false, dq: false },
+        ];
+        expect(() =>
+            render(
+                <AdHocMatchModal
+                    {...baseProps({
+                        allianceSelectionArrays: toolAlliancesWithRound3,
+                        adHocMatch: matchWithReserve,
+                        selectedRedAlliance: 1,
+                    })}
+                />
+            )
+        ).not.toThrow();
+    });
+});
+
 describe("AdHocMatchModal – match data rendering", () => {
     it("shows 'Awaiting match data' when adHocMatch is null", () => {
         render(<AdHocMatchModal {...baseProps({ adHocMatch: null })} />);

--- a/src/components/AllianceSelection.jsx
+++ b/src/components/AllianceSelection.jsx
@@ -6,6 +6,7 @@ import { useHotkeysContext, useHotkeys } from "react-hotkeys-hook";
 import { useEffect } from "react";
 import { originalAndSustaining, allianceSelectionBaseRounds } from "../data/appConfig";
 import useWindowDimensions from "hooks/UseWindowDimensions";
+import { useSettings } from "../contexts/SettingsContext";
 
 const ALLIANCE_DECLINED_TITLE =
     "Not eligible to be selected (previously declined an alliance offer).";
@@ -20,6 +21,7 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
     const [allianceMode, setAllianceMode] = useState(null);
     const { disableScope, enableScope } = useHotkeysContext();
     const { width } = useWindowDimensions();
+    const { allianceSelectionRoundOrder } = useSettings();
 
 
     var availColumns = [[], [], [], [], []];
@@ -66,13 +68,23 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
         }
     }
 
+    const buildRoundSequence = (roundKey, roundIndex) => {
+        const count = allianceCount?.count || 8;
+        const customDir = allianceSelectionRoundOrder?.[roundKey];
+        if (customDir) {
+            const seq = customDir === "descending"
+                ? Array.from({ length: count }, (_, i) => count - i)
+                : Array.from({ length: count }, (_, i) => i + 1);
+            return seq.map(number => ({ number, round: roundIndex + 1 }));
+        }
+        return AllianceSelectionBaseRounds[roundKey]
+            .filter(alliance => alliance <= count)
+            .map(number => ({ number, round: roundIndex + 1 }));
+    };
+
     allianceSelectionRounds.forEach((round, index) => {
-        AllianceSelectionBaseRounds[round].forEach((alliance) => {
-            if (alliance <= allianceCount?.count) {
-                allianceSelectionOrderRounds[round].push({ number: alliance, round: index + 1 });
-            }
-        })
-    })
+        allianceSelectionOrderRounds[round] = buildRoundSequence(round, index);
+    });
 
     allianceSelectionRounds.forEach((round) => {
         allianceSelectionOrder = _.concat(allianceSelectionOrder, allianceSelectionOrderRounds[round]);
@@ -84,11 +96,14 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
         return _.findIndex(teamList?.teams, { "teamNumber": team?.teamNumber }) >= 0;
     });
 
-    if (allianceCount?.count <= 4) {
-        allianceDisplayOrder = [[1, 4], [2, 3]]
-    } else if (allianceCount?.count <= 6) {
-        allianceDisplayOrder = [[1, 6], [2, 5], [3, 4]]
-    } else { allianceDisplayOrder = [[1, 8], [2, 7], [3, 6], [4, 5]] }
+    {
+        const count = allianceCount?.count || 8;
+        for (let i = 1; i <= Math.ceil(count / 2); i++) {
+            const pair = [i];
+            if (count + 1 - i !== i) pair.push(count + 1 - i);
+            allianceDisplayOrder.push(pair);
+        }
+    }
 
     const resetFilter = () => {
         const filterControl = document.getElementById("filterControl");
@@ -411,96 +426,25 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
             }
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [useFourTeamAlliances])
+    }, [useFourTeamAlliances, allianceSelectionRoundOrder])
 
     // Initialize alliance selection arrays when needed
     useEffect(() => {
         if (selectedEvent && rankings && teamList && allianceCount?.count > 0 && communityUpdates) {
             if (!allianceSelectionArrays || _.isEmpty(allianceSelectionArrays) || allianceSelectionArrays?.allianceCount !== allianceCount?.count) {
                 const sortedAndRankedTeams = _.orderBy(sortedTeams, ["rank"], ["asc"]);
+                const maxAlliances = Math.min(allianceCount?.count || 8, 16);
                 const newAsArrays = {
-                    alliances: [
-                        {
-                            "number": 1,
-                            "captain": sortedAndRankedTeams[0],
-                            "round1": null,
-                            "round2": null,
-                            "round3": null,
-                            "backup": null,
-                            "backupReplaced": null,
-                            "name": "Alliance 1"
-                        },
-                        {
-                            "number": 2,
-                            "captain": sortedAndRankedTeams[1],
-                            "round1": null,
-                            "round2": null,
-                            "round3": null,
-                            "backup": null,
-                            "backupReplaced": null,
-                            "name": "Alliance 2"
-                        },
-                        {
-                            "number": 3,
-                            "captain": sortedAndRankedTeams[2],
-                            "round1": null,
-                            "round2": null,
-                            "round3": null,
-                            "backup": null,
-                            "backupReplaced": null,
-                            "name": "Alliance 3"
-                        },
-                        {
-                            "number": 4,
-                            "captain": sortedAndRankedTeams[3],
-                            "round1": null,
-                            "round2": null,
-                            "round3": null,
-                            "backup": null,
-                            "backupReplaced": null,
-                            "name": "Alliance 4"
-                        },
-                        {
-                            "number": 5,
-                            "captain": 5 <= allianceCount?.count ? sortedAndRankedTeams[4] : null,
-                            "round1": null,
-                            "round2": null,
-                            "round3": null,
-                            "backup": null,
-                            "backupReplaced": null,
-                            "name": "Alliance 5"
-                        },
-                        {
-                            "number": 6,
-                            "captain": 6 <= allianceCount?.count ? sortedAndRankedTeams[5] : null,
-                            "round1": null,
-                            "round2": null,
-                            "round3": null,
-                            "backup": null,
-                            "backupReplaced": null,
-                            "name": "Alliance 6"
-                        },
-                        {
-                            "number": 7,
-                            "captain": 7 <= allianceCount?.count ? sortedAndRankedTeams[6] : null,
-                            "round1": null,
-                            "round2": null,
-                            "round3": null,
-                            "backup": null,
-                            "backupReplaced": null,
-                            "name": "Alliance 7"
-                        },
-                        {
-                            "number": 8,
-                            "captain": 8 <= allianceCount?.count ? sortedAndRankedTeams[7] : null,
-                            "round1": null,
-                            "round2": null,
-                            "round3": null,
-                            "backup": null,
-                            "backupReplaced": null,
-                            "name": "Alliance 8"
-                        }
-                    ],
+                    alliances: Array.from({ length: maxAlliances }, (_, i) => ({
+                        number: i + 1,
+                        captain: (i + 1) <= allianceCount?.count ? sortedAndRankedTeams[i] : null,
+                        round1: null,
+                        round2: null,
+                        round3: null,
+                        backup: null,
+                        backupReplaced: null,
+                        name: `Alliance ${i + 1}`,
+                    })),
                     allianceCount: allianceCount?.count,
                     rankedTeams: _.orderBy(sortedAndRankedTeams, ["rank", "asc"]),
                     availableTeams: _.orderBy(sortedAndRankedTeams, ["teamNumber", "asc"]),
@@ -523,7 +467,7 @@ function AllianceSelection({ selectedYear, selectedEvent, rankings, teamList, al
             }
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [selectedEvent, rankings, teamList, allianceCount, communityUpdates, allianceSelectionArrays])
+    }, [selectedEvent, rankings, teamList, allianceCount, communityUpdates, allianceSelectionArrays, allianceSelectionRoundOrder])
 
     useHotkeys('return', () => document.getElementById("acceptButton")?.click(), { scopes: 'allianceAccept' });
     useHotkeys('d', () => document.getElementById("declineButton")?.click(), { scopes: 'allianceDecline' });

--- a/src/components/Announce.jsx
+++ b/src/components/Announce.jsx
@@ -45,7 +45,7 @@ function Announce({
                 <span className={"announceTeamNumber"} ><b>{displayTeamNumber}</b></span><br />
                 {team?.updates?.sayNumber && <span className={"playByPlaysayNumber"}>{team.updates?.sayNumber}<br /></span>}
                 <span >{team?.rookieYear}<br />({years === 1 ? "" : years}{yearsDisplay} season)</span>
-                {inPlayoffs && <p className={"announceAlliance"}>{team.alliance}{(selectedEvent?.value?.name.includes("OFFLINE") && !playoffOnly) ? <></> : <><br />{team.allianceRole}</>}</p>}
+                {(inPlayoffs || team.alliance) && <p className={"announceAlliance"}>{team.alliance}{(selectedEvent?.value?.name.includes("OFFLINE") && !playoffOnly) ? <></> : <><br />{team.allianceRole}</>}</p>}
             </td>
             <td className={'col2'} style={{ backgroundColor: _.toLower(allianceColor) === "red" ? announceBackground.red : announceBackground.blue }}>
                 <span className={"teamName"}>{team?.updates?.nameShortLocal ? team?.updates?.nameShortLocal : team?.nameShort}</span><br />

--- a/src/components/BottomNavigation.jsx
+++ b/src/components/BottomNavigation.jsx
@@ -87,6 +87,20 @@ function BottomNavigation({ ftcMode }) {
             style={{ cursor: "pointer" }}
                 onClick={() => {
                   setURL({
+                    title: "Nexus API",
+                    url: "https://frc.nexus/en/api",
+                  });
+                }}
+              >
+                <i>
+                  <b>Nexus</b>
+                </i>
+              </span>{", by "}
+              <span
+                className="app-footer-link"
+            style={{ cursor: "pointer" }}
+                onClick={() => {
+                  setURL({
                     title: "Caster's Tool",
                     url: "https://casterstool.com",
                   });

--- a/src/components/PlayByPlay.jsx
+++ b/src/components/PlayByPlay.jsx
@@ -37,7 +37,7 @@ function PlayByPlay({ station, team, inPlayoffs, selectedEvent, adHocMode, playo
                         <p className={team?.updates?.organizationLocal ? (team?.updates?.organizationLocal?.length > 60 ? "playByPlayOrganization narrowFont" : "playByPlayOrganization") : (team?.organization?.length > 60 ? "playByPlayOrganization narrowFont" : "playByPlayOrganization")}>{team?.updates?.organizationLocal ? team?.updates?.organizationLocal : team?.organization}</p>
                         <p className={"playByPlayCity"}>{team?.updates?.cityStateLocal ? team?.updates?.cityStateLocal : `${team?.city}, ${team?.stateProv}${team?.country !== "USA" && !team?.updates?.cityStateLocal ? `, ${team?.country}` : ""}`}</p>
                         {(showMottoes || _.isNull(showMottoes)) && <p className={"playByPlayCity mottoes"}>{team?.updates?.teamMottoLocal}</p>}
-                        {inPlayoffs && width < height && <p className={"playByPlayAlliance"}>{team?.alliance}{(selectedEvent?.value?.name.includes("OFFLINE") && !playoffOnly) ? <></> : <><br />{team.allianceRole}</>}</p>}
+                        {(inPlayoffs || team?.alliance) && width < height && <p className={"playByPlayAlliance"}>{team?.alliance}{(selectedEvent?.value?.name.includes("OFFLINE") && !playoffOnly) ? <></> : <><br />{team.allianceRole}</>}</p>}
                     </>
                 }
                 {!team?.teamNumber && <>
@@ -71,7 +71,7 @@ function PlayByPlay({ station, team, inPlayoffs, selectedEvent, adHocMode, playo
                                 {team?.qualifiedFirstCmp && (selectedEvent?.value?.champLevel !== "CMPDIV" && selectedEvent?.value?.champLevel !== "CMPSUB" && selectedEvent?.value?.champLevel !== "CMPSUB") && <>Qualified for World Champs</>}
                             </p>}
                         {(showNotes || _.isNull(showNotes)) && <p className={`notes playByPlayWinLossTie teamNotes${team?.updates?.teamNotesLocal?.length > 60 ? " narrowFont" : ""}`} dangerouslySetInnerHTML={{ __html: team?.updates?.teamNotesLocal }}></p>}
-                        {inPlayoffs && width >= height && <p className={"playByPlayAlliance"}>{team?.alliance}{selectedEvent?.value?.name.includes("OFFLINE") ? <></> : <><br />{team.allianceRole}</>}</p>}
+                        {(inPlayoffs || team?.alliance) && width >= height && <p className={"playByPlayAlliance"}>{team?.alliance}{selectedEvent?.value?.name.includes("OFFLINE") ? <></> : <><br />{team.allianceRole}</>}</p>}
                     </>
                 }
                 {!team?.teamNumber && <>

--- a/src/components/TopButtons.jsx
+++ b/src/components/TopButtons.jsx
@@ -752,7 +752,8 @@ function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatc
         allAllianceMembersKnown &&
         !(matchDetails?.description || "").includes("Bye Match");
     // Show a single combined button when either the add-team or reorder action is available.
-    const showTopBarTeamOpsCol = showTopBarAddTeamCol || showTopBarReorderStationsCol;
+    // In test match (adHoc) mode, this button is hidden — users configure teams via "Change Teams" instead.
+    const showTopBarTeamOpsCol = !adHocMode && (showTopBarAddTeamCol || showTopBarReorderStationsCol);
     const promoteCount =
         (showTopBarTeamOpsCol ? 1 : 0) +
         (showTopBarChangeTeamsCol ? 1 : 0);

--- a/src/components/TopButtons.jsx
+++ b/src/components/TopButtons.jsx
@@ -187,7 +187,7 @@ function SortableTeamRow({ id, teamNumber, orderHint, station }) {
 
 // ─── TopButtons ───────────────────────────────────────────────────────────────
 
-function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatchFromMenu, selectedEvent, matchDetails, rawMatchDetailsForReserve = null, alliances, setAlliances, rankings, inPlayoffs, backupTeam, setBackupTeam, upsertPlayoffReserveOverlay, removePlayoffReserveOverlay, playoffReserveEdits, playoffStationOrderEdits, upsertPlayoffStationOrderOverlay, removePlayoffStationOrderOverlay, teamList, adHocMatch, setAdHocMatch, adHocMode, playoffOnly, eventLabel, ftcMode, remapNumberToString, remapStringToNumber }) {
+function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatchFromMenu, selectedEvent, matchDetails, rawMatchDetailsForReserve = null, alliances, setAlliances, rankings, inPlayoffs, backupTeam, setBackupTeam, upsertPlayoffReserveOverlay, removePlayoffReserveOverlay, playoffReserveEdits, playoffStationOrderEdits, upsertPlayoffStationOrderOverlay, removePlayoffStationOrderOverlay, teamList, adHocMatch, setAdHocMatch, adHocMode, adHocRedAlliance, setAdHocRedAlliance, adHocBlueAlliance, setAdHocBlueAlliance, playoffOnly, eventLabel, ftcMode, remapNumberToString, remapStringToNumber, allianceSelectionArrays }) {
     const { swapScreen } = useSettings();
 
     // ── shared modal state ────────────────────────────────────────────────────
@@ -1052,6 +1052,12 @@ function TopButtons({ previousMatch, nextMatch, currentMatch, matchMenu, setMatc
                     adHocMatch={adHocMatch}
                     onStationChange={setAdHocMatch}
                     eventTeams={eventTeams}
+                    allianceSelectionArrays={allianceSelectionArrays}
+                    alliances={alliances}
+                    selectedRedAlliance={adHocRedAlliance}
+                    setSelectedRedAlliance={setAdHocRedAlliance}
+                    selectedBlueAlliance={adHocBlueAlliance}
+                    setSelectedBlueAlliance={setAdHocBlueAlliance}
                 />
             </Row>
         </>

--- a/src/contexts/SettingsContext.jsx
+++ b/src/contexts/SettingsContext.jsx
@@ -143,6 +143,10 @@ export function SettingsProvider({ children }) {
     "setting:playoffCountOverride",
     null
   );
+  const [allianceSelectionRoundOrder, setAllianceSelectionRoundOrder] = usePersistentState(
+    "setting:allianceSelectionRoundOrder",
+    null
+  );
 
   // Multi-screen sync
   const [syncEvent, setSyncEvent] = usePersistentState(
@@ -202,6 +206,7 @@ export function SettingsProvider({ children }) {
     rankingsOverride, setRankingsOverride,
     allianceCount, setAllianceCount,
     playoffCountOverride, setPlayoffCountOverride,
+    allianceSelectionRoundOrder, setAllianceSelectionRoundOrder,
     // Multi-screen sync
     syncEvent, setSyncEvent,
     screenMode, setScreenMode,
@@ -219,7 +224,7 @@ export function SettingsProvider({ children }) {
     teamReduction, reverseEmcee, useSwipe, usePullDownToUpdate, useScrollMemory,
     useFourTeamAlliances,
     eventFilters, regionFilters, timeFilter,
-    rankingsOverride, allianceCount, playoffCountOverride,
+    rankingsOverride, allianceCount, playoffCountOverride, allianceSelectionRoundOrder,
     syncEvent, screenMode, screenModeSyncFrequency,
     backgroundDataRefresh, backgroundDataRefreshFrequency,
     // Setters are stable (from useState) — no need to include them, but including for safety
@@ -232,7 +237,7 @@ export function SettingsProvider({ children }) {
     setTeamReduction, setReverseEmcee, setUseSwipe, setUsePullDownToUpdate, setUseScrollMemory,
     setUseFourTeamAlliances,
     setEventFilters, setRegionFilters, setTimeFilter,
-    setRankingsOverride, setAllianceCount, setPlayoffCountOverride,
+    setRankingsOverride, setAllianceCount, setPlayoffCountOverride, setAllianceSelectionRoundOrder,
     setSyncEvent, setScreenMode, setScreenModeSyncFrequency,
     setBackgroundDataRefresh, setBackgroundDataRefreshFrequency,
   ]);

--- a/src/data/appConfig.js
+++ b/src/data/appConfig.js
@@ -57,15 +57,31 @@ export const allianceSelectionOrderBase = [
 ];
 
 export const allianceSelectionBaseRounds = {
-  round1: [1, 2, 3, 4, 5, 6, 7, 8],
-  round2: [8, 7, 6, 5, 4, 3, 2, 1],
-  round3: [1, 2, 3, 4, 5, 6, 7, 8],
-  round4: [8, 7, 6, 5, 4, 3, 2, 1],
+  round1: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+  round2: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
+  round3: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+  round4: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
 };
 
 export const refreshRate = 15; //Refresh rate in seconds for auto update
 
 export const playoffOverrideMenu = [
+  { value: 8, label: 8 },
+  { value: 7, label: 7 },
+  { value: 6, label: 6 },
+  { value: 5, label: 5 },
+  { value: 4, label: 4 },
+];
+
+export const playoffOverrideMenuOffseason = [
+  { value: 16, label: 16 },
+  { value: 15, label: 15 },
+  { value: 14, label: 14 },
+  { value: 13, label: 13 },
+  { value: 12, label: 12 },
+  { value: 11, label: 11 },
+  { value: 10, label: 10 },
+  { value: 9, label: 9 },
   { value: 8, label: 8 },
   { value: 7, label: 7 },
   { value: 6, label: 6 },

--- a/src/data/appUpdates.js
+++ b/src/data/appUpdates.js
@@ -1,5 +1,27 @@
 export const appUpdates = [
   {
+    date: "June 3, 2026",
+    message: (
+      <>
+      <b>OFFSEASON UPDATES</b><br />
+      <ul>
+        <li>FRC:</li>
+        <ul>
+          <li>Test Match mode:</li>
+          <ul>
+            <li>Users can now add a 4th team to an Alliance in Test Match mode</li>
+            <li>Users can now add choose Alliances in Test Match mode</li>
+          </ul>
+        <li>Alliance Selection:</li>
+          <ul>
+            <li>Alliance Selection now supports more than 8 Alliances</li>
+            <li>Alliance Selection now supports changing the order of the Alliance Selection rounds</li>
+          </ul>
+        </ul>
+      </ul>
+      </>
+    ),
+  },{
     date: "May 8, 2026",
     message: (
       <>

--- a/src/pages/AllianceSelectionPage.jsx
+++ b/src/pages/AllianceSelectionPage.jsx
@@ -32,7 +32,7 @@ function AllianceSelectionPage({
 }) {
   const { selectedEvent, selectedYear, qualSchedule, playoffSchedule, offlinePlayoffSchedule, alliances, rankings, teamList, allianceCount, communityUpdates, practiceSchedule, currentMatch, eventLabel, ftcMode, remapNumberToString } = useEventData();
   const { getRanks, loadEvent, nextMatch, previousMatch, getSchedule } = useEventActions();
-    const { timeFormat, useSwipe, usePullDownToUpdate, useFourTeamAlliances, useScrollMemory, rankingsOverride,
+    const { timeFormat, useSwipe, usePullDownToUpdate, useFourTeamAlliances, setUseFourTeamAlliances, useScrollMemory, rankingsOverride,
         playoffCountOverride, setPlayoffCountOverride, allianceSelectionRoundOrder, setAllianceSelectionRoundOrder } = useSettings();
     /**
      * This function finds a team by their station assignment
@@ -119,7 +119,8 @@ function AllianceSelectionPage({
 
     const handleReset = () => {
         // @ts-ignore
-        document.getElementById("filterControl").value = "";
+        const filterControl = document.getElementById("filterControl");
+        if (filterControl) filterControl.value = "";
         setTeamFilter("");
         setAllianceSelectionArrays({});
     }
@@ -259,7 +260,7 @@ function AllianceSelectionPage({
                 <div>
                     {isOffseason && (
                         <Alert variant="warning">
-                            <Row className="align-items-center">
+                            <Row className="align-items-center justify-content-center">
                                 <Col xs="auto"><b>Alliance Count Override:</b></Col>
                                 <Col xs={3}>
                                     <Select classNamePrefix="gatool-rs"
@@ -272,6 +273,14 @@ function AllianceSelectionPage({
                                         Reorder Alliance Selection
                                     </Button>
                                 </Col>
+                                {!ftcMode && (
+                                    <Col xs="auto" className="d-flex align-items-center gap-2">
+                                        <Switch
+                                            checked={useFourTeamAlliances === null ? false : useFourTeamAlliances}
+                                            onChange={setUseFourTeamAlliances} />
+                                        <b>Use 4 team Alliances for playoffs</b>
+                                    </Col>
+                                )}
                             </Row>
                         </Alert>
                     )}

--- a/src/pages/AllianceSelectionPage.jsx
+++ b/src/pages/AllianceSelectionPage.jsx
@@ -1,4 +1,5 @@
 import { Alert, Col, Row, Container, Modal, Button } from "react-bootstrap";
+import Select from "react-select";
 import Bracket from "../components/Bracket";
 import FourAllianceBracket from "components/FourAllianceBracket";
 import FourAllianceBracketFTC from "components/FourAllianceBracketFTC";
@@ -7,6 +8,7 @@ import DaVinciTournamentBracket from "components/DaVinciTournamentBracket";
 import TwoAllianceBracket from "components/TwollianceBracket";
 import moment from "moment/moment";
 import AllianceSelection from "../components/AllianceSelection";
+import { playoffOverrideMenuOffseason } from "../data/appConfig";
 import { useState, useEffect, useRef } from "react";
 import Switch from "react-switch";
 import { useHotkeysContext, useHotkeys } from "react-hotkeys-hook";
@@ -30,7 +32,8 @@ function AllianceSelectionPage({
 }) {
   const { selectedEvent, selectedYear, qualSchedule, playoffSchedule, offlinePlayoffSchedule, alliances, rankings, teamList, allianceCount, communityUpdates, practiceSchedule, currentMatch, eventLabel, ftcMode, remapNumberToString } = useEventData();
   const { getRanks, loadEvent, nextMatch, previousMatch, getSchedule } = useEventActions();
-    const { timeFormat, useSwipe, usePullDownToUpdate, useFourTeamAlliances, useScrollMemory, rankingsOverride } = useSettings();
+    const { timeFormat, useSwipe, usePullDownToUpdate, useFourTeamAlliances, useScrollMemory, rankingsOverride,
+        playoffCountOverride, setPlayoffCountOverride, allianceSelectionRoundOrder, setAllianceSelectionRoundOrder } = useSettings();
     /**
      * This function finds a team by their station assignment
      * @param teams the array of team objects
@@ -46,6 +49,41 @@ function AllianceSelectionPage({
     const [overrideAllianceSelection, setOverrideAllianceSelection] = useState(false);
     const [resetAllianceSelection, setResetAllianceSelection] = useState(false);
     const [teamFilter, setTeamFilter] = useState("");
+    const [showRoundOrderModal, setShowRoundOrderModal] = useState(false);
+    const [roundOrderDraft, setRoundOrderDraft] = useState(null);
+
+    const isOffseason = selectedEvent?.value?.type?.includes("OffSeason");
+    const inChamps = !!(
+        selectedEvent?.value?.champLevel === "CHAMPS" ||
+        selectedEvent?.value?.champLevel === "CMPDIV" ||
+        selectedEvent?.value?.champLevel === "CMPSUB" ||
+        useFourTeamAlliances
+    );
+    const allianceSelectionRounds = ftcMode
+        ? (inChamps ? ["round1", "round2"] : ["round1"])
+        : (inChamps ? ["round1", "round2", "round3"] : ["round1", "round2"]);
+
+    const defaultRoundDirection = { round1: "ascending", round2: "descending", round3: "ascending" };
+    const roundDirectionOptions = [
+        { value: "ascending", label: "Ascending (Alliance 1 first)" },
+        { value: "descending", label: "Descending (highest Alliance first)" },
+    ];
+
+    const openRoundOrderModal = () => {
+        const current = allianceSelectionRoundOrder || {};
+        const draft = {};
+        allianceSelectionRounds.forEach((r) => {
+            draft[r] = current[r] || defaultRoundDirection[r] || "ascending";
+        });
+        setRoundOrderDraft(draft);
+        setShowRoundOrderModal(true);
+    };
+
+    const saveRoundOrder = () => {
+        setAllianceSelectionRoundOrder(roundOrderDraft);
+        setAllianceSelectionArrays({});
+        setShowRoundOrderModal(false);
+    };
     const [waitingForRankingsUpdate, setWaitingForRankingsUpdate] = useState(false);
     const previousRankingsRef = useRef(null);
     const { disableScope, enableScope } = useHotkeysContext();
@@ -219,6 +257,24 @@ function AllianceSelectionPage({
                 </div>}
             {selectedEvent && ((qualSchedule?.schedule?.length > 0 || qualSchedule?.schedule?.schedule?.length > 0 || practiceSchedule?.schedule?.length > 0) && !playoffs && (allianceSelection || overrideAllianceSelection)) &&
                 <div>
+                    {isOffseason && (
+                        <Alert variant="warning">
+                            <Row className="align-items-center">
+                                <Col xs="auto"><b>Alliance Count Override:</b></Col>
+                                <Col xs={3}>
+                                    <Select classNamePrefix="gatool-rs"
+                                        options={playoffOverrideMenuOffseason}
+                                        value={playoffCountOverride ? playoffCountOverride : (allianceCount?.menu ? allianceCount.menu : playoffOverrideMenuOffseason[0])}
+                                        onChange={setPlayoffCountOverride} />
+                                </Col>
+                                <Col xs="auto">
+                                    <Button size="sm" variant="info" onClick={openRoundOrderModal}>
+                                        Reorder Alliance Selection
+                                    </Button>
+                                </Col>
+                            </Row>
+                        </Alert>
+                    )}
                     {!allianceCount || !allianceCount?.count || allianceCount?.count <= 0 ? (
                         <Alert variant="danger">
                             <h4>Alliance Count Required</h4>
@@ -242,6 +298,30 @@ function AllianceSelectionPage({
                 <FourAllianceBracketFTC currentMatch={currentMatch} qualsLength={qualsLength} nextMatch={nextMatch} previousMatch={previousMatch} getSchedule={getSchedule} useSwipe={useSwipe} usePullDownToUpdate={usePullDownToUpdate} offlinePlayoffSchedule={offlinePlayoffSchedule} setOfflinePlayoffSchedule={setOfflinePlayoffSchedule} eventLabel={eventLabel} ftcMode={ftcMode} matches={matches} allianceNumbers={allianceNumbers} allianceName={allianceName} matchScore={matchScore} matchWinner={matchWinner} alliances={alliances} remapNumberToString={remapNumberToString} />}
             {selectedEvent && (alliancesCount === 2) && playoffs &&
                 <TwoAllianceBracket nextMatch={nextMatch} previousMatch={previousMatch} getSchedule={getSchedule} useSwipe={useSwipe} usePullDownToUpdate={usePullDownToUpdate} eventLabel={eventLabel} ftcMode={ftcMode} matches={matches} allianceNumbers={allianceNumbers} allianceName={allianceName} matchScore={matchScore} matchWinner={matchWinner} />}
+            <Modal centered={true} show={showRoundOrderModal} onHide={() => setShowRoundOrderModal(false)}>
+                <Modal.Header className={"allianceSelectionDecline"} closeVariant={"white"} closeButton>
+                    <Modal.Title>Configure Alliance Selection Round Order</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <p>Choose the selection direction for each round. <strong>Saving will reset Alliance Selection.</strong></p>
+                    {roundOrderDraft && allianceSelectionRounds.map((roundKey, idx) => (
+                        <Row key={roundKey} className="align-items-center mb-2">
+                            <Col xs={3}><b>Round {idx + 1}:</b></Col>
+                            <Col xs={9}>
+                                <Select classNamePrefix="gatool-rs"
+                                    options={roundDirectionOptions}
+                                    value={roundDirectionOptions.find(o => o.value === roundOrderDraft[roundKey])}
+                                    onChange={(opt) => setRoundOrderDraft(prev => ({ ...prev, [roundKey]: opt.value }))} />
+                            </Col>
+                        </Row>
+                    ))}
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button variant="danger" size="sm" onClick={saveRoundOrder}>Save &amp; Reset Alliance Selection</Button>
+                    <Button size="sm" onClick={() => setShowRoundOrderModal(false)}>Cancel</Button>
+                </Modal.Footer>
+            </Modal>
+
             <Modal centered={true} show={resetAllianceSelection} onHide={handleClose}>
                 <Modal.Header className={"allianceSelectionDecline"} closeVariant={"white"} closeButton>
                     <Modal.Title>

--- a/src/pages/AllianceSelectionPage.test.jsx
+++ b/src/pages/AllianceSelectionPage.test.jsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import AllianceSelectionPage from "./AllianceSelectionPage";
+
+// ─── Context / hook mocks ─────────────────────────────────────────────────────
+
+vi.mock("../contexts/SettingsContext", () => ({
+    useSettings: vi.fn(),
+}));
+
+vi.mock("contexts/EventDataContext", () => ({
+    useEventData: vi.fn(),
+}));
+
+vi.mock("contexts/EventActionsContext", () => ({
+    useEventActions: vi.fn(),
+}));
+
+vi.mock("react-hotkeys-hook", () => ({
+    useHotkeysContext: () => ({ disableScope: vi.fn(), enableScope: vi.fn() }),
+    useHotkeys: vi.fn(),
+}));
+
+vi.mock("../hooks/useScrollPosition", () => ({
+    default: vi.fn(),
+}));
+
+// AllianceSelection child component is complex; stub it out
+vi.mock("../components/AllianceSelection", () => ({
+    default: () => <div data-testid="alliance-selection-stub" />,
+}));
+
+import { useSettings } from "../contexts/SettingsContext";
+import { useEventData } from "contexts/EventDataContext";
+import { useEventActions } from "contexts/EventActionsContext";
+
+// ─── Fixture builders ─────────────────────────────────────────────────────────
+
+function makeOffseasonEvent() {
+    return {
+        value: {
+            type: "OffSeason",
+            code: "OFFTEST",
+            champLevel: null,
+        },
+        label: "Test Offseason Event",
+    };
+}
+
+function makeRegularEvent() {
+    return {
+        value: {
+            type: "Regional",
+            code: "REGTEST",
+            champLevel: null,
+        },
+        label: "Test Regional Event",
+    };
+}
+
+function makeQualSchedule() {
+    return { schedule: [{ matchNumber: 1 }] };
+}
+
+function setupMocks({ eventOverrides = {}, settingsOverrides = {} } = {}) {
+    useEventData.mockReturnValue({
+        selectedEvent: makeOffseasonEvent(),
+        selectedYear: 2026,
+        qualSchedule: makeQualSchedule(),
+        playoffSchedule: null,
+        offlinePlayoffSchedule: null,
+        alliances: { alliances: [], Lookup: {} },
+        rankings: null,
+        teamList: { teams: [] },
+        allianceCount: { count: 8, menu: null },
+        communityUpdates: null,
+        practiceSchedule: null,
+        currentMatch: 1,
+        eventLabel: "Test Offseason Event",
+        ftcMode: false,
+        remapNumberToString: (n) => String(n),
+        ...eventOverrides,
+    });
+
+    useSettings.mockReturnValue({
+        timeFormat: { value: "h:mm A" },
+        useSwipe: false,
+        usePullDownToUpdate: false,
+        useFourTeamAlliances: false,
+        setUseFourTeamAlliances: vi.fn(),
+        useScrollMemory: false,
+        rankingsOverride: false,
+        playoffCountOverride: null,
+        setPlayoffCountOverride: vi.fn(),
+        allianceSelectionRoundOrder: null,
+        setAllianceSelectionRoundOrder: vi.fn(),
+        ...settingsOverrides,
+    });
+
+    useEventActions.mockReturnValue({
+        getRanks: vi.fn(),
+        loadEvent: vi.fn(),
+        nextMatch: vi.fn(),
+        previousMatch: vi.fn(),
+        getSchedule: vi.fn(),
+    });
+}
+
+function baseProps(overrides = {}) {
+    return {
+        allianceSelection: true,
+        playoffs: false,
+        allianceSelectionArrays: {},
+        setAllianceSelectionArrays: vi.fn(),
+        setOfflinePlayoffSchedule: vi.fn(),
+        qualsLength: 50,
+        ...overrides,
+    };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("AllianceSelectionPage – 4-team alliances switch", () => {
+    beforeEach(() => {
+        setupMocks();
+    });
+
+    it("shows the 4-team alliances switch for offseason events in non-FTC mode", () => {
+        render(<AllianceSelectionPage {...baseProps()} />);
+        expect(screen.getByText("Use 4 team Alliances for playoffs")).toBeInTheDocument();
+    });
+
+    it("does not show the switch for non-offseason events", () => {
+        useEventData.mockReturnValue({
+            ...useEventData(),
+            selectedEvent: makeRegularEvent(),
+            ftcMode: false,
+        });
+        render(<AllianceSelectionPage {...baseProps()} />);
+        expect(screen.queryByText("Use 4 team Alliances for playoffs")).not.toBeInTheDocument();
+    });
+
+    it("does not show the switch in FTC mode even for offseason events", () => {
+        useEventData.mockReturnValue({
+            ...useEventData(),
+            ftcMode: true,
+        });
+        render(<AllianceSelectionPage {...baseProps()} />);
+        expect(screen.queryByText("Use 4 team Alliances for playoffs")).not.toBeInTheDocument();
+    });
+
+    it("does not show the switch when in playoffs mode", () => {
+        render(<AllianceSelectionPage {...baseProps({ playoffs: true })} />);
+        expect(screen.queryByText("Use 4 team Alliances for playoffs")).not.toBeInTheDocument();
+    });
+
+    it("shows the switch checked when useFourTeamAlliances is true", () => {
+        setupMocks({ settingsOverrides: { useFourTeamAlliances: true } });
+        render(<AllianceSelectionPage {...baseProps()} />);
+        expect(screen.getByText("Use 4 team Alliances for playoffs")).toBeInTheDocument();
+        // The Switch renders a checkbox input; verify it reflects the checked state
+        const checkbox = document.querySelector("input[type='checkbox']");
+        expect(checkbox?.checked).toBe(true);
+    });
+
+    it("works with OffSeasonWithAzureSync event type", () => {
+        useEventData.mockReturnValue({
+            ...useEventData(),
+            selectedEvent: {
+                value: { type: "OffSeasonWithAzureSync", code: "OFFSYNC", champLevel: null },
+                label: "Azure Sync Offseason",
+            },
+        });
+        render(<AllianceSelectionPage {...baseProps()} />);
+        expect(screen.getByText("Use 4 team Alliances for playoffs")).toBeInTheDocument();
+    });
+});

--- a/src/pages/AnnouncePage.jsx
+++ b/src/pages/AnnouncePage.jsx
@@ -122,7 +122,7 @@ function AnnouncePage({
       ]?.alliance;
 
 
-    if (station.slice(-1) !== "4") {
+    if (station.slice(-1) !== "4" || adHocMode) {
       team =
         matchDetails?.teams[
         _.findIndex(matchDetails?.teams, { station: station })
@@ -174,7 +174,7 @@ function AnnouncePage({
       }
     }
 
-    if (station?.slice(-1) === "4") {
+    if (station?.slice(-1) === "4" && !adHocMode) {
 
       if (inPlayoffs || selectedEvent?.value?.champLevel === "CHAMPS") {
         var playoffTeams = matchDetails?.teams.map((team) => {
@@ -309,56 +309,12 @@ function AnnouncePage({
         matchNumber: 1,
         field: "Primary",
         tournamentLevel: "Practice",
-        teams: [
-          {
-            teamNumber: adHocMatch[0]?.teamNumber
-              ? adHocMatch[0]?.teamNumber
-              : null,
-            station: "Red1",
-            surrogate: false,
-            dq: false,
-          },
-          {
-            teamNumber: adHocMatch[1]?.teamNumber
-              ? adHocMatch[1]?.teamNumber
-              : null,
-            station: "Red2",
-            surrogate: false,
-            dq: false,
-          },
-          {
-            teamNumber: adHocMatch[2]?.teamNumber
-              ? adHocMatch[2]?.teamNumber
-              : null,
-            station: "Red3",
-            surrogate: false,
-            dq: false,
-          },
-          {
-            teamNumber: adHocMatch[3]?.teamNumber
-              ? adHocMatch[3]?.teamNumber
-              : null,
-            station: "Blue1",
-            surrogate: false,
-            dq: false,
-          },
-          {
-            teamNumber: adHocMatch[4]?.teamNumber
-              ? adHocMatch[4]?.teamNumber
-              : null,
-            station: "Blue2",
-            surrogate: false,
-            dq: false,
-          },
-          {
-            teamNumber: adHocMatch[5]?.teamNumber
-              ? adHocMatch[5]?.teamNumber
-              : null,
-            station: "Blue3",
-            surrogate: false,
-            dq: false,
-          },
-        ],
+        teams: adHocMatch.map((t) => ({
+          teamNumber: t.teamNumber || null,
+          station: t.station,
+          surrogate: false,
+          dq: false,
+        })),
         isReplay: false,
         matchVideoLink: null,
         scoreRedFinal: null,

--- a/src/pages/AnnouncePage.jsx
+++ b/src/pages/AnnouncePage.jsx
@@ -45,12 +45,17 @@ function AnnouncePage({
   adHocMatch,
   setAdHocMatch,
   adHocMode,
+  adHocRedAlliance,
+  setAdHocRedAlliance,
+  adHocBlueAlliance,
+  setAdHocBlueAlliance,
   qualsLength,
   playoffOnly,
   eventMessage,
   eventBell,
   setEventBell,
   alliancePartnerConnectionsCache,
+  allianceSelectionArrays,
 }) {
   const { selectedEvent, selectedYear, eventLabel, ftcMode, teamList, qualSchedule, playoffSchedule, practiceSchedule, offlinePlayoffSchedule, rankings, districtRankings, alliances, allianceCount, communityUpdates, currentMatch, remapNumberToString, remapStringToNumber, regionalEventDetail } = useEventData();
   const { nextMatch, previousMatch, setMatchFromMenu, getSchedule, getRegionalEventDetail } = useEventActions();
@@ -113,6 +118,17 @@ function AnnouncePage({
     return map;
   }, [communityUpdates]);
 
+  function getAdHocAllianceInfo(teamNumber) {
+    if (!teamNumber || !allianceSelectionArrays?.alliances) return null;
+    for (const a of allianceSelectionArrays.alliances) {
+      if (a.captain?.teamNumber === teamNumber) return { alliance: a.name, role: "Captain" };
+      if (a.round1?.teamNumber === teamNumber) return { alliance: a.name, role: "Round 1 Selection" };
+      if (a.round2?.teamNumber === teamNumber) return { alliance: a.name, role: "Round 2 Selection" };
+      if (a.round3?.teamNumber === teamNumber) return { alliance: a.name, role: "Round 3 Selection" };
+    }
+    return null;
+  }
+
   function updateTeamDetails(station, matchDetails) {
     var team = {};
     var alliance = station.slice(0, station.length - 1);
@@ -146,6 +162,13 @@ function AnnouncePage({
       );
       team.alliance = announceAllianceEntry?.alliance ?? null;
       team.allianceRole = announceAllianceEntry?.role ?? null;
+      if (adHocMode && !team.alliance) {
+        const adHocInfo = getAdHocAllianceInfo(team?.teamNumber);
+        if (adHocInfo) {
+          team.alliance = adHocInfo.alliance;
+          team.allianceRole = adHocInfo.role;
+        }
+      }
 
       var teamDistrictRanks =
         _.filter(districtRankings?.districtRanks, {
@@ -544,11 +567,16 @@ function AnnouncePage({
               adHocMatch={adHocMatch}
               setAdHocMatch={setAdHocMatch}
               adHocMode={adHocMode}
+              adHocRedAlliance={adHocRedAlliance}
+              setAdHocRedAlliance={setAdHocRedAlliance}
+              adHocBlueAlliance={adHocBlueAlliance}
+              setAdHocBlueAlliance={setAdHocBlueAlliance}
               playoffOnly={playoffOnly}
               eventLabel={eventLabel}
               ftcMode={ftcMode}
               remapNumberToString={remapNumberToString}
               remapStringToNumber={remapStringToNumber}
+              allianceSelectionArrays={allianceSelectionArrays}
             />
             <NotificationBanner notification={notification} />
             <EventNotificationBanner

--- a/src/pages/PlayByPlayPage.jsx
+++ b/src/pages/PlayByPlayPage.jsx
@@ -49,7 +49,7 @@ function PlayByPlayPage({
 }) {
   const { selectedEvent, selectedYear, eventLabel, ftcMode, teamList, qualSchedule, playoffSchedule, practiceSchedule, offlinePlayoffSchedule, rankings, districtRankings, alliances, allianceCount, communityUpdates, currentMatch, remapNumberToString, remapStringToNumber, EPA, regionalEventDetail } = useEventData();
   const { nextMatch, previousMatch, setMatchFromMenu, getSchedule, getRegionalEventDetail } = useEventActions();
-  const { swapScreen, hidePracticeSchedule, teamReduction, showInspection, usePullDownToUpdate, useSwipe, useScrollMemory } = useSettings();
+  const { swapScreen, hidePracticeSchedule, teamReduction, showInspection, usePullDownToUpdate, useSwipe, useScrollMemory, useFourTeamAlliances } = useSettings();
   // Remember scroll position for Play by play page
   useScrollPosition('playbyplay', true, false, useScrollMemory);
   const scrollToTop = useScrollToTop();
@@ -123,7 +123,7 @@ function PlayByPlayPage({
       matchDetails?.teams[
         _.findIndex(matchDetails?.teams, { station: `${alliance}1` })
       ]?.alliance;
-    if (station.slice(-1) !== "4") {
+    if (station.slice(-1) !== "4" || adHocMode) {
       team =
         matchDetails?.teams[
         _.findIndex(matchDetails?.teams, { station: station })
@@ -176,7 +176,7 @@ function PlayByPlayPage({
       }
     }
 
-    if (station.slice(-1) === "4") {
+    if (station.slice(-1) === "4" && !adHocMode) {
       if (inPlayoffs) {
         var playoffTeams = matchDetails?.teams.map((team) => {
           return { teamNumber: team?.teamNumber, alliance: team.alliance };
@@ -333,56 +333,12 @@ function PlayByPlayPage({
       matchNumber: 1,
       field: "Primary",
       tournamentLevel: "Practice",
-      teams: [
-        {
-          teamNumber: adHocMatch[0]?.teamNumber
-            ? adHocMatch[0]?.teamNumber
-            : null,
-          station: "Red1",
-          surrogate: false,
-          dq: false,
-        },
-        {
-          teamNumber: adHocMatch[1]?.teamNumber
-            ? adHocMatch[1]?.teamNumber
-            : null,
-          station: "Red2",
-          surrogate: false,
-          dq: false,
-        },
-        {
-          teamNumber: adHocMatch[2]?.teamNumber
-            ? adHocMatch[2]?.teamNumber
-            : null,
-          station: "Red3",
-          surrogate: false,
-          dq: false,
-        },
-        {
-          teamNumber: adHocMatch[3]?.teamNumber
-            ? adHocMatch[3]?.teamNumber
-            : null,
-          station: "Blue1",
-          surrogate: false,
-          dq: false,
-        },
-        {
-          teamNumber: adHocMatch[4]?.teamNumber
-            ? adHocMatch[4]?.teamNumber
-            : null,
-          station: "Blue2",
-          surrogate: false,
-          dq: false,
-        },
-        {
-          teamNumber: adHocMatch[5]?.teamNumber
-            ? adHocMatch[5]?.teamNumber
-            : null,
-          station: "Blue3",
-          surrogate: false,
-          dq: false,
-        },
-      ],
+      teams: adHocMatch.map((t) => ({
+        teamNumber: t.teamNumber || null,
+        station: t.station,
+        surrogate: false,
+        dq: false,
+      })),
       isReplay: false,
       matchVideoLink: null,
       scoreRedFinal: null,
@@ -633,7 +589,8 @@ function PlayByPlayPage({
                     </tr>
                   )}
                   {((inPlayoffs && !ftcMode) ||
-                    selectedEvent?.value?.champLevel === "CHAMPS") &&
+                    selectedEvent?.value?.champLevel === "CHAMPS" ||
+                    (adHocMode && useFourTeamAlliances && !ftcMode)) &&
                     (!_.isEmpty(teamDetails["Red4"]) ||
                       !_.isEmpty(teamDetails["Blue4"])) && (
                       <tr className={"gatool-playbyplay"}>

--- a/src/pages/PlayByPlayPage.jsx
+++ b/src/pages/PlayByPlayPage.jsx
@@ -41,11 +41,16 @@ function PlayByPlayPage({
   adHocMatch,
   setAdHocMatch,
   adHocMode,
+  adHocRedAlliance,
+  setAdHocRedAlliance,
+  adHocBlueAlliance,
+  setAdHocBlueAlliance,
   qualsLength,
   playoffOnly,
   eventMessage,
   eventBell,
   setEventBell,
+  allianceSelectionArrays,
 }) {
   const { selectedEvent, selectedYear, eventLabel, ftcMode, teamList, qualSchedule, playoffSchedule, practiceSchedule, offlinePlayoffSchedule, rankings, districtRankings, alliances, allianceCount, communityUpdates, currentMatch, remapNumberToString, remapStringToNumber, EPA, regionalEventDetail } = useEventData();
   const { nextMatch, previousMatch, setMatchFromMenu, getSchedule, getRegionalEventDetail } = useEventActions();
@@ -116,6 +121,17 @@ function PlayByPlayPage({
     return map;
   }, [communityUpdates]);
 
+  function getAdHocAllianceInfo(teamNumber) {
+    if (!teamNumber || !allianceSelectionArrays?.alliances) return null;
+    for (const a of allianceSelectionArrays.alliances) {
+      if (a.captain?.teamNumber === teamNumber) return { alliance: a.name, role: "Captain" };
+      if (a.round1?.teamNumber === teamNumber) return { alliance: a.name, role: "Round 1 Selection" };
+      if (a.round2?.teamNumber === teamNumber) return { alliance: a.name, role: "Round 2 Selection" };
+      if (a.round3?.teamNumber === teamNumber) return { alliance: a.name, role: "Round 3 Selection" };
+    }
+    return null;
+  }
+
   function updateTeamDetails(station, matchDetails) {
     var team = {};
     var alliance = station.slice(0, station.length - 1);
@@ -148,6 +164,13 @@ function PlayByPlayPage({
       );
       team.alliance = pbpAllianceEntry?.alliance ?? null;
       team.allianceRole = pbpAllianceEntry?.role ?? null;
+      if (adHocMode && !team.alliance) {
+        const adHocInfo = getAdHocAllianceInfo(team?.teamNumber);
+        if (adHocInfo) {
+          team.alliance = adHocInfo.alliance;
+          team.allianceRole = adHocInfo.role;
+        }
+      }
 
       var teamDistrictRanks =
         _.filter(districtRankings?.districtRanks, {
@@ -497,11 +520,16 @@ function PlayByPlayPage({
               adHocMatch={adHocMatch}
               setAdHocMatch={setAdHocMatch}
               adHocMode={adHocMode}
+              adHocRedAlliance={adHocRedAlliance}
+              setAdHocRedAlliance={setAdHocRedAlliance}
+              adHocBlueAlliance={adHocBlueAlliance}
+              setAdHocBlueAlliance={setAdHocBlueAlliance}
               playoffOnly={playoffOnly}
               eventLabel={eventLabel}
               ftcMode={ftcMode}
               remapNumberToString={remapNumberToString}
               remapStringToNumber={remapStringToNumber}
+              allianceSelectionArrays={allianceSelectionArrays}
             />
             <NotificationBanner
               notification={notification}

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -9,7 +9,7 @@ import { useOnlineStatus } from "../contextProviders/OnlineContext";
 import { useState } from "react";
 import { toast } from "react-toastify";
 import { isSafari, isChrome, fullBrowserVersion, browserVersion, isIOS, browserName, isDesktop, isTablet, isMobile } from "react-device-detect";
-import { playoffOverrideMenu } from "data/appConfig";
+import { playoffOverrideMenu, playoffOverrideMenuOffseason } from "data/appConfig";
 import { useSettings } from "contexts/SettingsContext";
 import { useEventData } from "contexts/EventDataContext";
 import { useEventActions } from "contexts/EventActionsContext";
@@ -527,7 +527,14 @@ function SetupPage({
                         {selectedEvent?.value.dateStart && <p><b>Event Start: </b>{moment(selectedEvent?.value.dateStart, 'YYYY-MM-DDTHH:mm:ss').format('ddd, MMM Do YYYY')}</p>}
                         {selectedEvent?.value.dateEnd && <p><b>Event End: </b>{moment(selectedEvent?.value.dateEnd, 'YYYY-MM-DDTHH:mm:ss').format('ddd, MMM Do YYYY')}</p>}
                         <Alert variant={"danger"}><b>ADVANCED EVENT SETTINGS:</b><br />If your event includes non-competing teams in the team list, indicate the number of non-competing teams here. <b>THIS IS A RARE CONDITION</b><Select classNamePrefix="gatool-rs" options={teamReducer} value={teamReduction ? teamReduction : teamReducer[0]} onChange={setTeamReduction} isDisabled={!teamList?.teamCountTotal} /><br />
-                            If your event requires a reduced Alliance Count, you can override the Alliance Count here. <b>THIS SHOULD ONLY APPLY TO EVENTS WITH LESS THAN 26 TEAMS. </b><Select classNamePrefix="gatool-rs" options={playoffOverrideMenu} value={playoffCountOverride ? playoffCountOverride : (allianceCount?.menu ? allianceCount.menu : playoffOverrideMenu[0])} onChange={setPlayoffCountOverride} />
+                            {selectedEvent?.value?.type?.includes("OffSeason")
+                                ? "If your event requires a non-standard Alliance Count, you can override the Alliance Count here."
+                                : <span>If your event requires a reduced Alliance Count, you can override the Alliance Count here. <b>THIS SHOULD ONLY APPLY TO EVENTS WITH LESS THAN 26 TEAMS.</b></span>
+                            }
+                            <Select classNamePrefix="gatool-rs"
+                                options={selectedEvent?.value?.type?.includes("OffSeason") ? playoffOverrideMenuOffseason : playoffOverrideMenu}
+                                value={playoffCountOverride ? playoffCountOverride : (allianceCount?.menu ? allianceCount.menu : (selectedEvent?.value?.type?.includes("OffSeason") ? playoffOverrideMenuOffseason[0] : playoffOverrideMenu[0]))}
+                                onChange={setPlayoffCountOverride} />
                         </Alert>
                         <div>
                             {!ftcMode && (


### PR DESCRIPTION
This updates the test match mode to provide access to a fourth Alliance member slot. It also detects when Alliances are known and displays a new Alliance picker to quickly populate the Alliances during playoffs. This is to better support events with non-standard playoff structures, which could have more than 8 Alliances or more than three members on an Alliance.

This also introduces flexible Alliance Selection configuration for offseason events. Users can now configure up to 16 Alliances and include a 4th member on the Alliance. Additionally, it allows the user to reconfigure the Alliance Selection round selection order to accommodate non-standard Alliance Selection flows.