### PR TITLE
 3-team Alliance support for FTC events

### DIFF
--- a/public/help-wiki-manifest.json
+++ b/public/help-wiki-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-03T23:44:50.033Z",
+  "generatedAt": "2026-06-08T00:05:50.143Z",
   "rawBaseUrl": "https://raw.githubusercontent.com/wiki/arthurlockman/gatool-ui",
   "pages": [
     {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -600,8 +600,11 @@ function App() {
    * @returns {Promise<string>} The effective team number for API calls
    */
   const getEffectiveTeamNumber = async (teamNumber, eventCode = null, tbaEventKey = null) => {
-    // Check if team number is a demo team (9970-9999) and NOT in FTC mode
-    if (teamNumber >= 9970 && teamNumber <= 9999 && !ftcMode) {
+    // FRC demo teams: 9970-9999 (non-FTC mode)
+    // FTC demo teams: 99900-99999 (FTC mode)
+    const isFRCDemo = !ftcMode && teamNumber >= 9970 && teamNumber <= 9999;
+    const isFTCDemo = ftcMode && teamNumber >= 99900 && teamNumber <= 99999;
+    if (isFRCDemo || isFTCDemo) {
       // Use eventCode if available
       if (eventCode) {
         return `${eventCode}_${teamNumber}`;

--- a/src/data/appUpdates.js
+++ b/src/data/appUpdates.js
@@ -1,5 +1,18 @@
 export const appUpdates = [
   {
+    date: "June 7, 2026",
+    message: (
+      <>
+      <b>OFFSEASON UPDATES</b><br />
+      <ul>
+        <li>FTC:</li>
+        <ul>
+          <li>3-Team Alliances are now supported for FTC events</li>
+        </ul>
+      </ul>
+      </>
+    ),
+  },{
     date: "June 5, 2026",
     message: (
       <>

--- a/src/data/appUpdates.js
+++ b/src/data/appUpdates.js
@@ -8,6 +8,7 @@ export const appUpdates = [
         <li>FTC:</li>
         <ul>
           <li>3-Team Alliances are now supported for FTC events</li>
+          <li>Proper support for offseason demo teams in FTC events</li>
         </ul>
       </ul>
       </>

--- a/src/hooks/useCommunityUpdates.js
+++ b/src/hooks/useCommunityUpdates.js
@@ -160,8 +160,12 @@ export function useCommunityUpdates({
                 teamNumber: typeof team.teamNumber === 'string' ? parseInt(team.teamNumber) : team.teamNumber
               }));
 
-              // Demo teams (9970-9999) are always keyed by event in the API. Always fetch their
+              // Demo teams are always keyed by event in the API. Always fetch their
               // community updates from the event-prefixed endpoint so edits don't get overwritten by bulk data.
+              // FRC demo teams: 9970-9999. FTC demo teams: 99900-99999.
+              const isDemoTeam = ftcMode
+                ? (n) => n >= 99900 && n <= 99999
+                : (n) => n >= 9970 && n <= 9999;
               const demoTeamNumbers = new Set();
               const collectDemoTeams = (scheduleObj) => {
                 const matchList = Array.isArray(scheduleObj) ? scheduleObj : (scheduleObj?.schedule ?? []);
@@ -170,7 +174,7 @@ export function useCommunityUpdates({
                   const list = match?.teams ?? match?.schedule?.teams ?? [];
                   (Array.isArray(list) ? list : []).forEach((t) => {
                     const num = t?.teamNumber;
-                    if (num != null && num >= 9970 && num <= 9999) demoTeamNumbers.add(num);
+                    if (num != null && isDemoTeam(num)) demoTeamNumbers.add(num);
                   });
                 });
               };
@@ -178,10 +182,8 @@ export function useCommunityUpdates({
               collectDemoTeams(playoffSchedule?.schedule ?? playoffSchedule);
               (teamList?.teams ?? []).forEach((t) => {
                 const num = t?.teamNumber;
-                if (num != null && num >= 9970 && num <= 9999) demoTeamNumbers.add(num);
+                if (num != null && isDemoTeam(num)) demoTeamNumbers.add(num);
               });
-              // Remove any demo teams from bulk response so we always use event-keyed data for them
-              const isDemoTeam = (n) => n >= 9970 && n <= 9999;
               teams = (teams || []).filter((t) => !isDemoTeam(t.teamNumber));
               if (demoTeamNumbers.size > 0) {
                 const eventCode = selectedEvent?.value?.code ?? null;

--- a/src/pages/AllianceSelectionPage.jsx
+++ b/src/pages/AllianceSelectionPage.jsx
@@ -53,6 +53,7 @@ function AllianceSelectionPage({
     const [roundOrderDraft, setRoundOrderDraft] = useState(null);
 
     const isOffseason = selectedEvent?.value?.type?.includes("OffSeason");
+    const isFTCThreeTeamEligible = !!(ftcMode && ["2", "4", "7", "10", "17"].includes(selectedEvent?.value?.type));
     const inChamps = !!(
         selectedEvent?.value?.champLevel === "CHAMPS" ||
         selectedEvent?.value?.champLevel === "CMPDIV" ||
@@ -259,7 +260,7 @@ function AllianceSelectionPage({
                 </div>}
             {selectedEvent && ((qualSchedule?.schedule?.length > 0 || qualSchedule?.schedule?.schedule?.length > 0 || practiceSchedule?.schedule?.length > 0) && !playoffs && (allianceSelection || overrideAllianceSelection)) &&
                 <div>
-                    {isOffseason && (
+                    {(isOffseason || isFTCThreeTeamEligible) && (
                         <Alert variant="warning">
                             <Row className="align-items-center justify-content-center">
                                 <Col xs="auto"><b>Alliance Count Override:</b></Col>
@@ -274,12 +275,12 @@ function AllianceSelectionPage({
                                         Reorder Alliance Selection
                                     </Button>
                                 </Col>
-                                {!ftcMode && (
+                                {(!ftcMode || isFTCThreeTeamEligible) && (
                                     <Col xs="auto" className="d-flex align-items-center gap-2">
                                         <Switch
                                             checked={useFourTeamAlliances === null ? false : useFourTeamAlliances}
                                             onChange={setUseFourTeamAlliances} />
-                                        <b>Use 4 team Alliances for playoffs</b>
+                                        <b>{ftcMode ? "Use 3 team Alliances" : "Use 4 team Alliances for playoffs"}</b>
                                     </Col>
                                 )}
                             </Row>

--- a/src/pages/AllianceSelectionPage.test.jsx
+++ b/src/pages/AllianceSelectionPage.test.jsx
@@ -247,3 +247,80 @@ describe("AllianceSelectionPage – nonStandardPlayoffs", () => {
         expect(screen.getByTestId("bracket-stub")).toBeInTheDocument();
     });
 });
+
+// ─── FTC 3-team alliances ─────────────────────────────────────────────────────
+
+function makeFTCEvent(type) {
+    return {
+        value: { type, code: `FTC${type}`, champLevel: "" },
+        label: `FTC Event type ${type}`,
+    };
+}
+
+describe("AllianceSelectionPage – FTC 3-team alliances switch", () => {
+    beforeEach(() => {
+        setupMocks({ eventOverrides: { ftcMode: true, selectedEvent: makeFTCEvent("2") } });
+    });
+
+    it.each(["2", "4", "7", "10", "17"])(
+        "shows '3 team Alliances' switch for FTC event type %s",
+        (type) => {
+            useEventData.mockReturnValue({ ...useEventData(), ftcMode: true, selectedEvent: makeFTCEvent(type) });
+            render(<AllianceSelectionPage {...baseProps()} />);
+            expect(screen.getByText("Use 3 team Alliances")).toBeInTheDocument();
+        }
+    );
+
+    it.each(["2", "4", "7", "10", "17"])(
+        "shows Alliance Count Override for FTC event type %s",
+        (type) => {
+            useEventData.mockReturnValue({ ...useEventData(), ftcMode: true, selectedEvent: makeFTCEvent(type) });
+            render(<AllianceSelectionPage {...baseProps()} />);
+            expect(screen.getByText("Alliance Count Override:")).toBeInTheDocument();
+        }
+    );
+
+    it.each(["2", "4", "7", "10", "17"])(
+        "shows Reorder Alliance Selection button for FTC event type %s",
+        (type) => {
+            useEventData.mockReturnValue({ ...useEventData(), ftcMode: true, selectedEvent: makeFTCEvent(type) });
+            render(<AllianceSelectionPage {...baseProps()} />);
+            expect(screen.getByText("Reorder Alliance Selection")).toBeInTheDocument();
+        }
+    );
+
+    it("does not show alliance controls for non-eligible FTC type (League Meet = '1')", () => {
+        useEventData.mockReturnValue({ ...useEventData(), ftcMode: true, selectedEvent: makeFTCEvent("1") });
+        render(<AllianceSelectionPage {...baseProps()} />);
+        expect(screen.queryByText("Use 3 team Alliances")).not.toBeInTheDocument();
+        expect(screen.queryByText("Alliance Count Override:")).not.toBeInTheDocument();
+        expect(screen.queryByText("Reorder Alliance Selection")).not.toBeInTheDocument();
+    });
+
+    it("does not show alliance controls for non-eligible FTC type (FIRST Championship = '6')", () => {
+        useEventData.mockReturnValue({ ...useEventData(), ftcMode: true, selectedEvent: makeFTCEvent("6") });
+        render(<AllianceSelectionPage {...baseProps()} />);
+        expect(screen.queryByText("Use 3 team Alliances")).not.toBeInTheDocument();
+    });
+
+    it("does not show 'Use 4 team Alliances for playoffs' label in FTC mode", () => {
+        render(<AllianceSelectionPage {...baseProps()} />);
+        expect(screen.queryByText("Use 4 team Alliances for playoffs")).not.toBeInTheDocument();
+    });
+
+    it("shows the switch checked when useFourTeamAlliances is true in FTC mode", () => {
+        setupMocks({
+            eventOverrides: { ftcMode: true, selectedEvent: makeFTCEvent("2") },
+            settingsOverrides: { useFourTeamAlliances: true },
+        });
+        render(<AllianceSelectionPage {...baseProps()} />);
+        expect(screen.getByText("Use 3 team Alliances")).toBeInTheDocument();
+        const checkbox = document.querySelector("input[type='checkbox']");
+        expect(checkbox?.checked).toBe(true);
+    });
+
+    it("does not show alliance controls in playoffs mode (controls only in selection phase)", () => {
+        render(<AllianceSelectionPage {...baseProps({ playoffs: true })} />);
+        expect(screen.queryByText("Use 3 team Alliances")).not.toBeInTheDocument();
+    });
+});

--- a/src/pages/PlayByPlayPage.jsx
+++ b/src/pages/PlayByPlayPage.jsx
@@ -590,7 +590,7 @@ function PlayByPlayPage({
                       remapNumberToString={remapNumberToString}
                     />
                   </tr>
-                  {(!ftcMode || (inPlayoffs && ftcMode && (selectedEvent?.value?.champLevel === "CHAMPS" || selectedEvent?.value?.champLevel === "CMPDIV" || selectedEvent?.value?.champLevel === "CMPSUB"))) && (
+                  {(!ftcMode || (inPlayoffs && ftcMode && (selectedEvent?.value?.champLevel === "CHAMPS" || selectedEvent?.value?.champLevel === "CMPDIV" || selectedEvent?.value?.champLevel === "CMPSUB")) || (inPlayoffs && ftcMode && useFourTeamAlliances) || (adHocMode && ftcMode)) && (
                     <tr className={"gatool-playbyplay"}>
                       <PlayByPlay
                         station={displayOrder[4]}

--- a/src/pages/PlayByPlayPage.test.jsx
+++ b/src/pages/PlayByPlayPage.test.jsx
@@ -1,0 +1,223 @@
+// Tests for PlayByPlayPage — focused on row-5 (Blue3/Red3) visibility in FTC mode.
+//
+// Row 5 contains the 3rd team slots (Blue3 / Red3). In FTC mode it is hidden
+// by default (standard alliances are 2-team), but must appear when:
+//   (a) the event has champLevel CHAMPS / CMPDIV / CMPSUB, OR
+//   (b) useFourTeamAlliances is enabled (3-team toggle) during playoffs, OR
+//   (c) adHocMode (test match) is active.
+//
+// These tests focus on case (b): the new useFourTeamAlliances path.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("../contexts/SettingsContext", () => ({ useSettings: vi.fn() }));
+vi.mock("contexts/EventDataContext", () => ({ useEventData: vi.fn() }));
+vi.mock("contexts/EventActionsContext", () => ({ useEventActions: vi.fn() }));
+
+// Stub every child component that makes its own network/context calls.
+// PlayByPlay is stubbed to render a detectable element keyed by station so
+// tests can assert which rows are rendered without parsing CSS class names.
+vi.mock("../components/PlayByPlay", () => ({
+    default: ({ station }) => <td data-testid={`pbp-${station}`} />,
+}));
+vi.mock("../components/TopButtons", () => ({ default: () => <div data-testid="top-buttons" /> }));
+vi.mock("../components/BottomButtons", () => ({ default: () => <div data-testid="bottom-buttons" /> }));
+vi.mock("components/NotificationBanner", () => ({ default: () => null }));
+vi.mock("components/EventNotificationBanner", () => ({ default: () => null }));
+
+vi.mock("../hooks/useScrollPosition", () => ({ default: vi.fn() }));
+vi.mock("../contextProviders/ScrollContainerContext", () => ({ useScrollToTop: () => vi.fn() }));
+vi.mock("react-swipeable", () => ({ useSwipeable: () => ({}) }));
+vi.mock("react-hotkeys-hook", () => ({ useHotkeys: vi.fn() }));
+
+vi.mock("../utils/applyPlayoffStationOrderToMatch", () => ({
+    applyPlayoffStationOrderToMatch: (match) => match,
+}));
+vi.mock("../utils/playoffStationOrderEdits", () => ({
+    applyPlayoffStationOrderToMatch: (match) => match,
+}));
+
+import PlayByPlayPage from "./PlayByPlayPage";
+import { useSettings } from "../contexts/SettingsContext";
+import { useEventData } from "contexts/EventDataContext";
+import { useEventActions } from "contexts/EventActionsContext";
+
+// ─── Fixture helpers ──────────────────────────────────────────────────────────
+
+/** A minimal FTC Qualifier event (no champLevel → standard 2-team alliances). */
+function makeFTCQualifierEvent() {
+    return {
+        value: { code: "FTCTEST", type: "2", champLevel: "", name: "FTC Qualifier Test" },
+        label: "FTC Qualifier Test",
+    };
+}
+
+/** A 6-team playoff match with tournamentLevel "Playoff". */
+function makePlayoffMatch() {
+    return {
+        description: "Playoff 1",
+        matchNumber: 1,
+        tournamentLevel: "Playoff",
+        startTime: null,
+        field: "Primary",
+        isReplay: false,
+        matchVideoLink: null,
+        scoreRedFinal: null, scoreRedFoul: null, scoreRedAuto: null,
+        scoreBlueFinal: null, scoreBlueFoul: null, scoreBlueAuto: null,
+        autoStartTime: null, actualStartTime: null, postResultTime: null,
+        winner: { winner: null, tieWinner: null, level: null },
+        teams: [
+            { teamNumber: 1001, station: "Red1", surrogate: false, dq: false, alliance: "Alliance 1" },
+            { teamNumber: 1002, station: "Red2", surrogate: false, dq: false, alliance: "Alliance 1" },
+            { teamNumber: 1003, station: "Red3", surrogate: false, dq: false, alliance: "Alliance 1" },
+            { teamNumber: 2001, station: "Blue1", surrogate: false, dq: false, alliance: "Alliance 2" },
+            { teamNumber: 2002, station: "Blue2", surrogate: false, dq: false, alliance: "Alliance 2" },
+            { teamNumber: 2003, station: "Blue3", surrogate: false, dq: false, alliance: "Alliance 2" },
+        ],
+    };
+}
+
+function makeTeamList() {
+    return {
+        teams: [1001, 1002, 1003, 2001, 2002, 2003].map((n) => ({
+            teamNumber: n, name: `Team ${n}`, city: "City", stateProv: "ST", country: "USA", organization: `Org ${n}`,
+        })),
+    };
+}
+
+function setupMocks({ useFourTeamAlliances = false, champLevel = "" } = {}) {
+    useEventData.mockReturnValue({
+        selectedEvent: { ...makeFTCQualifierEvent(), value: { ...makeFTCQualifierEvent().value, champLevel } },
+        selectedYear: { value: "2026" },
+        eventLabel: "FTC Qualifier Test",
+        ftcMode: true,
+        teamList: makeTeamList(),
+        qualSchedule: { schedule: [] },
+        playoffSchedule: { schedule: [makePlayoffMatch()] },
+        practiceSchedule: { schedule: [] },
+        offlinePlayoffSchedule: { schedule: [] },
+        rankings: null,
+        districtRankings: null,
+        alliances: { alliances: [], Lookup: {} },
+        allianceCount: { count: 4 },
+        communityUpdates: [],
+        currentMatch: 1,
+        remapNumberToString: (n) => String(n),
+        remapStringToNumber: (s) => Number(s),
+        EPA: [],
+        regionalEventDetail: null,
+    });
+
+    useSettings.mockReturnValue({
+        swapScreen: false,
+        hidePracticeSchedule: false,
+        teamReduction: null,
+        showInspection: false,
+        usePullDownToUpdate: false,
+        useSwipe: false,
+        useScrollMemory: false,
+        useFourTeamAlliances,
+        showNotes: false,
+        showMottoes: false,
+        showQualsStats: false,
+        showQualsStatsQuals: false,
+        playoffStationOrderEdits: {},
+    });
+
+    useEventActions.mockReturnValue({
+        nextMatch: vi.fn(),
+        previousMatch: vi.fn(),
+        setMatchFromMenu: vi.fn(),
+        getSchedule: vi.fn(),
+        getRegionalEventDetail: vi.fn(),
+    });
+}
+
+function baseProps(overrides = {}) {
+    return {
+        worldStats: null,
+        ftcRegionHighScores: null,
+        ftcLeagueHighScores: null,
+        frcDistrictHighScores: null,
+        districts: [],
+        ftcLeagues: [],
+        eventNamesCY: [],
+        setAlliances: vi.fn(),
+        eventHighScores: null,
+        backupTeam: null,
+        setBackupTeam: vi.fn(),
+        upsertPlayoffReserveOverlay: vi.fn(),
+        removePlayoffReserveOverlay: vi.fn(),
+        playoffReserveEdits: {},
+        playoffStationOrderEdits: {},
+        upsertPlayoffStationOrderOverlay: vi.fn(),
+        removePlayoffStationOrderOverlay: vi.fn(),
+        adHocMatch: null,
+        setAdHocMatch: vi.fn(),
+        adHocMode: false,
+        adHocRedAlliance: null,
+        setAdHocRedAlliance: vi.fn(),
+        adHocBlueAlliance: null,
+        setAdHocBlueAlliance: vi.fn(),
+        qualsLength: 0,
+        playoffOnly: false,
+        eventMessage: [],
+        eventBell: 0,
+        setEventBell: vi.fn(),
+        allianceSelectionArrays: {},
+        ...overrides,
+    };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("PlayByPlayPage – FTC row-5 (Blue3/Red3) visibility", () => {
+    beforeEach(() => {
+        setupMocks();
+    });
+
+    it("shows Blue3 and Red3 during FTC playoffs when useFourTeamAlliances is enabled", () => {
+        setupMocks({ useFourTeamAlliances: true });
+        render(<PlayByPlayPage {...baseProps()} />);
+        expect(screen.getByTestId("pbp-Blue3")).toBeInTheDocument();
+        expect(screen.getByTestId("pbp-Red3")).toBeInTheDocument();
+    });
+
+    it("hides Blue3 and Red3 during FTC playoffs when useFourTeamAlliances is disabled and no champLevel", () => {
+        setupMocks({ useFourTeamAlliances: false, champLevel: "" });
+        render(<PlayByPlayPage {...baseProps()} />);
+        expect(screen.queryByTestId("pbp-Blue3")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("pbp-Red3")).not.toBeInTheDocument();
+    });
+
+    it("shows Blue3 and Red3 during FTC playoffs for CHAMPS champLevel without useFourTeamAlliances", () => {
+        setupMocks({ useFourTeamAlliances: false, champLevel: "CHAMPS" });
+        render(<PlayByPlayPage {...baseProps()} />);
+        expect(screen.getByTestId("pbp-Blue3")).toBeInTheDocument();
+        expect(screen.getByTestId("pbp-Red3")).toBeInTheDocument();
+    });
+
+    it("shows Blue3 and Red3 in FTC adHocMode regardless of useFourTeamAlliances", () => {
+        const adHocMatch = [
+            { teamNumber: 1001, station: "Red1", surrogate: false, dq: false },
+            { teamNumber: 1002, station: "Red2", surrogate: false, dq: false },
+            { teamNumber: 1003, station: "Red3", surrogate: false, dq: false },
+            { teamNumber: 2001, station: "Blue1", surrogate: false, dq: false },
+            { teamNumber: 2002, station: "Blue2", surrogate: false, dq: false },
+            { teamNumber: 2003, station: "Blue3", surrogate: false, dq: false },
+        ];
+        setupMocks({ useFourTeamAlliances: false });
+        render(<PlayByPlayPage {...baseProps({ adHocMode: true, adHocMatch })} />);
+        expect(screen.getByTestId("pbp-Blue3")).toBeInTheDocument();
+        expect(screen.getByTestId("pbp-Red3")).toBeInTheDocument();
+    });
+
+    it("always shows Blue1 and Red2 regardless of useFourTeamAlliances setting", () => {
+        setupMocks({ useFourTeamAlliances: false });
+        render(<PlayByPlayPage {...baseProps()} />);
+        expect(screen.getByTestId("pbp-Blue1")).toBeInTheDocument();
+        expect(screen.getByTestId("pbp-Red2")).toBeInTheDocument();
+    });
+});

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -545,10 +545,16 @@ function SetupPage({
                                 options={selectedEvent?.value?.type?.includes("OffSeason") ? playoffOverrideMenuOffseason : playoffOverrideMenu}
                                 value={playoffCountOverride ? playoffCountOverride : (allianceCount?.menu ? allianceCount.menu : (selectedEvent?.value?.type?.includes("OffSeason") ? playoffOverrideMenuOffseason[0] : playoffOverrideMenu[0]))}
                                 onChange={(val) => { setPlayoffCountOverride(val); getAlliances(undefined, val?.value); }} />
-                                {!ftcMode && (selectedEvent?.value?.type === "OffSeason" || selectedEvent?.value?.type === "OffSeasonWithAzureSync") && 
+                                {!ftcMode && (selectedEvent?.value?.type === "OffSeason" || selectedEvent?.value?.type === "OffSeasonWithAzureSync") &&
                                 <><br/><label style={{ display: "flex", alignItems: "center", gap: "10px", marginTop: "8px" }}>
                                 <Switch checked={useFourTeamAlliances === null ? false : useFourTeamAlliances} onChange={setUseFourTeamAlliances} />
                                 <span><b>Use 4 team Alliances for playoffs</b></span>
+                            </label></>
+                                }
+                                {ftcMode && ["2", "4", "7", "10", "17"].includes(selectedEvent?.value?.type) &&
+                                <><br/><label style={{ display: "flex", alignItems: "center", gap: "10px", marginTop: "8px" }}>
+                                <Switch checked={useFourTeamAlliances === null ? false : useFourTeamAlliances} onChange={setUseFourTeamAlliances} />
+                                <span><b>Use 3 team Alliances for playoffs</b></span>
                             </label></>
                                 }
                         </Alert>

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -539,7 +539,7 @@ function SetupPage({
                             </>}
                             {selectedEvent?.value?.type?.includes("OffSeason")
                                 ? "If your event requires a non-standard Alliance Count, you can override the Alliance Count here."
-                                : <span>If your event requires a reduced Alliance Count, you can override the Alliance Count here. <b>THIS SHOULD ONLY APPLY TO EVENTS WITH LESS THAN 26 TEAMS.</b></span>
+                                : <span>If your event requires a reduced Alliance Count, you can override the Alliance Count here. {!ftcMode && <b>THIS SHOULD ONLY APPLY TO EVENTS WITH LESS THAN 26 TEAMS.</b>}</span>
                             }
                             <Select classNamePrefix="gatool-rs"
                                 options={selectedEvent?.value?.type?.includes("OffSeason") ? playoffOverrideMenuOffseason : playoffOverrideMenu}
@@ -551,7 +551,7 @@ function SetupPage({
                                 <span><b>Use 4 team Alliances for playoffs</b></span>
                             </label></>
                                 }
-                                {ftcMode && ["2", "4", "7", "10", "17"].includes(selectedEvent?.value?.type) &&
+                                {ftcMode && ["0", "10", "17"].includes(selectedEvent?.value?.type) &&
                                 <><br/><label style={{ display: "flex", alignItems: "center", gap: "10px", marginTop: "8px" }}>
                                 <Switch checked={useFourTeamAlliances === null ? false : useFourTeamAlliances} onChange={setUseFourTeamAlliances} />
                                 <span><b>Use 3 team Alliances for playoffs</b></span>


### PR DESCRIPTION
This brings 3-team Alliance support for FTC events in support of #784 

This brings true 3-team Alliance support for Alliance Selection as well as in match display for Scrimmage, Off-Season and Premier events. If the event retains 3-team Alliances in the field-sourced API data, gatool will display it. Prior to a match being played, the user can choose to add a team to the Alliance at match time.

It also adds proper support for off-season demo teams so that if an event updates team details, those changes won't collide with details from another event.