### PR TITLE
Resilience for non-standard events

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -92,6 +92,25 @@ td {
   text-align: left;
 }
 
+.data-source-badge {
+  display: inline-block;
+  font-size: 0.72em;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background-color: #e0e7ff;
+  color: #3730a3;
+  border: 1px solid #c7d2fe;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+[data-bs-theme="dark"] .data-source-badge {
+  background-color: #1e1b4b;
+  color: #a5b4fc;
+  border-color: #3730a3;
+}
+
 .TBAButton {
   margin-right: 10px;
   margin-bottom: 10px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -295,6 +295,7 @@ function App() {
     usePullDownToUpdate, setUsePullDownToUpdate,
     useScrollMemory, setUseScrollMemory,
     useFourTeamAlliances, setUseFourTeamAlliances,
+    nonStandardPlayoffs, setNonStandardPlayoffs,
     // Event list filters
     eventFilters, setEventFilters,
     regionFilters, setRegionFilters,
@@ -900,6 +901,7 @@ function App() {
       ftcMode: ftcMode,
       useCheesyArena: useCheesyArena,
       useFourTeamAlliances: useFourTeamAlliances,
+      nonStandardPlayoffs: nonStandardPlayoffs,
       useFTCOffline: useFTCOffline,
       FTCKey: FTCKey,
       FTCServerURL: FTCServerURL,
@@ -1727,6 +1729,9 @@ function App() {
         }
         if (userPrefs.useFourTeamAlliances !== undefined && userPrefs.useFourTeamAlliances !== useFourTeamAlliances) {
           setUseFourTeamAlliances(userPrefs.useFourTeamAlliances);
+        }
+        if (userPrefs.nonStandardPlayoffs !== undefined && userPrefs.nonStandardPlayoffs !== nonStandardPlayoffs) {
+          setNonStandardPlayoffs(userPrefs.nonStandardPlayoffs);
         }
         if (userPrefs.useFTCOffline !== undefined && userPrefs.useFTCOffline !== useFTCOffline) {
           setUseFTCOffline(userPrefs.useFTCOffline);

--- a/src/components/BottomButtons.jsx
+++ b/src/components/BottomButtons.jsx
@@ -26,11 +26,11 @@ function BottomButtons({
   districts,
   ftcLeagues,
 }) {
-  const { showWorldAndStatsOnAnnouncePlayByPlay, highScoreMode } = useSettings();
+  const { showWorldAndStatsOnAnnouncePlayByPlay, highScoreMode, nonStandardPlayoffs } = useSettings();
     var matches = playoffSchedule?.schedule;
     var eventHighScore = eventHighScores?.highscores?.overallqual;
     if (!highScoreMode) {
-        if (matchDetails?.tournamentLevel.toLowerCase() === "playoff") {
+        if (matchDetails?.tournamentLevel?.toLowerCase() === "playoff") {
             eventHighScore = eventHighScores?.highscores?.overallplayoff;
         }
     } else
@@ -39,7 +39,9 @@ function BottomButtons({
         }
     const hasEventHighScore = Number(eventHighScore?.score) > 0;
     const isDaVinci = selectedEvent?.value?.code === "FTCCMP1";
-
+    const isPlayoff = matchDetails?.tournamentLevel?.toLowerCase() === "playoff";
+    const showPlayoffDetails = !nonStandardPlayoffs && isPlayoff &&
+      (!isDaVinci || matchDetails?.series >= 16);
 
     return (
       <>
@@ -61,8 +63,7 @@ function BottomButtons({
               </Button>
             )}
           </Col>
-          {matchDetails?.tournamentLevel.toLowerCase() === "playoff" &&
-            (!isDaVinci || (isDaVinci && matchDetails?.series >= 16)) && (
+          {showPlayoffDetails && (
               <Col
                 xs={hasEventHighScore ? "5" : "8"}
                 lg={hasEventHighScore ? "4" : "6"}
@@ -80,27 +81,15 @@ function BottomButtons({
 
           {hasEventHighScore && (
             <Col
-              xs={
-                matchDetails?.tournamentLevel.toLowerCase() !== "playoff"
-                  ? "8"
-                  : isDaVinci && matchDetails?.series < 16
-                    ? "8"
-                    : "3"
-              }
-              lg={
-                matchDetails?.tournamentLevel.toLowerCase() !== "playoff"
-                  ? "6"
-                  : isDaVinci && matchDetails?.series < 16
-                    ? "6"
-                    : "2"
-              }
+              xs={showPlayoffDetails ? "3" : "8"}
+              lg={showPlayoffDetails ? "2" : "6"}
             >
               <div className="border rounded p-2 h-100 gatool-highscores-summary-panel gatool-highscores-summary--event">
                 <p className="mb-0">
                   <b>
                     {highScoreMode
                       ? "Event"
-                      : matchDetails?.tournamentLevel.toLowerCase() ===
+                      : matchDetails?.tournamentLevel?.toLowerCase() ===
                           "playoff"
                         ? "Playoffs"
                         : "Quals"}{" "}
@@ -114,8 +103,7 @@ function BottomButtons({
             </Col>
           )}
 
-          {matchDetails?.tournamentLevel.toLowerCase() !== "playoff" &&
-            !hasEventHighScore && (
+          {!showPlayoffDetails && !hasEventHighScore && (
               <Col xs={"8"} lg={"6"}>
                 <h4 className="gatool-awaiting-inline">
                   {currentMatch === 1

--- a/src/components/Bracket.jsx
+++ b/src/components/Bracket.jsx
@@ -356,26 +356,31 @@ function Bracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule, currentMat
 			};
 		}
 
+		const setTeamNum = (match, station, num) => {
+			const t = match?.teams?.find((tm) => tm.station === station);
+			if (t) t.teamNumber = num;
+		};
+
 		if (winnerTo <= 14) {
 			if (winnerTo) {
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `${winnerStation}1` })].teamNumber = tempTeams[winningAlliance][0];
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `${winnerStation}2` })].teamNumber = tempTeams[winningAlliance][1];
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `${winnerStation}3` })].teamNumber = tempTeams[winningAlliance][2];
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `${winnerStation}1`, tempTeams[winningAlliance][0]);
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `${winnerStation}2`, tempTeams[winningAlliance][1]);
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `${winnerStation}3`, tempTeams[winningAlliance][2]);
 			}
 
 			if (loserTo) {
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `${loserStation}1` })].teamNumber = tempTeams[losingAlliance][0];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `${loserStation}2` })].teamNumber = tempTeams[losingAlliance][1];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `${loserStation}3` })].teamNumber = tempTeams[losingAlliance][2];
+				setTeamNum(tempMatches.schedule[loserTo - 1], `${loserStation}1`, tempTeams[losingAlliance][0]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `${loserStation}2`, tempTeams[losingAlliance][1]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `${loserStation}3`, tempTeams[losingAlliance][2]);
 			}
 		} else {
 			if (winnerTo) {
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `Red1` })].teamNumber = tempTeams["red"][0];
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `Red2` })].teamNumber = tempTeams["red"][1];
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `Red3` })].teamNumber = tempTeams["red"][2];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `Blue1` })].teamNumber = tempTeams["blue"][0];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `Blue2` })].teamNumber = tempTeams["blue"][1];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `Blue3` })].teamNumber = tempTeams["blue"][2];
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `Red1`, tempTeams["red"][0]);
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `Red2`, tempTeams["red"][1]);
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `Red3`, tempTeams["red"][2]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `Blue1`, tempTeams["blue"][0]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `Blue2`, tempTeams["blue"][1]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `Blue3`, tempTeams["blue"][2]);
 			}
 		}
 

--- a/src/components/FourAllianceBracket.jsx
+++ b/src/components/FourAllianceBracket.jsx
@@ -201,26 +201,31 @@ function FourAllianceBracket({ currentMatch, qualsLength, nextMatch, previousMat
 			};
 		}
 
+		const setTeamNum = (match, station, num) => {
+			const t = match?.teams?.find((tm) => tm.station === station);
+			if (t) t.teamNumber = num;
+		};
+
 		if (winnerTo <= 14) {
 			if (winnerTo) {
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `${winnerStation}1` })].teamNumber = tempTeams[winningAlliance][0];
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `${winnerStation}2` })].teamNumber = tempTeams[winningAlliance][1];
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `${winnerStation}3` })].teamNumber = tempTeams[winningAlliance][2];
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `${winnerStation}1`, tempTeams[winningAlliance][0]);
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `${winnerStation}2`, tempTeams[winningAlliance][1]);
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `${winnerStation}3`, tempTeams[winningAlliance][2]);
 			}
 
 			if (loserTo) {
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `${loserStation}1` })].teamNumber = tempTeams[losingAlliance][0];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `${loserStation}2` })].teamNumber = tempTeams[losingAlliance][1];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `${loserStation}3` })].teamNumber = tempTeams[losingAlliance][2];
+				setTeamNum(tempMatches.schedule[loserTo - 1], `${loserStation}1`, tempTeams[losingAlliance][0]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `${loserStation}2`, tempTeams[losingAlliance][1]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `${loserStation}3`, tempTeams[losingAlliance][2]);
 			}
 		} else {
 			if (winnerTo) {
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `Red1` })].teamNumber = tempTeams["red"][0];
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `Red2` })].teamNumber = tempTeams["red"][1];
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `Red3` })].teamNumber = tempTeams["red"][2];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `Blue1` })].teamNumber = tempTeams["blue"][0];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `Blue2` })].teamNumber = tempTeams["blue"][1];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `Blue3` })].teamNumber = tempTeams["blue"][2];
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `Red1`, tempTeams["red"][0]);
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `Red2`, tempTeams["red"][1]);
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `Red3`, tempTeams["red"][2]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `Blue1`, tempTeams["blue"][0]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `Blue2`, tempTeams["blue"][1]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `Blue3`, tempTeams["blue"][2]);
 			}
 		}
 

--- a/src/components/FourAllianceBracketFTC.jsx
+++ b/src/components/FourAllianceBracketFTC.jsx
@@ -264,26 +264,31 @@ function FourAllianceBracketFTC({ currentMatch, qualsLength, nextMatch, previous
 			};
 		}
 
+		const setTeamNum = (match, station, num) => {
+			const t = match?.teams?.find((tm) => tm.station === station);
+			if (t) t.teamNumber = num;
+		};
+
 		if (winnerTo <= 14) {
 			if (winnerTo) {
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `${winnerStation}1` })].teamNumber = tempTeams[winningAlliance][0];
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `${winnerStation}2` })].teamNumber = tempTeams[winningAlliance][1];
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `${winnerStation}3` })].teamNumber = tempTeams[winningAlliance][2];
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `${winnerStation}1`, tempTeams[winningAlliance][0]);
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `${winnerStation}2`, tempTeams[winningAlliance][1]);
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `${winnerStation}3`, tempTeams[winningAlliance][2]);
 			}
 
 			if (loserTo) {
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `${loserStation}1` })].teamNumber = tempTeams[losingAlliance][0];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `${loserStation}2` })].teamNumber = tempTeams[losingAlliance][1];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `${loserStation}3` })].teamNumber = tempTeams[losingAlliance][2];
+				setTeamNum(tempMatches.schedule[loserTo - 1], `${loserStation}1`, tempTeams[losingAlliance][0]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `${loserStation}2`, tempTeams[losingAlliance][1]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `${loserStation}3`, tempTeams[losingAlliance][2]);
 			}
 		} else {
 			if (winnerTo) {
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `Red1` })].teamNumber = tempTeams["red"][0];
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `Red2` })].teamNumber = tempTeams["red"][1];
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `Red3` })].teamNumber = tempTeams["red"][2];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `Blue1` })].teamNumber = tempTeams["blue"][0];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `Blue2` })].teamNumber = tempTeams["blue"][1];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `Blue3` })].teamNumber = tempTeams["blue"][2];
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `Red1`, tempTeams["red"][0]);
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `Red2`, tempTeams["red"][1]);
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `Red3`, tempTeams["red"][2]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `Blue1`, tempTeams["blue"][0]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `Blue2`, tempTeams["blue"][1]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `Blue3`, tempTeams["blue"][2]);
 			}
 		}
 

--- a/src/components/PlayoffDetails.jsx
+++ b/src/components/PlayoffDetails.jsx
@@ -121,7 +121,7 @@ function PlayoffDetails({
   ];
 
   _.forEach(
-    byeCount[playoffCountOverride?.value || 8].replacementMatchClasses,
+    (byeCount[playoffCountOverride?.value || 8] ?? byeCount[8]).replacementMatchClasses,
     (match) => {
       var tempClass = _.findIndex(matchClasses, {
         matchNumber: match.matchNumber,
@@ -149,7 +149,7 @@ function PlayoffDetails({
       })[0]
     : null;
 
-  if (matchDetails?.tournamentLevel.toLowerCase() === "playoff") {
+  if (matchDetails?.tournamentLevel?.toLowerCase() === "playoff") {
     // In FTC mode, Red (higher seed) starts with an advantage: Red has 0 losses, Blue has 1 loss
     // This means Red needs 1 win to win the series, Blue needs 2 wins
     // Initialize: Red starts with advantage of 1 (equivalent to Blue having 1 loss)

--- a/src/components/SixAllianceBracket.jsx
+++ b/src/components/SixAllianceBracket.jsx
@@ -317,26 +317,31 @@ function SixAllianceBracket({ offlinePlayoffSchedule, setOfflinePlayoffSchedule,
 			};
 		}
 
+		const setTeamNum = (match, station, num) => {
+			const t = match?.teams?.find((tm) => tm.station === station);
+			if (t) t.teamNumber = num;
+		};
+
 		if (winnerTo <= 10) {
 			if (winnerTo) {
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `${winnerStation}1` })].teamNumber = tempTeams[winningAlliance][0];
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `${winnerStation}2` })].teamNumber = tempTeams[winningAlliance][1];
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `${winnerStation}3` })].teamNumber = tempTeams[winningAlliance][2];
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `${winnerStation}1`, tempTeams[winningAlliance][0]);
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `${winnerStation}2`, tempTeams[winningAlliance][1]);
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `${winnerStation}3`, tempTeams[winningAlliance][2]);
 			}
 
 			if (loserTo) {
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `${loserStation}1` })].teamNumber = tempTeams[losingAlliance][0];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `${loserStation}2` })].teamNumber = tempTeams[losingAlliance][1];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `${loserStation}3` })].teamNumber = tempTeams[losingAlliance][2];
+				setTeamNum(tempMatches.schedule[loserTo - 1], `${loserStation}1`, tempTeams[losingAlliance][0]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `${loserStation}2`, tempTeams[losingAlliance][1]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `${loserStation}3`, tempTeams[losingAlliance][2]);
 			}
 		} else {
 			if (winnerTo) {
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `Red1` })].teamNumber = tempTeams["red"][0];
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `Red2` })].teamNumber = tempTeams["red"][1];
-				tempMatches.schedule[winnerTo - 1].teams[_.findIndex(tempMatches.schedule[winnerTo - 1].teams, { "station": `Red3` })].teamNumber = tempTeams["red"][2];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `Blue1` })].teamNumber = tempTeams["blue"][0];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `Blue2` })].teamNumber = tempTeams["blue"][1];
-				tempMatches.schedule[loserTo - 1].teams[_.findIndex(tempMatches.schedule[loserTo - 1].teams, { "station": `Blue3` })].teamNumber = tempTeams["blue"][2];
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `Red1`, tempTeams["red"][0]);
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `Red2`, tempTeams["red"][1]);
+				setTeamNum(tempMatches.schedule[winnerTo - 1], `Red3`, tempTeams["red"][2]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `Blue1`, tempTeams["blue"][0]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `Blue2`, tempTeams["blue"][1]);
+				setTeamNum(tempMatches.schedule[loserTo - 1], `Blue3`, tempTeams["blue"][2]);
 			}
 		}
 

--- a/src/contexts/SettingsContext.jsx
+++ b/src/contexts/SettingsContext.jsx
@@ -115,6 +115,10 @@ export function SettingsProvider({ children }) {
     "setting:useFourTeamAlliances",
     null
   );
+  const [nonStandardPlayoffs, setNonStandardPlayoffs] = usePersistentState(
+    "setting:nonStandardPlayoffs",
+    null
+  );
 
   // Event list filters
   const [eventFilters, setEventFilters] = usePersistentState(
@@ -198,6 +202,7 @@ export function SettingsProvider({ children }) {
     usePullDownToUpdate, setUsePullDownToUpdate,
     useScrollMemory, setUseScrollMemory,
     useFourTeamAlliances, setUseFourTeamAlliances,
+    nonStandardPlayoffs, setNonStandardPlayoffs,
     // Event list filters
     eventFilters, setEventFilters,
     regionFilters, setRegionFilters,
@@ -223,6 +228,7 @@ export function SettingsProvider({ children }) {
     highScoreMode, autoUpdate, awardsMenu, showQualsStats, showQualsStatsQuals,
     teamReduction, reverseEmcee, useSwipe, usePullDownToUpdate, useScrollMemory,
     useFourTeamAlliances,
+    nonStandardPlayoffs,
     eventFilters, regionFilters, timeFilter,
     rankingsOverride, allianceCount, playoffCountOverride, allianceSelectionRoundOrder,
     syncEvent, screenMode, screenModeSyncFrequency,
@@ -236,6 +242,7 @@ export function SettingsProvider({ children }) {
     setHighScoreMode, setAutoUpdate, setAwardsMenu, setShowQualsStats, setShowQualsStatsQuals,
     setTeamReduction, setReverseEmcee, setUseSwipe, setUsePullDownToUpdate, setUseScrollMemory,
     setUseFourTeamAlliances,
+    setNonStandardPlayoffs,
     setEventFilters, setRegionFilters, setTimeFilter,
     setRankingsOverride, setAllianceCount, setPlayoffCountOverride, setAllianceSelectionRoundOrder,
     setSyncEvent, setScreenMode, setScreenModeSyncFrequency,

--- a/src/data/appUpdates.js
+++ b/src/data/appUpdates.js
@@ -1,5 +1,18 @@
 export const appUpdates = [
   {
+    date: "June 5, 2026",
+    message: (
+      <>
+      <b>OFFSEASON UPDATES</b><br />
+      <ul>
+        <li>FRC:</li>
+        <ul>
+          <li>When using a registered FRC event, if gatool cannot get event data from FIRST API, we will now attempt to load event data from TBA API. If that fails, we will fall back to Nexus API for schedule.</li>
+        </ul>
+      </ul>
+      </>
+    ),
+  },{
     date: "June 3, 2026",
     message: (
       <>

--- a/src/hooks/useRankingsAlliances.js
+++ b/src/hooks/useRankingsAlliances.js
@@ -196,6 +196,7 @@ export function useRankingsAlliances(deps) {
       undefined,
       signal()
     );
+    if (result.status !== 200) return;
     districtranks = await result.json();
     districtranks.lastUpdate = moment().format();
     setDistrictRankings(districtranks);
@@ -209,11 +210,13 @@ export function useRankingsAlliances(deps) {
     const getRanksEpoch = getRanksEpochRef.current;
     var result = null;
     var ranks = null;
+    var ranksDataSource = "FRC";
     if (selectedEvent?.value?.code.includes("OFFLINE")) {
       ranks = { rankings: { Rankings: [] } };
     } else if (!selectedEvent?.value?.code.includes("PRACTICE")) {
       ranks = { rankings: { Rankings: [] } };
       if (useCheesyArena && cheesyArenaAvailable) {
+        ranksDataSource = "Cheesy Arena";
         result = await fetchLocal("http://10.0.100.5:8080/api/rankings");
         if (result.status === 200) {
           var data = await result.json();
@@ -232,6 +235,7 @@ export function useRankingsAlliances(deps) {
         FTCOfflineAvailable &&
         ftcMode?.value === "FTCLocal"
       ) {
+        ranksDataSource = "FTC Local Server";
         console.log("Using FTC Local Server for ranks");
         const rankingsResult = await httpClient.getNoAuth(
           `/api/v1/events/${selectedEvent?.value.code}/rankings/`,
@@ -259,6 +263,7 @@ export function useRankingsAlliances(deps) {
         selectedEvent?.value?.type === "OffSeason" &&
         !ftcMode
       ) {
+        ranksDataSource = "TBA";
         console.log("Using TBA for Offseason Event Rankings");
         const eventKey = selectedEvent?.value?.tbaEventKey;
 
@@ -286,7 +291,43 @@ export function useRankingsAlliances(deps) {
             ranks = { rankings: { Rankings: [] } };
           }
         }
+      } else if (
+        !useFTCOffline &&
+        selectedEvent?.value?.type === "OffSeasonWithAzureSync" &&
+        !ftcMode
+      ) {
+        // OffSeasonWithAzureSync: FRC primary, TBA fallback.
+        let frcRankingsResult = null;
+        result = await httpClient.getNoAuth(
+          `${selectedYear?.value}/rankings/${selectedEvent?.value.code}`,
+          undefined,
+          undefined,
+          undefined,
+          signal()
+        );
+        if (result.status === 200) {
+          frcRankingsResult = await result.json();
+        }
+        const frcHasRankings =
+          (frcRankingsResult?.Rankings?.length > 0) ||
+          (frcRankingsResult?.rankings?.Rankings?.length > 0) ||
+          (frcRankingsResult?.rankings?.rankings?.length > 0);
+        if (frcHasRankings) {
+          ranks = frcRankingsResult;
+          ranksDataSource = ftcMode ? "FTC API" : "FRC";
+        } else if (selectedEvent?.value?.tbaEventKey) {
+          console.log("FRC returned no rankings; falling back to TBA for OffSeasonWithAzureSync");
+          const tbaRankings = await fetchTBARankings(
+            selectedEvent?.value?.tbaEventKey,
+            selectedYear?.value
+          );
+          if (tbaRankings?.rankings?.rankings?.length > 0) {
+            ranks = { rankings: { rankings: tbaRankings.rankings.rankings } };
+            ranksDataSource = "TBA";
+          }
+        }
       } else if (!useFTCOffline) {
+        ranksDataSource = ftcMode ? "FTC API" : "FRC";
         result = await httpClient.getNoAuth(
           `${selectedYear?.value}/rankings/${selectedEvent?.value.code}`,
           ftcMode ? ftcBaseURL : undefined,
@@ -380,6 +421,8 @@ export function useRankingsAlliances(deps) {
       });
     }
 
+    ranks.dataSource = ranksDataSource;
+
     ranks.lastModified = ranks.headers
       ? moment(ranks?.headers["last-modified"]).format()
       : moment().format();
@@ -415,17 +458,19 @@ export function useRankingsAlliances(deps) {
 
   // --- getAlliances ---
 
-  async function getAlliances(allianceTemp) {
+  async function getAlliances(allianceTemp, overrideExpectedCount = null) {
     console.log("Getting Alliances");
     getAlliancesEpochRef.current += 1;
     const getAlliancesEpoch = getAlliancesEpochRef.current;
     var result = null;
     var alliancesData = allianceTemp || { Alliances: [] };
+    var alliancesDataSource = "FRC";
     if (
       !selectedEvent?.value?.code.includes("PRACTICE") &&
       !selectedEvent?.value?.code.includes("OFFLINE")
     ) {
       if (useCheesyArena && cheesyArenaAvailable) {
+        alliancesDataSource = "Cheesy Arena";
         result = await fetchLocal("http://10.0.100.5:8080/api/alliances");
         var data = await result.json();
         if (data.length > 0) {
@@ -449,6 +494,7 @@ export function useRankingsAlliances(deps) {
         FTCOfflineAvailable &&
         ftcMode?.value === "FTCLocal"
       ) {
+        alliancesDataSource = "FTC Local Server";
         console.log("Using FTC Local Server for Alliances");
         const allianceResult = await httpClient.getNoAuth(
           `/api/v1/events/${selectedEvent?.value.code}/elim/alliances/`,
@@ -474,6 +520,7 @@ export function useRankingsAlliances(deps) {
         selectedEvent?.value?.type === "OffSeason" &&
         !ftcMode
       ) {
+        alliancesDataSource = "TBA";
         console.log("Using TBA for Offseason Event Alliances");
         const eventKey = selectedEvent?.value?.tbaEventKey;
 
@@ -499,7 +546,47 @@ export function useRankingsAlliances(deps) {
             );
           }
         }
+      } else if (
+        !useFTCOffline &&
+        selectedEvent?.value?.type === "OffSeasonWithAzureSync" &&
+        !ftcMode
+      ) {
+        // OffSeasonWithAzureSync: FRC primary, TBA fallback.
+        let frcHasAlliances = false;
+        result = await httpClient.getNoAuth(
+          `${selectedYear?.value}/alliances/${selectedEvent?.value.code}`,
+          undefined,
+          undefined,
+          undefined,
+          signal()
+        );
+        if (result.status === 200) {
+          const frcAlliancesResult = await result.json();
+          const frcAlliances = frcAlliancesResult?.alliances ?? frcAlliancesResult?.Alliances;
+          const frcCount = frcAlliances?.length ?? 0;
+          const expectedCount = overrideExpectedCount ?? allianceCount?.count ?? 0;
+          // Accept FRC data only when it's non-empty AND matches (or exceeds) the
+          // expected alliance count. A partial list means alliance selection is still
+          // in progress on FRC — fall back to TBA which may already have the full set.
+          if (frcCount > 0 && (expectedCount === 0 || frcCount >= expectedCount)) {
+            alliancesData = frcAlliancesResult;
+            alliancesDataSource = "FRC";
+            frcHasAlliances = true;
+          }
+        }
+        if (!frcHasAlliances && selectedEvent?.value?.tbaEventKey) {
+          console.log("FRC returned incomplete or no alliances; falling back to TBA for OffSeasonWithAzureSync");
+          const tbaAlliances = await fetchTBAAlliances(
+            selectedEvent?.value?.tbaEventKey,
+            selectedYear?.value
+          );
+          if (tbaAlliances?.alliances?.length > 0) {
+            alliancesData = { Alliances: tbaAlliances.alliances, count: tbaAlliances.count };
+            alliancesDataSource = "TBA";
+          }
+        }
       } else if (!useFTCOffline) {
+        alliancesDataSource = ftcMode ? "FTC API" : "FRC";
         result = await httpClient.getNoAuth(
           `${selectedYear?.value}/alliances/${selectedEvent?.value.code}`,
           ftcMode ? ftcBaseURL : undefined,
@@ -670,6 +757,7 @@ export function useRankingsAlliances(deps) {
       alliancesData.Lookup = allianceLookup;
     }
 
+    alliancesData.dataSource = alliancesDataSource;
     alliancesData.lastUpdate = moment().format();
     console.log(`${alliancesData?.alliances?.length} Alliances loaded.`);
     if (getAlliancesEpoch !== getAlliancesEpochRef.current) {
@@ -742,6 +830,7 @@ export function useRankingsAlliances(deps) {
         await setRankings(null);
         await setAllianceCount(null);
         await setRankingsOverride(null);
+        await setAlliances(null);
       }
       await setPlayoffs(false);
       await setDistrictRankings(null);

--- a/src/hooks/useRankingsAlliances.test.js
+++ b/src/hooks/useRankingsAlliances.test.js
@@ -15,7 +15,7 @@ import {
   EventSelectionProvider,
   useEventSelection,
 } from "../contexts/EventSelectionContext";
-import { SettingsProvider } from "../contexts/SettingsContext";
+import { SettingsProvider, useSettings } from "../contexts/SettingsContext";
 import { useRankingsAlliances } from "./useRankingsAlliances";
 
 const BASE = "https://api.gatool.org/v3";
@@ -40,14 +40,17 @@ function makeWrapper({
   selectedEvent = MAWOR_EVENT,
   selectedYear = YEAR_2026,
   ftcMode = null,
+  allianceCount: allianceCountSeed = undefined,
 } = {}) {
   function Seeder({ children }) {
     const ctx = useEventSelection();
+    const { setAllianceCount } = useSettings();
     const [seeded, setSeeded] = useState(false);
     useEffect(() => {
       ctx.setSelectedEvent(selectedEvent);
       ctx.setSelectedYear(selectedYear);
       ctx.setFTCMode(ftcMode);
+      if (allianceCountSeed !== undefined) setAllianceCount(allianceCountSeed);
       setSeeded(true);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
@@ -247,6 +250,217 @@ describe("useRankingsAlliances (FRC)", () => {
     expect(deps.setPlayoffs).not.toHaveBeenCalled();
   });
 
+  it("getRanks: uses TBA endpoint for OffSeason events", async () => {
+    const tbaRankings = {
+      rankings: {
+        rankings: [
+          { teamNumber: 1277, rank: 1, wins: 8, losses: 2, ties: 0 },
+          { teamNumber: 126, rank: 2, wins: 7, losses: 3, ties: 0 },
+        ],
+      },
+    };
+    server.use(
+      http.get(`${BASE}/2026/offseason/rankings/2026bcwpi/`, () =>
+        HttpResponse.json(tbaRankings)
+      )
+    );
+    const { result, deps } = await renderRA(
+      {},
+      {
+        selectedEvent: {
+          value: { code: "BCWPI", name: "BattleCry", type: "OffSeason", tbaEventKey: "2026bcwpi" },
+          label: "BattleCry",
+        },
+      }
+    );
+
+    await result.current.getRanks();
+
+    await waitFor(() => expect(deps.setRankings).toHaveBeenCalled());
+    const committed = deps.setRankings.mock.calls.at(-1)[0];
+    expect(committed.ranks).toHaveLength(2);
+    expect(committed.ranks[0].teamNumber).toBe(1277);
+  });
+
+  it("getRanks: uses TBA endpoint for OffSeasonWithAzureSync events", async () => {
+    const tbaRankings = {
+      rankings: {
+        rankings: [{ teamNumber: 190, rank: 1, wins: 9, losses: 1, ties: 0 }],
+      },
+    };
+    server.use(
+      http.get(`${BASE}/2026/offseason/rankings/2026bcwpi/`, () =>
+        HttpResponse.json(tbaRankings)
+      )
+    );
+    const { result, deps } = await renderRA(
+      {},
+      {
+        selectedEvent: {
+          value: { code: "BCWPI", name: "BattleCry", type: "OffSeasonWithAzureSync", tbaEventKey: "2026bcwpi" },
+          label: "BattleCry",
+        },
+      }
+    );
+
+    await result.current.getRanks();
+
+    await waitFor(() => expect(deps.setRankings).toHaveBeenCalled());
+    const committed = deps.setRankings.mock.calls.at(-1)[0];
+    expect(committed.ranks).toHaveLength(1);
+    expect(committed.ranks[0].teamNumber).toBe(190);
+  });
+
+  it("getAlliances: uses TBA endpoint for OffSeason events", async () => {
+    const tbaAlliances = {
+      alliances: [
+        { number: 1, name: "Alliance 1", captain: 1277, round1: 126, round2: 5494 },
+        { number: 2, name: "Alliance 2", captain: 190, round1: 3467, round2: 8085 },
+      ],
+      count: 2,
+    };
+    server.use(
+      http.get(`${BASE}/2026/offseason/alliances/2026bcwpi/`, () =>
+        HttpResponse.json(tbaAlliances)
+      )
+    );
+    const { result, deps } = await renderRA(
+      {},
+      {
+        selectedEvent: {
+          value: { code: "BCWPI", name: "BattleCry", type: "OffSeason", tbaEventKey: "2026bcwpi" },
+          label: "BattleCry",
+        },
+      }
+    );
+
+    await result.current.getAlliances();
+
+    await waitFor(() => expect(deps.setAlliances).toHaveBeenCalled());
+    const committed = deps.setAlliances.mock.calls.at(-1)[0];
+    expect(committed.alliances).toHaveLength(2);
+    expect(committed.alliances[0].captain).toBe(1277);
+    expect(deps.setPlayoffs).toHaveBeenCalledWith(true);
+  });
+
+  it("getAlliances: uses TBA endpoint for OffSeasonWithAzureSync events", async () => {
+    const tbaAlliances = {
+      alliances: [
+        { number: 1, name: "Alliance 1", captain: 190, round1: 1277, round2: 126 },
+      ],
+      count: 1,
+    };
+    server.use(
+      http.get(`${BASE}/2026/offseason/alliances/2026bcwpi/`, () =>
+        HttpResponse.json(tbaAlliances)
+      )
+    );
+    const { result, deps } = await renderRA(
+      {},
+      {
+        selectedEvent: {
+          value: { code: "BCWPI", name: "BattleCry", type: "OffSeasonWithAzureSync", tbaEventKey: "2026bcwpi" },
+          label: "BattleCry",
+        },
+      }
+    );
+
+    await result.current.getAlliances();
+
+    await waitFor(() => expect(deps.setAlliances).toHaveBeenCalled());
+    const committed = deps.setAlliances.mock.calls.at(-1)[0];
+    expect(committed.alliances).toHaveLength(1);
+    expect(committed.alliances[0].captain).toBe(190);
+    expect(deps.setPlayoffs).toHaveBeenCalledWith(true);
+  });
+
+  it("getAlliances: falls back to TBA when FRC returns fewer alliances than expected count", async () => {
+    // FRC returns only 1 alliance but the event expects 4 → fall back to TBA.
+    const frcIncompleteAlliances = {
+      Alliances: [
+        { number: 1, name: "Alliance 1", captain: 190, round1: 1277, round2: 126 },
+      ],
+      count: 1,
+    };
+    const tbaAlliances = {
+      alliances: [
+        { number: 1, name: "Alliance 1", captain: 190, round1: 1277, round2: 126 },
+        { number: 2, name: "Alliance 2", captain: 3467, round1: 1768, round2: 5494 },
+        { number: 3, name: "Alliance 3", captain: 8085, round1: 2523, round2: 6328 },
+        { number: 4, name: "Alliance 4", captain: 4048, round1: 1519, round2: 2168 },
+      ],
+      count: 4,
+    };
+    server.use(
+      http.get(`${BASE}/2026/alliances/BCWPI`, () =>
+        HttpResponse.json(frcIncompleteAlliances)
+      ),
+      http.get(`${BASE}/2026/offseason/alliances/2026bcwpi/`, () =>
+        HttpResponse.json(tbaAlliances)
+      )
+    );
+    const { result, deps } = await renderRA(
+      {},
+      {
+        selectedEvent: {
+          value: { code: "BCWPI", name: "BattleCry", type: "OffSeasonWithAzureSync", tbaEventKey: "2026bcwpi" },
+          label: "BattleCry",
+        },
+        allianceCount: { count: 4 },
+      }
+    );
+
+    await result.current.getAlliances();
+
+    await waitFor(() => expect(deps.setAlliances).toHaveBeenCalled());
+    const committed = deps.setAlliances.mock.calls.at(-1)[0];
+    // Should have 4 alliances from TBA, not 1 from FRC.
+    expect(committed.alliances).toHaveLength(4);
+    expect(committed.alliances[0].captain).toBe(190);
+    expect(committed.alliances[1].captain).toBe(3467);
+    expect(committed.dataSource).toBe("TBA");
+    expect(deps.setPlayoffs).toHaveBeenCalledWith(true);
+  });
+
+  it("getAlliances: uses FRC data when alliance count matches expected count", async () => {
+    // FRC returns 4 alliances and event expects 4 → use FRC, do NOT call TBA.
+    const frcAlliances = {
+      Alliances: [
+        { number: 1, name: "Alliance 1", captain: 190, round1: 1277, round2: 126 },
+        { number: 2, name: "Alliance 2", captain: 3467, round1: 1768, round2: 5494 },
+        { number: 3, name: "Alliance 3", captain: 8085, round1: 2523, round2: 6328 },
+        { number: 4, name: "Alliance 4", captain: 4048, round1: 1519, round2: 2168 },
+      ],
+      count: 4,
+    };
+    const tbaSpy = vi.fn(() => HttpResponse.json({ alliances: [], count: 0 }));
+    server.use(
+      http.get(`${BASE}/2026/alliances/BCWPI`, () =>
+        HttpResponse.json(frcAlliances)
+      ),
+      http.get(`${BASE}/2026/offseason/alliances/2026bcwpi/`, tbaSpy)
+    );
+    const { result, deps } = await renderRA(
+      {},
+      {
+        selectedEvent: {
+          value: { code: "BCWPI", name: "BattleCry", type: "OffSeasonWithAzureSync", tbaEventKey: "2026bcwpi" },
+          label: "BattleCry",
+        },
+        allianceCount: { count: 4 },
+      }
+    );
+
+    await result.current.getAlliances();
+
+    await waitFor(() => expect(deps.setAlliances).toHaveBeenCalled());
+    const committed = deps.setAlliances.mock.calls.at(-1)[0];
+    // Should use FRC data (4 alliances), TBA should NOT be called.
+    expect(committed.alliances).toHaveLength(4);
+    expect(committed.dataSource).toBe("FRC");
+    expect(tbaSpy).not.toHaveBeenCalled();
+  });
+
   it("getDistrictRanks: fetches and commits district rankings with lastUpdate", async () => {
     const districtPayload = {
       districtRanks: [
@@ -274,5 +488,63 @@ describe("useRankingsAlliances (FRC)", () => {
     const committed = deps.setDistrictRankings.mock.calls[0][0];
     expect(committed.districtRanks).toEqual(districtPayload.districtRanks);
     expect(committed.lastUpdate).toEqual(expect.any(String));
+  });
+
+  it("getDistrictRanks: does not commit rankings on non-200 response", async () => {
+    server.use(
+      http.get(
+        `${BASE}/:year/district/rankings/:district`,
+        () => new HttpResponse(null, { status: 404 })
+      )
+    );
+    const { result, deps } = await renderRA();
+
+    await result.current.getDistrictRanks();
+
+    // Allow any pending microtasks to flush.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(deps.setDistrictRankings).not.toHaveBeenCalled();
+  });
+});
+
+describe("useRankingsAlliances – resetRankingsAlliancesState", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("clears rankings, allianceCount, rankingsOverride, alliances, playoffs, and districtRankings when preserveOfflineData is false", async () => {
+    const { result, deps } = await renderRA();
+
+    await result.current.resetRankingsAlliancesState(false);
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(deps.setRankings).toHaveBeenCalledWith(null);
+    expect(deps.setAlliances).toHaveBeenCalledWith(null);
+    expect(deps.setDistrictRankings).toHaveBeenCalledWith(null);
+    expect(deps.setPlayoffs).toHaveBeenCalledWith(false);
+  });
+
+  it("preserves rankings and alliances (does not clear them) when preserveOfflineData is true", async () => {
+    const { result, deps } = await renderRA();
+
+    await result.current.resetRankingsAlliancesState(true);
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(deps.setRankings).not.toHaveBeenCalled();
+    expect(deps.setAlliances).not.toHaveBeenCalled();
+    // playoffs and districtRankings are always reset
+    expect(deps.setPlayoffs).toHaveBeenCalledWith(false);
+    expect(deps.setDistrictRankings).toHaveBeenCalledWith(null);
+  });
+
+  it("always resets playoffs to false regardless of preserveOfflineData", async () => {
+    const { result: r1 } = await renderRA();
+    const { result: r2, deps: deps2 } = await renderRA();
+
+    await r1.current.resetRankingsAlliancesState(false);
+    await r2.current.resetRankingsAlliancesState(true);
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(deps2.setPlayoffs).toHaveBeenCalledWith(false);
   });
 });

--- a/src/hooks/useScheduleLoader.js
+++ b/src/hooks/useScheduleLoader.js
@@ -92,8 +92,10 @@ export function useScheduleLoader(deps, opts = {}) {
    * Remaps a string team identifier to its numeric team number (e.g., "TeamA" -> 9990)
    */
   const remapStringToNumber = (teamString) => {
-    if (!teamRemappings) return Number(teamString);
-    return Number(teamRemappings.strings[teamString]) || Number(teamString) || null;
+    // Strip TBA-style "frc" prefix (e.g. "frc1277" → 1277) before numeric conversion.
+    const stripped = typeof teamString === "string" ? teamString.replace(/^frc/i, "") : teamString;
+    if (!teamRemappings) return Number(stripped) || null;
+    return Number(teamRemappings.strings[teamString]) || Number(stripped) || null;
   };
 
   /**
@@ -121,6 +123,35 @@ export function useScheduleLoader(deps, opts = {}) {
     } catch (error) {
       console.error("Error fetching TBA matches:", error);
       return [];
+    }
+  };
+
+  /**
+   * Helper function to fetch FRC Nexus schedule for an offseason event.
+   * Used as a fallback when TBA returns no playoff schedule.
+   * @param {string} nexusEventCode Event code without year prefix (e.g. "mawor1")
+   * @param {string} year Competition year
+   * @returns HybridScheduleResponse or null
+   */
+  const fetchNexusMatches = async (nexusEventCode, year) => {
+    try {
+      console.log(`Fetching FRC Nexus schedule for event: ${year}${nexusEventCode}`);
+      const result = await httpClient.getNoAuth(
+        `${year}/nexus/schedule/${nexusEventCode}`,
+        undefined,
+        undefined,
+        undefined,
+        signal()
+      );
+      if (result.status === 200) {
+        // @ts-ignore
+        const matches = await result.json();
+        return matches;
+      }
+      return null;
+    } catch (error) {
+      console.error("Error fetching FRC Nexus matches:", error);
+      return null;
     }
   };
 
@@ -158,6 +189,9 @@ export function useScheduleLoader(deps, opts = {}) {
     var playoffschedule = null;
     var playoffScores = null;
     var qualslength = 0;
+    var qualScheduleFromTBA = false;
+    var playoffScheduleFromTBA = false;
+    var playoffUsedNexus = false;
 
     console.log(
       `Fetching Practice Schedule for ${selectedEvent?.value?.name}...`
@@ -173,14 +207,15 @@ export function useScheduleLoader(deps, opts = {}) {
       selectedEvent?.value?.type === "OffSeason" &&
       selectedEvent?.value?.tbaEventKey
     ) {
-      // Skip practice schedule for TBA offseason events - TBA doesn't provide practice matches
+      // Skip practice schedule for TBA-primary offseason events — TBA doesn't provide practice matches.
+      // OffSeasonWithAzureSync falls through to the FRC practice path below.
       console.log("Skipping practice schedule for TBA offseason event");
       practiceschedule = { schedule: { schedule: [] } };
     } else if (!selectedEvent?.value?.code.includes("PRACTICE") && !ftcMode) {
       if (useCheesyArena && cheesyArenaAvailable) {
         // get schedule from Cheesy Arena
         var result = await fetchLocal("http://10.0.100.5:8080/api/matches/practice");
-        var data = await result.json();
+        var data = result.status === 200 ? await result.json() : [];
         if (data.length > 0) {
           // reformat data to match FIRST API format
           practiceschedule = {
@@ -260,7 +295,7 @@ export function useScheduleLoader(deps, opts = {}) {
         result = await fetchLocal(
           "http://10.0.100.5:8080/api/matches/qualification"
         );
-        data = await result.json();
+        data = result.status === 200 ? await result.json() : [];
         if (data.length > 0) {
           // reformat data to match FIRST API format
           qualschedule = {
@@ -416,6 +451,56 @@ export function useScheduleLoader(deps, opts = {}) {
             }
           }
         }
+      } else if (
+        !useFTCOffline &&
+        selectedEvent?.value?.type === "OffSeasonWithAzureSync" &&
+        !ftcMode
+      ) {
+        // OffSeasonWithAzureSync: FRC is the primary source (event data is Azure-synced).
+        // Fall back to TBA if FRC returns no schedule.
+        const qualsResult = await httpClient.getNoAuth(
+          `${selectedYear?.value}/schedule/hybrid/${selectedEvent?.value.code}/qual`,
+          undefined,
+          undefined,
+          undefined,
+          signal()
+        );
+        if (qualsResult.status === 200) {
+          // @ts-ignore
+          qualschedule = await qualsResult.json();
+        }
+        const frcHasQualData =
+          (qualschedule?.Schedule?.schedule?.length > 0) ||
+          (qualschedule?.schedule?.schedule?.length > 0) ||
+          (Array.isArray(qualschedule?.schedule) && qualschedule.schedule.length > 0);
+        if (!frcHasQualData && selectedEvent?.value?.tbaEventKey) {
+          console.log("FRC returned no qual schedule; falling back to TBA for OffSeasonWithAzureSync");
+          const tbaMatches = await fetchTBAMatches(selectedEvent?.value?.tbaEventKey, selectedYear?.value);
+          if (tbaMatches?.Schedule?.schedule?.length > 0) {
+            const qualMatches = tbaMatches.Schedule.schedule
+              .filter((match) => match.tournamentLevel === "Qual")
+              .sort((a, b) => a.matchNumber - b.matchNumber);
+            if (qualMatches.length > 0) {
+              const remappedMatches = qualMatches.map((match) => {
+                if (match.teams) {
+                  return {
+                    ...match,
+                    teams: match.teams.map((team) => {
+                      if (typeof team.teamNumber === "string") {
+                        const numericTeam = remapStringToNumber(team.teamNumber);
+                        if (numericTeam) return { ...team, teamNumber: numericTeam };
+                      }
+                      return team;
+                    }),
+                  };
+                }
+                return match;
+              });
+              qualschedule = { schedule: { schedule: remappedMatches } };
+              qualScheduleFromTBA = true;
+            }
+          }
+        }
       } else if (!useFTCOffline) {
         const qualsResult = await httpClient.getNoAuth(
           `${selectedYear?.value}/schedule/hybrid/${selectedEvent?.value.code}/qual`,
@@ -456,7 +541,7 @@ export function useScheduleLoader(deps, opts = {}) {
       !selectedEvent?.value?.code.includes("PRACTICE") &&
       !useFTCOffline &&
       qualschedule?.schedule?.schedule?.length > 0 &&
-      !(selectedEvent?.value?.type === "OffSeason")
+      selectedEvent?.value?.type !== "OffSeason" && !qualScheduleFromTBA
     ) {
       const qualsScoresResult = await httpClient.getNoAuth(
         `${selectedYear?.value}/scores/${selectedEvent?.value.code}/qual`,
@@ -498,7 +583,7 @@ export function useScheduleLoader(deps, opts = {}) {
       match.winner = winner(match, ftcMode);
       if (
         qualScores?.MatchScores &&
-        !(selectedEvent?.value?.type === "OffSeason")
+        selectedEvent?.value?.type !== "OffSeason" && !qualScheduleFromTBA
       ) {
         const matchResults = qualScores.MatchScores.filter((scoreMatch) => {
           return scoreMatch.matchNumber === match.matchNumber;
@@ -526,7 +611,7 @@ export function useScheduleLoader(deps, opts = {}) {
             );
           });
         }
-      } else if (selectedEvent?.value?.type === "OffSeason") {
+      } else if (selectedEvent?.value?.type === "OffSeason" || qualScheduleFromTBA) {
         match.scores = match?.matchScores || [];
         if (match?.matchScores) {
           delete match.matchScores;
@@ -579,6 +664,20 @@ export function useScheduleLoader(deps, opts = {}) {
     }
 
     qualschedule.completedMatchCount = completedMatchCount;
+
+    if (useCheesyArena && cheesyArenaAvailable) {
+      qualschedule.dataSource = "Cheesy Arena";
+    } else if (useFTCOffline) {
+      qualschedule.dataSource = "FTC Local Server";
+    } else if (ftcMode) {
+      qualschedule.dataSource = "FTC API";
+    } else if (selectedEvent?.value?.type === "OffSeason") {
+      qualschedule.dataSource = "TBA";
+    } else if (selectedEvent?.value?.type === "OffSeasonWithAzureSync") {
+      qualschedule.dataSource = qualScheduleFromTBA ? "TBA" : "FRC";
+    } else {
+      qualschedule.dataSource = "FRC";
+    }
 
     qualschedule.lastUpdate = moment().format();
 
@@ -778,6 +877,150 @@ export function useScheduleLoader(deps, opts = {}) {
             }
           }
         }
+
+        // FRC Nexus fallback: if TBA returned no playoff matches, try Nexus
+        if (!playoffschedule?.schedule?.length) {
+          // Derive Nexus event code: TBA key minus the 4-digit year prefix,
+          // or fall back to the lowercase FIRST event code
+          const nexusEventCode = eventKey
+            ? eventKey.replace(/^\d{4}/, "")
+            : selectedEvent?.value?.code?.toLowerCase();
+
+          if (nexusEventCode) {
+            console.log(`TBA returned no playoff matches; trying FRC Nexus for ${nexusEventCode}`);
+            const nexusMatches = await fetchNexusMatches(nexusEventCode, selectedYear?.value);
+
+            if (nexusMatches?.Schedule?.schedule?.length > 0) {
+              const nexusPlayoffMatches = nexusMatches.Schedule.schedule
+                .filter((match) => match.tournamentLevel === "Playoff")
+                .sort((a, b) => a.matchNumber - b.matchNumber);
+
+              if (nexusPlayoffMatches.length > 0) {
+                const remappedMatches = nexusPlayoffMatches.map((match) => {
+                  // Remap string team numbers; preserve description verbatim from Nexus.
+                  // Strip score fields — Nexus bracket structure is not guaranteed to
+                  // match the FRC double-elimination format the app uses for scoring.
+                  const remappedTeams = match.teams
+                    ? match.teams.map((team) => {
+                        if (typeof team.teamNumber === 'string') {
+                          const numericTeam = remapStringToNumber(team.teamNumber);
+                          if (numericTeam) return { ...team, teamNumber: numericTeam };
+                        }
+                        return team;
+                      })
+                    : match.teams;
+                  return {
+                    ...match,
+                    teams: remappedTeams,
+                    scoreRedFinal: null,
+                    scoreBlueFinal: null,
+                    scoreRedAuto: null,
+                    scoreBlueAuto: null,
+                    scoreRedFoul: null,
+                    scoreBlueFoul: null,
+                    scores: null,
+                    matchScores: null,
+                  };
+                });
+
+                playoffschedule = { schedule: remappedMatches };
+                playoffUsedNexus = true;
+                console.log(`Loaded ${remappedMatches.length} playoff matches from FRC Nexus`);
+              }
+            }
+          }
+        }
+      } else if (
+        !useFTCOffline &&
+        selectedEvent?.value?.type === "OffSeasonWithAzureSync" &&
+        !ftcMode
+      ) {
+        // OffSeasonWithAzureSync: FRC primary → TBA → Nexus fallback for playoffs.
+        const playoffResult = await httpClient.getNoAuth(
+          `${selectedYear?.value}/schedule/hybrid/${selectedEvent?.value.code}/playoff`,
+          undefined,
+          undefined,
+          undefined,
+          signal()
+        );
+        if (playoffResult.status === 200) {
+          // @ts-ignore
+          playoffschedule = await playoffResult.json();
+        }
+        const frcHasPlayoffData =
+          (playoffschedule?.Schedule?.schedule?.length > 0) ||
+          (playoffschedule?.schedule?.schedule?.length > 0) ||
+          (Array.isArray(playoffschedule?.schedule) && playoffschedule.schedule.length > 0);
+        if (!frcHasPlayoffData && selectedEvent?.value?.tbaEventKey) {
+          console.log("FRC returned no playoff schedule; falling back to TBA for OffSeasonWithAzureSync");
+          const tbaMatches = await fetchTBAMatches(selectedEvent?.value?.tbaEventKey, selectedYear?.value);
+          if (tbaMatches?.Schedule?.schedule?.length > 0) {
+            const playoffMatches = tbaMatches.Schedule.schedule
+              .filter((match) => match.tournamentLevel === "Playoff")
+              .sort((a, b) => a.matchNumber - b.matchNumber);
+            if (playoffMatches.length > 0) {
+              const remappedMatches = playoffMatches.map((match) => {
+                if (match.teams) {
+                  return {
+                    ...match,
+                    teams: match.teams.map((team) => {
+                      if (typeof team.teamNumber === "string") {
+                        const numericTeam = remapStringToNumber(team.teamNumber);
+                        if (numericTeam) return { ...team, teamNumber: numericTeam };
+                      }
+                      return team;
+                    }),
+                  };
+                }
+                return match;
+              });
+              playoffschedule = { schedule: remappedMatches };
+              playoffScheduleFromTBA = true;
+            }
+          }
+          // Nexus fallback if TBA also returned no playoff matches
+          if (!playoffScheduleFromTBA) {
+            const nexusEventCode = selectedEvent?.value?.tbaEventKey?.replace(/^\d{4}/, "")
+              || selectedEvent?.value?.code?.toLowerCase();
+            if (nexusEventCode) {
+              console.log(`TBA returned no playoff matches; trying FRC Nexus for ${nexusEventCode} (OffSeasonWithAzureSync)`);
+              const nexusMatches = await fetchNexusMatches(nexusEventCode, selectedYear?.value);
+              if (nexusMatches?.Schedule?.schedule?.length > 0) {
+                const nexusPlayoffMatches = nexusMatches.Schedule.schedule
+                  .filter((match) => match.tournamentLevel === "Playoff")
+                  .sort((a, b) => a.matchNumber - b.matchNumber);
+                if (nexusPlayoffMatches.length > 0) {
+                  const remappedMatches = nexusPlayoffMatches.map((match) => {
+                    const remappedTeams = match.teams
+                      ? match.teams.map((team) => {
+                          if (typeof team.teamNumber === "string") {
+                            const numericTeam = remapStringToNumber(team.teamNumber);
+                            if (numericTeam) return { ...team, teamNumber: numericTeam };
+                          }
+                          return team;
+                        })
+                      : match.teams;
+                    return {
+                      ...match,
+                      teams: remappedTeams,
+                      scoreRedFinal: null,
+                      scoreBlueFinal: null,
+                      scoreRedAuto: null,
+                      scoreBlueAuto: null,
+                      scoreRedFoul: null,
+                      scoreBlueFoul: null,
+                      scores: null,
+                      matchScores: null,
+                    };
+                  });
+                  playoffschedule = { schedule: remappedMatches };
+                  playoffUsedNexus = true;
+                  console.log(`Loaded ${remappedMatches.length} playoff matches from FRC Nexus (OffSeasonWithAzureSync fallback)`);
+                }
+              }
+            }
+          }
+        }
       } else if (!useFTCOffline) {
         const playoffResult = await httpClient.getNoAuth(
           `${selectedYear?.value}/schedule/hybrid/${selectedEvent?.value.code}/playoff`,
@@ -869,7 +1112,7 @@ export function useScheduleLoader(deps, opts = {}) {
     if (
       !selectedEvent?.value?.code.includes("PRACTICE") &&
       !useFTCOffline &&
-      !(selectedEvent?.value?.type === "OffSeason") &&
+      selectedEvent?.value?.type !== "OffSeason" && !playoffScheduleFromTBA &&
       playoffschedule?.schedule?.length > 0
     ) {
       const playoffScoresResult = await httpClient.getNoAuth(
@@ -914,7 +1157,7 @@ export function useScheduleLoader(deps, opts = {}) {
           //figure out how to match scores to match
           if (
             playoffScores?.MatchScores &&
-            !(selectedEvent?.value?.type === "OffSeason")
+            selectedEvent?.value?.type !== "OffSeason" && !playoffScheduleFromTBA
           ) {
             const matchResults = playoffScores.MatchScores.filter(
               (scoreMatch) => {
@@ -933,7 +1176,7 @@ export function useScheduleLoader(deps, opts = {}) {
                 hydrateFtcPlayoffTeamsFromResults(match, results);
               }
             }
-          } else if (selectedEvent?.value?.type === "OffSeason") {
+          } else if (selectedEvent?.value?.type === "OffSeason" || playoffScheduleFromTBA) {
             match.scores = match?.matchScores || [];
             if (match?.matchScores) {
               delete match.matchScores;
@@ -946,7 +1189,7 @@ export function useScheduleLoader(deps, opts = {}) {
 
       if (playoffScores?.MatchScores) {
         _.forEach(playoffScores.MatchScores, (score) => {
-          if (score.alliances[0].totalPoints === score.alliances[1].totalPoints) {
+          if (score.alliances?.[0]?.totalPoints === score.alliances?.[1]?.totalPoints) {
             const matchIndex = _.findIndex(
               playoffschedule.schedule,
               (m) =>
@@ -1004,6 +1247,19 @@ export function useScheduleLoader(deps, opts = {}) {
     }
 
     //setEventHighScores(highScores);
+    if (useCheesyArena && cheesyArenaAvailable) {
+      playoffschedule.dataSource = "Cheesy Arena";
+    } else if (useFTCOffline) {
+      playoffschedule.dataSource = "FTC Local Server";
+    } else if (ftcMode) {
+      playoffschedule.dataSource = "FTC API";
+    } else if (selectedEvent?.value?.type === "OffSeason") {
+      playoffschedule.dataSource = playoffUsedNexus ? "Nexus" : "TBA";
+    } else if (selectedEvent?.value?.type === "OffSeasonWithAzureSync") {
+      playoffschedule.dataSource = playoffUsedNexus ? "Nexus" : playoffScheduleFromTBA ? "TBA" : "FRC";
+    } else {
+      playoffschedule.dataSource = "FRC";
+    }
     playoffschedule.lastUpdate = moment().format();
     console.log(
       `There are ${playoffschedule?.schedule.length} playoff matches loaded.`

--- a/src/hooks/useScheduleLoader.test.js
+++ b/src/hooks/useScheduleLoader.test.js
@@ -68,10 +68,31 @@ function makeDeps(overrides = {}) {
   };
 }
 
-function setEvent({ code = "MAWOR", name = "MAWOR Test Event", type = "Regional" } = {}) {
-  eventSelectionState.selectedEvent = { value: { code, name, type } };
+function setEvent({ code = "MAWOR", name = "MAWOR Test Event", type = "Regional", tbaEventKey = undefined } = {}) {
+  eventSelectionState.selectedEvent = { value: { code, name, type, tbaEventKey } };
   eventSelectionState.selectedYear = { value: "2026" };
   eventSelectionState.ftcMode = null;
+}
+
+function makeNexusPlayoffMatch(matchNumber) {
+  return {
+    matchNumber,
+    tournamentLevel: "Playoff",
+    description: `Playoff ${matchNumber}`,
+    startTime: "2026-06-01T10:00:00",
+    actualStartTime: null,
+    postResultTime: null,
+    scoreRedFinal: null,
+    scoreBlueFinal: null,
+    teams: [
+      { teamNumber: 1234, station: "Red1", surrogate: false, dq: false },
+      { teamNumber: 2345, station: "Red2", surrogate: false, dq: false },
+      { teamNumber: 3456, station: "Red3", surrogate: false, dq: false },
+      { teamNumber: 4567, station: "Blue1", surrogate: false, dq: false },
+      { teamNumber: 5678, station: "Blue2", surrogate: false, dq: false },
+      { teamNumber: 6789, station: "Blue3", surrogate: false, dq: false },
+    ],
+  };
 }
 
 beforeEach(() => {
@@ -293,6 +314,7 @@ describe("useScheduleLoader (FRC)", () => {
   });
 
   it("uses event-scoped abort signal for fetches", async () => {
+
     setEvent();
     const controller = new AbortController();
     const seenSignals = [];
@@ -309,4 +331,291 @@ describe("useScheduleLoader (FRC)", () => {
     // The signal observed by MSW should be a real AbortSignal.
     expect(seenSignals[0]).toBeInstanceOf(AbortSignal);
   });
+});
+
+describe("useScheduleLoader – FRC Nexus offseason fallback", () => {
+  beforeEach(() => {
+    eventSelectionState.selectedEvent = null;
+    eventSelectionState.selectedYear = null;
+    eventSelectionState.ftcMode = null;
+    settingsState.playoffCountOverride = null;
+    settingsState.autoAdvance = false;
+    settingsState.autoUpdate = false;
+  });
+
+  it("uses Nexus playoff matches when TBA returns no playoff matches", async () => {
+    setEvent({
+      code: "BCWPI",
+      name: "BattleCry at WPI",
+      type: "OffSeason",
+      tbaEventKey: "2026bcwpi",
+    });
+
+    // TBA returns qual matches only (no playoffs)
+    server.use(
+      http.get(`${BASE}/2026/offseason/schedule/hybrid/2026bcwpi/`, () =>
+        HttpResponse.json({
+          Schedule: {
+            schedule: [
+              { matchNumber: 1, tournamentLevel: "Qualification", teams: [] },
+            ],
+          },
+        })
+      ),
+      http.get(`${BASE}/2026/nexus/schedule/bcwpi`, () =>
+        HttpResponse.json({
+          Schedule: {
+            schedule: [
+              makeNexusPlayoffMatch(1),
+              makeNexusPlayoffMatch(2),
+            ],
+          },
+        })
+      )
+    );
+
+    const deps = makeDeps();
+    const { result } = renderHook(() => useScheduleLoader(deps));
+    await result.current.getSchedule(true);
+
+    await waitFor(() => expect(deps.setPlayoffSchedule).toHaveBeenCalled());
+    const playoff = deps.setPlayoffSchedule.mock.calls.at(-1)[0];
+    expect(Array.isArray(playoff.schedule)).toBe(true);
+    expect(playoff.schedule.length).toBe(2);
+    expect(playoff.schedule[0].tournamentLevel).toBe("Playoff");
+    // Score fields are stripped from Nexus matches — bracket structure is not guaranteed
+    expect(playoff.schedule[0].scoreRedFinal).toBeNull();
+    expect(playoff.schedule[0].scoreBlueFinal).toBeNull();
+  });
+
+  it("uses Nexus when TBA returns an empty schedule", async () => {
+    setEvent({
+      code: "BCWPI",
+      name: "BattleCry at WPI",
+      type: "OffSeason",
+      tbaEventKey: "2026bcwpi",
+    });
+
+    server.use(
+      http.get(`${BASE}/2026/offseason/schedule/hybrid/2026bcwpi/`, () =>
+        HttpResponse.json({ Schedule: { schedule: [] } })
+      ),
+      http.get(`${BASE}/2026/nexus/schedule/bcwpi`, () =>
+        HttpResponse.json({
+          Schedule: { schedule: [makeNexusPlayoffMatch(1)] },
+        })
+      )
+    );
+
+    const deps = makeDeps();
+    const { result } = renderHook(() => useScheduleLoader(deps));
+    await result.current.getSchedule(true);
+
+    await waitFor(() => expect(deps.setPlayoffSchedule).toHaveBeenCalled());
+    const playoff = deps.setPlayoffSchedule.mock.calls.at(-1)[0];
+    expect(playoff.schedule.length).toBe(1);
+  });
+
+  it("prefers TBA when it returns playoff matches (Nexus not called)", async () => {
+    setEvent({
+      code: "BCWPI",
+      name: "BattleCry at WPI",
+      type: "OffSeason",
+      tbaEventKey: "2026bcwpi",
+    });
+
+    let nexusCalled = false;
+    server.use(
+      http.get(`${BASE}/2026/offseason/schedule/hybrid/2026bcwpi/`, () =>
+        HttpResponse.json({
+          Schedule: {
+            schedule: [makeNexusPlayoffMatch(1), makeNexusPlayoffMatch(2)],
+          },
+        })
+      ),
+      http.get(`${BASE}/2026/nexus/schedule/bcwpi`, () => {
+        nexusCalled = true;
+        return HttpResponse.json({ Schedule: { schedule: [] } });
+      })
+    );
+
+    const deps = makeDeps();
+    const { result } = renderHook(() => useScheduleLoader(deps));
+    await result.current.getSchedule(true);
+
+    await waitFor(() => expect(deps.setPlayoffSchedule).toHaveBeenCalled());
+    expect(nexusCalled).toBe(false);
+    const playoff = deps.setPlayoffSchedule.mock.calls.at(-1)[0];
+    expect(playoff.schedule.length).toBe(2);
+  });
+
+  it("derives Nexus event code by stripping year from TBA key", async () => {
+    setEvent({
+      code: "MAWOR1",
+      name: "WPI Offseason",
+      type: "OffSeason",
+      tbaEventKey: "2026mawor1",
+    });
+
+    let capturedUrl = null;
+    server.use(
+      http.get(`${BASE}/2026/offseason/schedule/hybrid/2026mawor1/`, () =>
+        HttpResponse.json({ Schedule: { schedule: [] } })
+      ),
+      http.get(`${BASE}/2026/nexus/schedule/:code`, ({ params }) => {
+        capturedUrl = params.code;
+        return HttpResponse.json({ Schedule: { schedule: [] } });
+      })
+    );
+
+    const deps = makeDeps();
+    const { result } = renderHook(() => useScheduleLoader(deps));
+    await result.current.getSchedule(true);
+
+    await waitFor(() => expect(deps.setPlayoffSchedule).toHaveBeenCalled());
+    expect(capturedUrl).toBe("mawor1");
+  });
+
+  it("OffSeasonWithAzureSync: uses FRC as primary source when schedule is available", async () => {
+    setEvent({
+      code: "BCWPI",
+      name: "BattleCry at WPI",
+      type: "OffSeasonWithAzureSync",
+      tbaEventKey: "2026bcwpi",
+    });
+
+    let tbaCalled = false;
+    server.use(
+      // FRC has qual and playoff data
+      http.get(`${BASE}/2026/schedule/hybrid/BCWPI/qual`, () =>
+        HttpResponse.json({
+          Schedule: {
+            schedule: [
+              { matchNumber: 1, tournamentLevel: "Qualification", description: "Qual 1",
+                startTime: "2026-06-01T09:00:00", actualStartTime: "2026-06-01T09:00:00",
+                postResultTime: "2026-06-01T09:10:00", teams: [] },
+            ],
+          },
+        })
+      ),
+      http.get(`${BASE}/2026/schedule/hybrid/BCWPI/playoff`, () =>
+        HttpResponse.json({
+          Schedule: {
+            schedule: [makeNexusPlayoffMatch(1), makeNexusPlayoffMatch(2)],
+          },
+        })
+      ),
+      http.get(`${BASE}/2026/scores/BCWPI/qual`, () =>
+        HttpResponse.json({ MatchScores: [] })
+      ),
+      http.get(`${BASE}/2026/scores/BCWPI/playoff`, () =>
+        HttpResponse.json({ MatchScores: [] })
+      ),
+      http.get(`${BASE}/2026/offseason/schedule/hybrid/2026bcwpi/`, () => {
+        tbaCalled = true;
+        return HttpResponse.json({ Schedule: { schedule: [] } });
+      })
+    );
+
+    const deps = makeDeps();
+    const { result } = renderHook(() => useScheduleLoader(deps));
+    await result.current.getSchedule(true);
+
+    await waitFor(() => expect(deps.setPlayoffSchedule).toHaveBeenCalled());
+    // FRC data was used — TBA should not have been called
+    expect(tbaCalled).toBe(false);
+    const playoff = deps.setPlayoffSchedule.mock.calls.at(-1)[0];
+    expect(playoff.schedule.length).toBe(2);
+  });
+
+  it("also applies Nexus fallback for OffSeasonWithAzureSync events (FRC empty → TBA empty → Nexus)", async () => {
+    setEvent({
+      code: "BCWPI",
+      name: "BattleCry at WPI",
+      type: "OffSeasonWithAzureSync",
+      tbaEventKey: "2026bcwpi",
+    });
+
+    // FRC returns 404 for unknown event code (no fixture); TBA returns empty; Nexus has 1 playoff match.
+    server.use(
+      http.get(`${BASE}/2026/offseason/schedule/hybrid/2026bcwpi/`, () =>
+        HttpResponse.json({ Schedule: { schedule: [] } })
+      ),
+      http.get(`${BASE}/2026/nexus/schedule/bcwpi`, () =>
+        HttpResponse.json({
+          Schedule: { schedule: [makeNexusPlayoffMatch(1)] },
+        })
+      )
+    );
+
+    const deps = makeDeps();
+    const { result } = renderHook(() => useScheduleLoader(deps));
+    await result.current.getSchedule(true);
+
+    await waitFor(() => expect(deps.setPlayoffSchedule).toHaveBeenCalled());
+    const playoff = deps.setPlayoffSchedule.mock.calls.at(-1)[0];
+    expect(playoff.schedule.length).toBe(1);
+  });
+
+  it("passes Nexus match descriptions through verbatim without transformation", async () => {
+    setEvent({
+      code: "BCWPI",
+      name: "BattleCry at WPI",
+      type: "OffSeason",
+      tbaEventKey: "2026bcwpi",
+    });
+
+    server.use(
+      http.get(`${BASE}/2026/offseason/schedule/hybrid/2026bcwpi/`, () =>
+        HttpResponse.json({ Schedule: { schedule: [] } })
+      ),
+      http.get(`${BASE}/2026/nexus/schedule/bcwpi`, () =>
+        HttpResponse.json({
+          Schedule: {
+            schedule: [
+              { ...makeNexusPlayoffMatch(1), description: "Playoff 1" },
+              { ...makeNexusPlayoffMatch(2), description: "Playoff 2" },
+            ],
+          },
+        })
+      )
+    );
+
+    const deps = makeDeps();
+    const { result } = renderHook(() => useScheduleLoader(deps));
+    await result.current.getSchedule(true);
+
+    await waitFor(() => expect(deps.setPlayoffSchedule).toHaveBeenCalled());
+    const playoff = deps.setPlayoffSchedule.mock.calls.at(-1)[0];
+    expect(playoff.schedule[0].description).toBe("Playoff 1");
+    expect(playoff.schedule[1].description).toBe("Playoff 2");
+  });
+
+  it("handles Nexus returning 204 (no content) gracefully", async () => {
+    setEvent({
+      code: "BCWPI",
+      name: "BattleCry at WPI",
+      type: "OffSeason",
+      tbaEventKey: "2026bcwpi",
+    });
+
+    server.use(
+      http.get(`${BASE}/2026/offseason/schedule/hybrid/2026bcwpi/`, () =>
+        HttpResponse.json({ Schedule: { schedule: [] } })
+      ),
+      http.get(`${BASE}/2026/nexus/schedule/bcwpi`, () =>
+        new HttpResponse(null, { status: 204 })
+      )
+    );
+
+    const deps = makeDeps();
+    const { result } = renderHook(() => useScheduleLoader(deps));
+    await result.current.getSchedule(true);
+
+    await waitFor(() => expect(deps.setPlayoffSchedule).toHaveBeenCalled());
+    const playoff = deps.setPlayoffSchedule.mock.calls.at(-1)[0];
+    // No Nexus data — playoff schedule stays empty
+    expect(playoff.schedule).toEqual([]);
+  });
+
 });

--- a/src/pages/AllianceSelectionPage.jsx
+++ b/src/pages/AllianceSelectionPage.jsx
@@ -33,7 +33,7 @@ function AllianceSelectionPage({
   const { selectedEvent, selectedYear, qualSchedule, playoffSchedule, offlinePlayoffSchedule, alliances, rankings, teamList, allianceCount, communityUpdates, practiceSchedule, currentMatch, eventLabel, ftcMode, remapNumberToString } = useEventData();
   const { getRanks, loadEvent, nextMatch, previousMatch, getSchedule } = useEventActions();
     const { timeFormat, useSwipe, usePullDownToUpdate, useFourTeamAlliances, setUseFourTeamAlliances, useScrollMemory, rankingsOverride,
-        playoffCountOverride, setPlayoffCountOverride, allianceSelectionRoundOrder, setAllianceSelectionRoundOrder } = useSettings();
+        playoffCountOverride, setPlayoffCountOverride, allianceSelectionRoundOrder, setAllianceSelectionRoundOrder, nonStandardPlayoffs } = useSettings();
     /**
      * This function finds a team by their station assignment
      * @param teams the array of team objects
@@ -296,17 +296,26 @@ function AllianceSelectionPage({
                     )}
                 </div>}
 
-            {selectedEvent && (alliancesCount === 8) && playoffs &&
+            {selectedEvent && playoffs && nonStandardPlayoffs && (
+                <Row className="mt-3">
+                    <Col>
+                        <Alert variant="info">
+                            <b>Nonstandard playoff format is enabled.</b> The playoff bracket is not displayed. Match result guidance is also hidden on Announce, Play By Play, and Emcee screens.
+                        </Alert>
+                    </Col>
+                </Row>
+            )}
+            {selectedEvent && (alliancesCount === 8) && playoffs && !nonStandardPlayoffs &&
                 <Bracket offlinePlayoffSchedule={offlinePlayoffSchedule} setOfflinePlayoffSchedule={setOfflinePlayoffSchedule} currentMatch={currentMatch} qualsLength={qualsLength} nextMatch={nextMatch} previousMatch={previousMatch} getSchedule={getSchedule} usePullDownToUpdate={usePullDownToUpdate} useSwipe={useSwipe} eventLabel={eventLabel} ftcMode={ftcMode} matches={matches} allianceNumbers={allianceNumbers} allianceName={allianceName} matchScore={matchScore} matchWinner={matchWinner} alliances={alliances} remapNumberToString={remapNumberToString} />}
-            {selectedEvent && (alliancesCount === 6) && playoffs && selectedEvent?.value?.code === "FTCCMP1" &&
+            {selectedEvent && (alliancesCount === 6) && playoffs && !nonStandardPlayoffs && selectedEvent?.value?.code === "FTCCMP1" &&
                 <DaVinciTournamentBracket offlinePlayoffSchedule={offlinePlayoffSchedule} currentMatch={currentMatch} qualsLength={qualsLength} nextMatch={nextMatch} previousMatch={previousMatch} getSchedule={getSchedule} usePullDownToUpdate={usePullDownToUpdate} useSwipe={useSwipe} eventLabel={eventLabel} ftcMode={ftcMode} matches={matches} allianceNumbers={allianceNumbers} allianceName={allianceName} matchScore={matchScore} matchWinner={matchWinner} alliances={alliances} remapNumberToString={remapNumberToString} />}
-            {selectedEvent && (alliancesCount === 6) && playoffs && selectedEvent?.value?.code !== "FTCCMP1" &&
+            {selectedEvent && (alliancesCount === 6) && playoffs && !nonStandardPlayoffs && selectedEvent?.value?.code !== "FTCCMP1" &&
                 <SixAllianceBracket offlinePlayoffSchedule={offlinePlayoffSchedule} setOfflinePlayoffSchedule={setOfflinePlayoffSchedule} currentMatch={currentMatch} qualsLength={qualsLength} nextMatch={nextMatch} previousMatch={previousMatch} getSchedule={getSchedule} usePullDownToUpdate={usePullDownToUpdate} useSwipe={useSwipe} eventLabel={eventLabel} ftcMode={ftcMode} matches={matches} allianceNumbers={allianceNumbers} allianceName={allianceName} matchScore={matchScore} matchWinner={matchWinner} alliances={alliances} remapNumberToString={remapNumberToString} />}
-            {selectedEvent && (alliancesCount === 4) && playoffs && !ftcMode &&
+            {selectedEvent && (alliancesCount === 4) && playoffs && !ftcMode && !nonStandardPlayoffs &&
                 <FourAllianceBracket currentMatch={currentMatch} qualsLength={qualsLength} nextMatch={nextMatch} previousMatch={previousMatch} getSchedule={getSchedule} useSwipe={useSwipe} usePullDownToUpdate={usePullDownToUpdate} offlinePlayoffSchedule={offlinePlayoffSchedule} setOfflinePlayoffSchedule={setOfflinePlayoffSchedule} eventLabel={eventLabel} ftcMode={ftcMode} matches={matches} allianceNumbers={allianceNumbers} allianceName={allianceName} matchScore={matchScore} matchWinner={matchWinner} />}
-            {selectedEvent && (alliancesCount === 4) && playoffs && ftcMode &&
+            {selectedEvent && (alliancesCount === 4) && playoffs && ftcMode && !nonStandardPlayoffs &&
                 <FourAllianceBracketFTC currentMatch={currentMatch} qualsLength={qualsLength} nextMatch={nextMatch} previousMatch={previousMatch} getSchedule={getSchedule} useSwipe={useSwipe} usePullDownToUpdate={usePullDownToUpdate} offlinePlayoffSchedule={offlinePlayoffSchedule} setOfflinePlayoffSchedule={setOfflinePlayoffSchedule} eventLabel={eventLabel} ftcMode={ftcMode} matches={matches} allianceNumbers={allianceNumbers} allianceName={allianceName} matchScore={matchScore} matchWinner={matchWinner} alliances={alliances} remapNumberToString={remapNumberToString} />}
-            {selectedEvent && (alliancesCount === 2) && playoffs &&
+            {selectedEvent && (alliancesCount === 2) && playoffs && !nonStandardPlayoffs &&
                 <TwoAllianceBracket nextMatch={nextMatch} previousMatch={previousMatch} getSchedule={getSchedule} useSwipe={useSwipe} usePullDownToUpdate={usePullDownToUpdate} eventLabel={eventLabel} ftcMode={ftcMode} matches={matches} allianceNumbers={allianceNumbers} allianceName={allianceName} matchScore={matchScore} matchWinner={matchWinner} />}
             <Modal centered={true} show={showRoundOrderModal} onHide={() => setShowRoundOrderModal(false)}>
                 <Modal.Header className={"allianceSelectionDecline"} closeVariant={"white"} closeButton>

--- a/src/pages/AllianceSelectionPage.test.jsx
+++ b/src/pages/AllianceSelectionPage.test.jsx
@@ -30,6 +30,14 @@ vi.mock("../components/AllianceSelection", () => ({
     default: () => <div data-testid="alliance-selection-stub" />,
 }));
 
+// Bracket components are complex; stub them all out
+vi.mock("../components/Bracket", () => ({ default: () => <div data-testid="bracket-stub" /> }));
+vi.mock("../components/SixAllianceBracket", () => ({ default: () => <div data-testid="six-alliance-bracket-stub" /> }));
+vi.mock("../components/FourAllianceBracket", () => ({ default: () => <div data-testid="four-alliance-bracket-stub" /> }));
+vi.mock("../components/FourAllianceBracketFTC", () => ({ default: () => <div data-testid="four-alliance-bracket-ftc-stub" /> }));
+vi.mock("../components/TwoAllianceBracket", () => ({ default: () => <div data-testid="two-alliance-bracket-stub" /> }));
+vi.mock("../components/DaVinciTournamentBracket", () => ({ default: () => <div data-testid="davinci-bracket-stub" /> }));
+
 import { useSettings } from "../contexts/SettingsContext";
 import { useEventData } from "contexts/EventDataContext";
 import { useEventActions } from "contexts/EventActionsContext";
@@ -94,6 +102,7 @@ function setupMocks({ eventOverrides = {}, settingsOverrides = {} } = {}) {
         setPlayoffCountOverride: vi.fn(),
         allianceSelectionRoundOrder: null,
         setAllianceSelectionRoundOrder: vi.fn(),
+        nonStandardPlayoffs: false,
         ...settingsOverrides,
     });
 
@@ -194,5 +203,47 @@ describe("AllianceSelectionPage – round order modal descending label", () => {
         render(<AllianceSelectionPage {...baseProps()} />);
         fireEvent.click(screen.getByText("Reorder Alliance Selection"));
         expect(screen.getByText("Alliance 6 → 1")).toBeInTheDocument();
+    });
+});
+
+describe("AllianceSelectionPage – nonStandardPlayoffs", () => {
+    beforeEach(() => {
+        setupMocks();
+    });
+
+    it("shows info alert when nonStandardPlayoffs is enabled in playoffs mode", () => {
+        setupMocks({ settingsOverrides: { nonStandardPlayoffs: true } });
+        render(<AllianceSelectionPage {...baseProps({ playoffs: true })} />);
+        expect(screen.getByText(/Nonstandard playoff format is enabled/)).toBeInTheDocument();
+    });
+
+    it("does not show info alert when nonStandardPlayoffs is false in playoffs mode", () => {
+        setupMocks({ settingsOverrides: { nonStandardPlayoffs: false } });
+        render(<AllianceSelectionPage {...baseProps({ playoffs: true })} />);
+        expect(screen.queryByText(/Nonstandard playoff format is enabled/)).not.toBeInTheDocument();
+    });
+
+    it("does not show info alert when nonStandardPlayoffs is enabled but not in playoffs mode", () => {
+        setupMocks({ settingsOverrides: { nonStandardPlayoffs: true } });
+        render(<AllianceSelectionPage {...baseProps({ playoffs: false })} />);
+        expect(screen.queryByText(/Nonstandard playoff format is enabled/)).not.toBeInTheDocument();
+    });
+
+    it("hides bracket and shows info alert instead of bracket when nonStandardPlayoffs is enabled", () => {
+        setupMocks({ settingsOverrides: { nonStandardPlayoffs: true } });
+        render(<AllianceSelectionPage {...baseProps({ playoffs: true })} />);
+        expect(screen.queryByTestId("bracket-stub")).not.toBeInTheDocument();
+        expect(screen.getByText(/Nonstandard playoff format is enabled/)).toBeInTheDocument();
+    });
+
+    it("shows bracket when nonStandardPlayoffs is false in playoffs mode", () => {
+        setupMocks({
+            settingsOverrides: { nonStandardPlayoffs: false },
+            eventOverrides: {
+                alliances: { alliances: Array(8).fill({ captain: null, round1: null }), Lookup: {} },
+            },
+        });
+        render(<AllianceSelectionPage {...baseProps({ playoffs: true })} />);
+        expect(screen.getByTestId("bracket-stub")).toBeInTheDocument();
     });
 });

--- a/src/pages/EmceePage.jsx
+++ b/src/pages/EmceePage.jsx
@@ -25,7 +25,7 @@ function EmceePage() {
     remapNumberToString,
   } = useEventData();
   const { nextMatch, previousMatch, getSchedule } = useEventActions();
-  const { reverseEmcee, hidePracticeSchedule, usePullDownToUpdate, useSwipe } =
+  const { reverseEmcee, hidePracticeSchedule, usePullDownToUpdate, useSwipe, nonStandardPlayoffs } =
     useSettings();
   const { height, width } = useWindowDimensions();
   const isDaVinci = selectedEvent?.value?.code === "FTCCMP1";
@@ -1012,7 +1012,7 @@ function EmceePage() {
               </Row>
             )}
 
-            {(!isDaVinci && playoffMatchNumber <= 13) ||
+            {!nonStandardPlayoffs && ((!isDaVinci && playoffMatchNumber <= 13) ||
               (isDaVinci && playoffMatchNumber >= 16 && (
                 <Row>
                   <Col
@@ -1028,7 +1028,7 @@ function EmceePage() {
                     />
                   </Col>
                 </Row>
-              ))}
+              )))}
           </Container>
         </>
       )}

--- a/src/pages/SchedulePage.jsx
+++ b/src/pages/SchedulePage.jsx
@@ -377,7 +377,7 @@ function SchedulePage({
 
         if (forPlayoffs) {
           // inject bye matches into schedule for playoff display
-          if (playoffOffset?.bye > 0) {
+          if (playoffOffset?.bye > 0 && innerSchedule.length > 0) {
             var matchTime = innerSchedule[0].startTime;
             _.forEach(playoffOffset.insertionOrder, (item, index) => {
               innerSchedule.splice(

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -132,7 +132,7 @@ function SetupPage({
   setUseOsTheme,
   appearanceDark,
 }) {
-  const { selectedEvent, selectedYear, eventLabel, ftcMode, teamList, qualSchedule, playoffSchedule, rankings, allianceCount } = useEventData();
+  const { selectedEvent, selectedYear, eventLabel, ftcMode, teamList, qualSchedule, playoffSchedule, rankings, alliances, allianceCount } = useEventData();
   const { setSelectedEvent, setSelectedYear, setFTCMode, getSchedule, getCommunityUpdates, getTeamList, getAlliances } = useEventActions();
     const {
         timeFormat, setTimeFormat, showSponsors, setShowSponsors, autoHideSponsors, setAutoHideSponsors,
@@ -156,6 +156,7 @@ function SetupPage({
         screenModeSyncFrequency, setScreenModeSyncFrequency,
         backgroundDataRefresh, setBackgroundDataRefresh,
         backgroundDataRefreshFrequency, setBackgroundDataRefreshFrequency,
+        nonStandardPlayoffs, setNonStandardPlayoffs,
     } = useSettings();
     const isOnline = useOnlineStatus();
     const PWASupported = (isChrome && Number(browserVersion) >= 76) || (isSafari && Number(browserVersion) >= 15 && Number(fullBrowserVersion.split(".")[1]) >= 4);
@@ -227,23 +228,26 @@ function SetupPage({
         return filterTemp
     }
 
-    const uploadLocalUpdates = () => {
-        var localUpdatesTemp = _.cloneDeep(localUpdates);
-        localUpdatesTemp.forEach(async function (update) {
-            var response = await putTeamData(update.teamNumber, update.update);
-            var errorText = "";
-            if (response.status !== 204) {
-                errorText = `Your update for team ${update.teamNumber} was not successful. We have preserved the change locally, and you can send it later from here.`;
-                toast.error(errorText);
-                throw new Error(errorText);
-            } else {
-                errorText = `Your update for team ${update.teamNumber} was successful.`;
-                localUpdatesTemp.splice(_.findIndex(localUpdatesTemp, { "teamNumber": update.teamNumber }), 1)
-                toast.success(errorText);
-            }
-        })
-
-        setLocalUpdates(localUpdatesTemp);
+    const uploadLocalUpdates = async () => {
+        const localUpdatesTemp = _.cloneDeep(localUpdates);
+        const results = await Promise.allSettled(
+            localUpdatesTemp.map(async (update) => {
+                const response = await putTeamData(update.teamNumber, update.update);
+                if (response.status !== 204) {
+                    const errorText = `Your update for team ${update.teamNumber} was not successful. We have preserved the change locally, and you can send it later from here.`;
+                    toast.error(errorText);
+                    throw new Error(errorText);
+                }
+                toast.success(`Your update for team ${update.teamNumber} was successful.`);
+                return update.teamNumber;
+            })
+        );
+        const successfulTeams = new Set(
+            results
+                .filter((r) => r.status === "fulfilled")
+                .map((r) => r.value)
+        );
+        setLocalUpdates(localUpdatesTemp.filter((u) => !successfulTeams.has(u.teamNumber)));
     }
 
     const deleteLocalUpdates = () => {
@@ -527,6 +531,12 @@ function SetupPage({
                         {selectedEvent?.value.dateStart && <p><b>Event Start: </b>{moment(selectedEvent?.value.dateStart, 'YYYY-MM-DDTHH:mm:ss').format('ddd, MMM Do YYYY')}</p>}
                         {selectedEvent?.value.dateEnd && <p><b>Event End: </b>{moment(selectedEvent?.value.dateEnd, 'YYYY-MM-DDTHH:mm:ss').format('ddd, MMM Do YYYY')}</p>}
                         <Alert variant={"danger"}><b>ADVANCED EVENT SETTINGS:</b><br />If your event includes non-competing teams in the team list, indicate the number of non-competing teams here. <b>THIS IS A RARE CONDITION</b><Select classNamePrefix="gatool-rs" options={teamReducer} value={teamReduction ? teamReduction : teamReducer[0]} onChange={setTeamReduction} isDisabled={!teamList?.teamCountTotal} /><br />
+                        {(selectedEvent?.value?.type === "OffSeason" || selectedEvent?.value?.type === "OffSeasonWithAzureSync") && <>
+                                <label style={{ display: "flex", alignItems: "center", gap: "10px", marginTop: "8px" }}>
+                                    <Switch checked={nonStandardPlayoffs === null ? false : nonStandardPlayoffs} onChange={setNonStandardPlayoffs} />
+                                    <span><b>Use nonstandard playoff format</b> — Enable when the event uses a playoff bracket or format that differs from the standard double-elimination bracket.</span>
+                                </label><br />
+                            </>}
                             {selectedEvent?.value?.type?.includes("OffSeason")
                                 ? "If your event requires a non-standard Alliance Count, you can override the Alliance Count here."
                                 : <span>If your event requires a reduced Alliance Count, you can override the Alliance Count here. <b>THIS SHOULD ONLY APPLY TO EVENTS WITH LESS THAN 26 TEAMS.</b></span>
@@ -534,7 +544,13 @@ function SetupPage({
                             <Select classNamePrefix="gatool-rs"
                                 options={selectedEvent?.value?.type?.includes("OffSeason") ? playoffOverrideMenuOffseason : playoffOverrideMenu}
                                 value={playoffCountOverride ? playoffCountOverride : (allianceCount?.menu ? allianceCount.menu : (selectedEvent?.value?.type?.includes("OffSeason") ? playoffOverrideMenuOffseason[0] : playoffOverrideMenu[0]))}
-                                onChange={setPlayoffCountOverride} />
+                                onChange={(val) => { setPlayoffCountOverride(val); getAlliances(undefined, val?.value); }} />
+                                {!ftcMode && (selectedEvent?.value?.type === "OffSeason" || selectedEvent?.value?.type === "OffSeasonWithAzureSync") && 
+                                <><br/><label style={{ display: "flex", alignItems: "center", gap: "10px", marginTop: "8px" }}>
+                                <Switch checked={useFourTeamAlliances === null ? false : useFourTeamAlliances} onChange={setUseFourTeamAlliances} />
+                                <span><b>Use 4 team Alliances for playoffs</b></span>
+                            </label></>
+                                }
                         </Alert>
                         <div>
                             {!ftcMode && (
@@ -566,12 +582,13 @@ function SetupPage({
                         {selectedEvent?.value.allianceCount === "SixAlliance" && <p><b>Playoff Type: </b>6 Alliance Playoffs</p>}
                         {selectedEvent?.value.allianceCount === "FourAlliance" && <p><b>Playoff Type: </b>4 Alliance Playoff</p>}
                         {selectedEvent?.value.allianceCount === "TwoAlliance" && <p><b>Playoff Type: </b>Best 2 out of 3 Playoff</p>}
-                        {qualSchedule?.scheduleLastModified && <p><b>Quals Schedule last updated: </b><br />{moment(qualSchedule?.scheduleLastModified).format("ddd, MMM Do YYYY, " + timeFormat.value)}</p>}
-                        {qualSchedule?.matchesLastModified && <p><b>Quals Results last updated: </b><br />{moment(qualSchedule?.matchesLastModified).format("ddd, MMM Do YYYY, " + timeFormat.value)}</p>}
-                        {playoffSchedule?.scheduleLastModified && <p><b>Playoff Schedule last updated: </b><br />{moment(playoffSchedule?.scheduleLastModified).format("ddd, MMM Do YYYY, " + timeFormat.value)}</p>}
-                        {playoffSchedule?.matchesLastModified && <p><b>Playoff Results last updated: </b><br />{moment(playoffSchedule?.matchesLastModified).format("ddd, MMM Do YYYY, " + timeFormat.value)}</p>}
-                        {teamList?.lastUpdate && <p><b>Team List last updated: </b><br />{moment(teamList?.lastUpdate).format("ddd, MMM Do YYYY, " + timeFormat.value)}</p>}
-                        {rankings?.lastModified && <p><b>Rankings last updated: </b><br />{moment(rankings?.lastModified).format("ddd, MMM Do YYYY, " + timeFormat.value)}</p>}
+                        {qualSchedule?.scheduleLastModified && <p><b>Quals Schedule last updated: </b><br />{moment(qualSchedule?.scheduleLastModified).format("ddd, MMM Do YYYY, " + timeFormat.value)}{qualSchedule?.dataSource && <> <span className="data-source-badge">via {qualSchedule.dataSource}</span></>}</p>}
+                        {qualSchedule?.matchesLastModified && <p><b>Quals Results last updated: </b><br />{moment(qualSchedule?.matchesLastModified).format("ddd, MMM Do YYYY, " + timeFormat.value)}{qualSchedule?.dataSource && <> <span className="data-source-badge">via {qualSchedule.dataSource}</span></>}</p>}
+                        {playoffSchedule?.scheduleLastModified && <p><b>Playoff Schedule last updated: </b><br />{moment(playoffSchedule?.scheduleLastModified).format("ddd, MMM Do YYYY, " + timeFormat.value)}{playoffSchedule?.dataSource && <> <span className="data-source-badge">via {playoffSchedule.dataSource}</span></>}</p>}
+                        {playoffSchedule?.matchesLastModified && <p><b>Playoff Results last updated: </b><br />{moment(playoffSchedule?.matchesLastModified).format("ddd, MMM Do YYYY, " + timeFormat.value)}{playoffSchedule?.dataSource && <> <span className="data-source-badge">via {playoffSchedule.dataSource}</span></>}</p>}
+                        {teamList?.lastUpdate && <p><b>Team List last updated: </b><br />{moment(teamList?.lastUpdate).format("ddd, MMM Do YYYY, " + timeFormat.value)}{selectedEvent?.value?.type === "OffSeason" && <> <span className="data-source-badge">via TBA</span></>}</p>}
+                        {rankings?.lastModified && <p><b>Rankings last updated: </b><br />{moment(rankings?.lastModified).format("ddd, MMM Do YYYY, " + timeFormat.value)}{rankings?.dataSource && <> <span className="data-source-badge">via {rankings.dataSource}</span></>}</p>}
+                        {alliances?.lastUpdate && <p><b>Alliances last updated: </b><br />{moment(alliances?.lastUpdate).format("ddd, MMM Do YYYY, " + timeFormat.value)}{alliances?.dataSource && <> <span className="data-source-badge">via {alliances.dataSource}</span></>}</p>}
                         {((isAuthenticated && user["https://gatool.org/roles"] && (user["https://gatool.org/roles"].indexOf("user") >= 0)) && localUpdates.length > 0) &&
                             <Alert>
                                 <p><b>You have {localUpdates.length === 1 ? "an update for team" : "updates for teams"} {_.sortBy(updatedTeamList).join(", ")} that can be uploaded to gatool Cloud.</b></p>
@@ -1038,14 +1055,6 @@ function SetupPage({
                                         <b>Enable Test Match Mode. If you enable this mode, you will need to enter team numbers on the Announce Screen. This will disable match navigation.</b>
                                     </td>
                                 </tr>
-                                {!ftcMode && (selectedEvent?.value?.type === "OffSeason" || selectedEvent?.value?.type === "OffSeasonWithAzureSync") && <tr>
-                                    <td>
-                                        <Switch checked={useFourTeamAlliances === null ? false : useFourTeamAlliances} onChange={setUseFourTeamAlliances} />
-                                    </td>
-                                    <td>
-                                        <b>Use 4 team Alliances for playoffs</b>
-                                    </td>
-                                </tr>}
                                 {!ftcMode && selectedEvent?.value?.type === "OffSeason" && <tr>
                                     <td>
                                         <Switch checked={useCheesyArena === null ? false : useCheesyArena} onChange={handleUseCheesy} />

--- a/src/utils/ftcHybridMatchTeams.js
+++ b/src/utils/ftcHybridMatchTeams.js
@@ -8,7 +8,11 @@ import _ from "lodash";
 function coerceTeamNumberValue(v) {
   if (v == null || v === "") return null;
   if (typeof v === "number" && !Number.isNaN(v)) return v;
-  if (typeof v === "string" && /^\d+$/.test(v.trim())) return parseInt(v.trim(), 10);
+  if (typeof v === "string") {
+    // Strip TBA-style "frc" prefix (e.g. "frc1277" → 1277) before attempting numeric parse.
+    const stripped = v.trim().replace(/^frc/i, "");
+    if (/^\d+$/.test(stripped)) return parseInt(stripped, 10);
+  }
   return v;
 }
 

--- a/src/utils/ftcHybridMatchTeams.test.js
+++ b/src/utils/ftcHybridMatchTeams.test.js
@@ -23,8 +23,15 @@ describe("extractAllianceSlotTeamNumber", () => {
     expect(extractAllianceSlotTeamNumber("  42  ")).toBe(42);
   });
 
-  it("returns non-numeric strings as-is", () => {
-    expect(extractAllianceSlotTeamNumber("frc254")).toBe("frc254");
+  it("strips frc prefix and parses to integer", () => {
+    expect(extractAllianceSlotTeamNumber("frc254")).toBe(254);
+    expect(extractAllianceSlotTeamNumber("FRC1114")).toBe(1114);
+    expect(extractAllianceSlotTeamNumber("frc0")).toBe(0);
+  });
+
+  it("returns truly non-numeric strings as-is", () => {
+    expect(extractAllianceSlotTeamNumber("team-foo")).toBe("team-foo");
+    expect(extractAllianceSlotTeamNumber("frc")).toBe("frc");
   });
 
   it("extracts teamNumber from object slot", () => {


### PR DESCRIPTION
There are multiple data sources from which we can derive event information for FRC events, namely FRC APIs, TBA and for scheduling, Nexus. This brings in a set of fallback functions for offseason events to try and use those secondary data sources when we don't get appropriate data from FRC. Some notable changes:
- Nonstandard event settings are now located in the ADVANCED EVENT SETTINGS section of the settings page
- Events can have up to 16 Alliances and can include 4-team Alliances
- Playoff tab will not render for nonstandard playoffs
- Match results guidance will be suppressed on Announce, Play by Play and Emcee page for nonstandard playoffs

This also fixes some potential crashers for edge case scenarios.