### PR TITLE
Handle lost IndexedDB connections instead of failing silently

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -318,7 +318,7 @@ function App() {
   const [alliancePartnerConnectionsCache, setAlliancePartnerConnectionsCache] =
     useState({});
   const [lastVisit, setLastVisit] = usePersistentState("cache:lastVisit", {});
-  const [localUpdates, setLocalUpdates] = usePersistentState(
+  const [localUpdates, setLocalUpdates, saveLocalUpdates] = usePersistentState(
     "cache:localUpdates",
     []
   );
@@ -2520,6 +2520,7 @@ function App() {
                     putTeamData={putTeamData}
                     localUpdates={localUpdates}
                     setLocalUpdates={setLocalUpdates}
+                    saveLocalUpdates={saveLocalUpdates}
                     originalAndSustaining={originalAndSustaining}
                     user={user}
                     isAuthenticated={isAuthenticated}

--- a/src/contextProviders/AuthProvider.jsx
+++ b/src/contextProviders/AuthProvider.jsx
@@ -20,6 +20,38 @@ const REFRESH_LEAD_SECONDS = 60; // refresh this many seconds before expiry
 
 const AuthContext = createContext(null);
 
+// The browser can refuse or drop local storage mid-session (Safari drops the
+// IndexedDB connection under memory pressure; private mode and quota limits
+// behave similarly). Session persistence is a convenience — losing it must
+// never fail a login, a refresh, or a logout, so every storage touch below is
+// best-effort and degrades to a memory-only session.
+async function readStored(key) {
+  try {
+    return await localforage.getItem(key);
+  } catch (e) {
+    console.warn(`Could not read "${key}" from local storage.`, e);
+    return null;
+  }
+}
+
+async function writeStored(key, value) {
+  try {
+    await localforage.setItem(key, value);
+    return true;
+  } catch (e) {
+    console.warn(`Could not write "${key}" to local storage.`, e);
+    return false;
+  }
+}
+
+async function removeStored(key) {
+  try {
+    await localforage.removeItem(key);
+  } catch (e) {
+    console.warn(`Could not remove "${key}" from local storage.`, e);
+  }
+}
+
 // Build a deterministic SVG initials avatar — used as the fallback when the
 // user has no Gravatar set (Gravatar 404s with d=404).
 export function initialsAvatar(email) {
@@ -140,8 +172,16 @@ export function AuthProvider({ children }) {
     async (tokenResp) => {
       accessTokenRef.current = tokenResp.accessToken;
       expiresAtRef.current = Date.now() + tokenResp.expiresIn * 1000;
-      await localforage.setItem(REFRESH_KEY, tokenResp.refreshToken);
-      await localforage.setItem(LAST_EMAIL_KEY, tokenResp.email);
+      // Best-effort: if storage is unavailable the user is still signed in for
+      // this tab, they just won't be remembered after a reload. Failing here
+      // would surface as "Network error" in LoginModal on a successful login.
+      const persisted = await writeStored(REFRESH_KEY, tokenResp.refreshToken);
+      await writeStored(LAST_EMAIL_KEY, tokenResp.email);
+      if (!persisted) {
+        console.warn(
+          "Signed in, but the session could not be saved locally; it will end when this page is closed."
+        );
+      }
       setLastEmail(tokenResp.email);
       setUser(buildUser(tokenResp.email, tokenResp.roles));
       scheduleRefresh(tokenResp.expiresIn);
@@ -153,13 +193,13 @@ export function AuthProvider({ children }) {
     accessTokenRef.current = null;
     expiresAtRef.current = 0;
     clearRefreshTimer();
-    await localforage.removeItem(REFRESH_KEY);
+    await removeStored(REFRESH_KEY);
     setUser(null);
   }, [clearRefreshTimer]);
 
   const refreshNow = useCallback(async () => {
     if (refreshPromiseRef.current) return refreshPromiseRef.current;
-    const refreshToken = await localforage.getItem(REFRESH_KEY);
+    const refreshToken = await readStored(REFRESH_KEY);
     if (!refreshToken) return null;
 
     const p = (async () => {
@@ -194,7 +234,7 @@ export function AuthProvider({ children }) {
     let cancelled = false;
     (async () => {
       try {
-        const lastEmailStored = await localforage.getItem(LAST_EMAIL_KEY);
+        const lastEmailStored = await readStored(LAST_EMAIL_KEY);
         if (lastEmailStored && !cancelled) setLastEmail(lastEmailStored);
         await refreshNow();
       } catch (e) {
@@ -211,7 +251,7 @@ export function AuthProvider({ children }) {
   }, []);
 
   const logout = useCallback(async () => {
-    const refreshToken = await localforage.getItem(REFRESH_KEY);
+    const refreshToken = await readStored(REFRESH_KEY);
     if (refreshToken) {
       // best-effort revoke
       try {

--- a/src/contextProviders/AuthProvider.test.jsx
+++ b/src/contextProviders/AuthProvider.test.jsx
@@ -1,0 +1,122 @@
+// Regression tests for AuthProvider when local storage is unavailable.
+//
+// Safari drops the IndexedDB connection under memory pressure, after which
+// every localforage call rejects. Session persistence is a convenience, so a
+// storage failure must never fail authentication: before this was handled,
+// applyTokens() rejected on setItem and LoginModal reported the resulting
+// throw to the user as "Network error. Please try again." on an otherwise
+// successful sign-in — and the one-time OTP had already been consumed.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import localforage from "localforage";
+import { server } from "../test/server";
+
+import { AuthProvider, useAuth } from "./AuthProvider";
+
+const BASE = "https://api.gatool.org/v3";
+const REFRESH_KEY = "gatool.auth.refresh";
+
+const TOKEN_RESPONSE = {
+  accessToken: "access-token-abc",
+  refreshToken: "refresh-token-def",
+  expiresIn: 3600,
+  email: "announcer@example.com",
+  roles: ["admin"],
+};
+
+let refreshResult;
+
+function Probe() {
+  const { isAuthenticated, isLoading, user, refreshNow } = useAuth();
+  return (
+    <div>
+      <span data-testid="loading">{String(isLoading)}</span>
+      <span data-testid="authed">{String(isAuthenticated)}</span>
+      <span data-testid="email">{user?.email ?? ""}</span>
+      <button
+        onClick={async () => {
+          refreshResult = await refreshNow();
+        }}
+      >
+        refresh
+      </button>
+    </div>
+  );
+}
+
+function renderAuth() {
+  return render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  refreshResult = undefined;
+  server.use(
+    http.post(`${BASE}/auth/refresh`, () => HttpResponse.json(TOKEN_RESPONSE))
+  );
+});
+
+describe("AuthProvider with unavailable local storage", () => {
+  it("still authenticates when the session cannot be written to storage", async () => {
+    // A stored refresh token exists, but writing the new one fails.
+    vi.spyOn(localforage, "getItem").mockImplementation(async (key) =>
+      key === REFRESH_KEY ? "stored-refresh-token" : null
+    );
+    vi.spyOn(localforage, "setItem").mockRejectedValue(
+      new Error("Connection to Indexed Database server lost. Refresh the page to try again")
+    );
+
+    renderAuth();
+
+    // Bootstrap refresh runs on mount and must sign the user in regardless.
+    await waitFor(() =>
+      expect(screen.getByTestId("authed").textContent).toBe("true")
+    );
+    expect(screen.getByTestId("email").textContent).toBe(
+      "announcer@example.com"
+    );
+  });
+
+  it("resolves an access token instead of rejecting when storage is dead", async () => {
+    vi.spyOn(localforage, "getItem").mockImplementation(async (key) =>
+      key === REFRESH_KEY ? "stored-refresh-token" : null
+    );
+    vi.spyOn(localforage, "setItem").mockRejectedValue(
+      new Error("Connection to Indexed Database server lost. Refresh the page to try again")
+    );
+
+    renderAuth();
+    await waitFor(() =>
+      expect(screen.getByTestId("loading").textContent).toBe("false")
+    );
+
+    await act(async () => {
+      screen.getByText("refresh").click();
+    });
+
+    // Before the fix this rejected, which LoginModal surfaced as
+    // "Network error. Please try again." on a successful sign-in.
+    await waitFor(() => expect(refreshResult).toBe("access-token-abc"));
+  });
+
+  it("does not fail bootstrap when the stored session cannot be read", async () => {
+    vi.spyOn(localforage, "getItem").mockRejectedValue(
+      new Error("Connection to Indexed Database server lost. Refresh the page to try again")
+    );
+    vi.spyOn(localforage, "setItem").mockResolvedValue(undefined);
+
+    renderAuth();
+
+    // Unreadable storage means anonymous, but the app must finish loading.
+    await waitFor(() =>
+      expect(screen.getByTestId("loading").textContent).toBe("false")
+    );
+    expect(screen.getByTestId("authed").textContent).toBe("false");
+  });
+});

--- a/src/hooks/UsePersistentState.jsx
+++ b/src/hooks/UsePersistentState.jsx
@@ -1,46 +1,147 @@
 import localforage from "localforage";
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "react-toastify";
+
+// Browsers can drop the IndexedDB connection mid-session — Safari does this
+// under memory pressure and every subsequent read/write then rejects with
+// "Connection to Indexed Database server lost". Previously nothing handled
+// those rejections, so a single dropped connection produced hundreds of
+// unhandled promise rejections over a long announcer session, and callers
+// went on telling users their changes were saved when they were not.
+//
+// We can't recover in-page. localforage does have a _tryReconnect path, but
+// createTransaction only reaches it when db.transaction() throws
+// synchronously (InvalidStateError / NotFoundError). Safari's dropped
+// connection instead aborts the transaction asynchronously, which localforage
+// surfaces straight to the caller via transaction.onabort with no reconnect
+// attempt. There is no public API to force one either: setDriver() is a no-op
+// when the driver is already selected, and createInstance() reuses the same
+// cached connection for a given database name.
+//
+// So: keep the app running from in-memory state, surface the problem once,
+// and let the user reload when it's safe for them to do so (this is a live
+// announcing tool — an automatic reload mid-match would be far worse, and
+// would also discard the in-memory edits that can still be pushed to the
+// cloud from Settings).
+let storageFailureReported = false;
+
+function reportStorageFailure(key, error) {
+  console.warn(`Could not persist "${key}" to local storage.`, error);
+  // One notice per page load — a dead connection fails every subsequent
+  // write, and this hook has ~85 call sites.
+  if (storageFailureReported) return;
+  storageFailureReported = true;
+  toast.error(
+    ({ closeToast }) => (
+      <div>
+        <div>
+          Your browser stopped saving data on this device, so changes will be
+          lost if you reload. If you have unsent team updates, send them to
+          gatool Cloud from Settings first.
+        </div>
+        <div className="mt-2 d-flex gap-2">
+          <button
+            type="button"
+            className="btn btn-sm btn-light"
+            onClick={() => window.location.reload()}
+          >
+            Reload now
+          </button>
+          <button
+            type="button"
+            className="btn btn-sm btn-outline-light"
+            onClick={closeToast}
+          >
+            Not now
+          </button>
+        </div>
+      </div>
+    ),
+    { autoClose: false, closeOnClick: false, draggable: false }
+  );
+}
+
+/** Test seam: clears the once-per-page-load notice guard. */
+export function resetStorageFailureNotice() {
+  storageFailureReported = false;
+}
 
 export const usePersistentState = (key, defaultValue) => {
-    const [value, setValue] = useState(defaultValue);
-    const [hydrated, setHydrated] = useState(false);
+  const [value, setValue] = useState(defaultValue);
+  const [hydrated, setHydrated] = useState(false);
+  // Serialized form of whatever was last written to (or read from) storage,
+  // so an explicit saveNow() and the write effect don't both write the same
+  // payload, and so hydration doesn't immediately echo the value back.
+  const lastPersistedRef = useRef(undefined);
 
-    useEffect(() => {
-        setHydrated(false);
-        let cancelled = false;
-        async function load() {
-            try {
-                const saved = await localforage.getItem(key);
-                if (cancelled) return;
-                if (saved !== null) {
-                    try {
-                        const initial = JSON.parse(saved);
-                        // Check for null/undefined explicitly to preserve false, 0, empty string, etc.
-                        setValue(
-                            initial !== null && initial !== undefined ? initial : defaultValue
-                        );
-                    } catch (e) {
-                        // If parsing fails, use default value
-                        setValue(defaultValue);
-                    }
-                }
-            } finally {
-                if (!cancelled) {
-                    setHydrated(true);
-                }
-            }
+  useEffect(() => {
+    setHydrated(false);
+    lastPersistedRef.current = undefined;
+    let cancelled = false;
+    async function load() {
+      try {
+        const saved = await localforage.getItem(key);
+        if (cancelled) return;
+        if (saved !== null) {
+          lastPersistedRef.current = saved;
+          try {
+            const initial = JSON.parse(saved);
+            // Check for null/undefined explicitly to preserve false, 0, empty string, etc.
+            setValue(
+              initial !== null && initial !== undefined ? initial : defaultValue
+            );
+          } catch (e) {
+            // If parsing fails, use default value
+            setValue(defaultValue);
+          }
         }
-        load();
-        return () => {
-            cancelled = true;
-        };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [key]);
+      } catch (e) {
+        // Storage is unreadable (dropped connection, private mode, quota).
+        // Fall back to the default and keep the app usable from memory.
+        if (!cancelled) reportStorageFailure(key, e);
+      } finally {
+        if (!cancelled) {
+          setHydrated(true);
+        }
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
 
-    useEffect(() => {
-        if (!hydrated) return;
-        localforage.setItem(key, JSON.stringify(value));
-    }, [key, value, hydrated]);
+  useEffect(() => {
+    if (!hydrated) return;
+    const serialized = JSON.stringify(value);
+    if (lastPersistedRef.current === serialized) return;
+    localforage
+      .setItem(key, serialized)
+      .then(() => {
+        lastPersistedRef.current = serialized;
+      })
+      .catch((e) => reportStorageFailure(key, e));
+  }, [key, value, hydrated]);
 
-    return [value, setValue];
+  // Like setValue, but resolves to whether the value actually reached storage.
+  // Use this instead of setValue whenever the UI is about to tell the user
+  // their change was saved. Takes a concrete value, not an updater function.
+  const saveNow = useCallback(
+    async (next) => {
+      setValue(next);
+      const serialized = JSON.stringify(next);
+      try {
+        await localforage.setItem(key, serialized);
+        lastPersistedRef.current = serialized;
+        return true;
+      } catch (e) {
+        reportStorageFailure(key, e);
+        return false;
+      }
+    },
+    [key]
+  );
+
+  return [value, setValue, saveNow];
 };

--- a/src/hooks/UsePersistentState.test.jsx
+++ b/src/hooks/UsePersistentState.test.jsx
@@ -1,0 +1,192 @@
+// Tests for usePersistentState's behaviour when local storage is unavailable.
+//
+// Browsers can drop the IndexedDB connection mid-session — Safari does this
+// under memory pressure and every subsequent read/write rejects with
+// "Connection to Indexed Database server lost". These tests pin the three
+// things that must hold when that happens: no unhandled promise rejections,
+// the app keeps working from memory, and saveNow() reports the failure
+// truthfully so callers don't tell users their data was saved.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor, render, screen } from "@testing-library/react";
+import localforage from "localforage";
+
+vi.mock("react-toastify", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+import { toast } from "react-toastify";
+
+import {
+  usePersistentState,
+  resetStorageFailureNotice,
+} from "./UsePersistentState";
+
+const IDB_LOST = () =>
+  new Error("Connection to Indexed Database server lost. Refresh the page to try again");
+
+let unhandled;
+let warnSpy;
+
+beforeEach(() => {
+  resetStorageFailureNotice();
+  vi.restoreAllMocks();
+  toast.error.mockClear();
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  unhandled = [];
+  // Node surfaces unhandled rejections on `process`, not on jsdom's `window`.
+  const onUnhandled = (reason) => unhandled.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  globalThis.__onUnhandled = onUnhandled;
+});
+
+afterEach(() => {
+  process.off("unhandledRejection", globalThis.__onUnhandled);
+});
+
+/** Give any floating promise chains a chance to settle and reject. */
+async function flushRejections() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+/** The hook reports every storage failure through console.warn. */
+function warnedAbout(key) {
+  return warnSpy.mock.calls.some(([msg]) =>
+    typeof msg === "string" && msg.includes(key)
+  );
+}
+
+describe("usePersistentState when storage writes fail", () => {
+  it("does not emit an unhandled rejection and keeps the value in memory", async () => {
+    vi.spyOn(localforage, "getItem").mockResolvedValue(null);
+    vi.spyOn(localforage, "setItem").mockRejectedValue(IDB_LOST());
+
+    const { result } = renderHook(() => usePersistentState("cache:test", []));
+
+    await act(async () => {
+      result.current[1]([{ teamNumber: 1234 }]);
+    });
+    await flushRejections();
+
+    // The rejection must be caught and reported, not left floating.
+    expect(warnedAbout("cache:test")).toBe(true);
+    expect(unhandled).toEqual([]);
+    // The app keeps running off in-memory state even though the write failed.
+    expect(result.current[0]).toEqual([{ teamNumber: 1234 }]);
+  });
+
+  it("saveNow resolves false so callers can tell the user the truth", async () => {
+    vi.spyOn(localforage, "getItem").mockResolvedValue(null);
+    vi.spyOn(localforage, "setItem").mockRejectedValue(IDB_LOST());
+
+    const { result } = renderHook(() => usePersistentState("cache:test", []));
+    await waitFor(() => expect(result.current[2]).toBeTypeOf("function"));
+
+    let persisted;
+    await act(async () => {
+      persisted = await result.current[2]([{ teamNumber: 1234 }]);
+    });
+
+    expect(persisted).toBe(false);
+    expect(unhandled).toEqual([]);
+  });
+
+  it("saveNow resolves true when the write lands", async () => {
+    vi.spyOn(localforage, "getItem").mockResolvedValue(null);
+    const setItem = vi.spyOn(localforage, "setItem").mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => usePersistentState("cache:test", []));
+    await waitFor(() => expect(result.current[2]).toBeTypeOf("function"));
+
+    let persisted;
+    await act(async () => {
+      persisted = await result.current[2]([{ teamNumber: 1234 }]);
+    });
+
+    expect(persisted).toBe(true);
+    expect(setItem).toHaveBeenCalledWith(
+      "cache:test",
+      JSON.stringify([{ teamNumber: 1234 }])
+    );
+  });
+
+  it("does not re-write the same payload after saveNow already persisted it", async () => {
+    vi.spyOn(localforage, "getItem").mockResolvedValue(null);
+    const setItem = vi.spyOn(localforage, "setItem").mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => usePersistentState("cache:test", []));
+    await waitFor(() => expect(result.current[2]).toBeTypeOf("function"));
+
+    await act(async () => {
+      await result.current[2]([{ teamNumber: 1234 }]);
+    });
+    await flushRejections();
+
+    const writes = setItem.mock.calls.filter(
+      ([, v]) => v === JSON.stringify([{ teamNumber: 1234 }])
+    );
+    expect(writes).toHaveLength(1);
+  });
+});
+
+describe("usePersistentState when storage reads fail", () => {
+  it("falls back to the default value without an unhandled rejection", async () => {
+    vi.spyOn(localforage, "getItem").mockRejectedValue(IDB_LOST());
+    vi.spyOn(localforage, "setItem").mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      usePersistentState("cache:test", ["fallback"])
+    );
+    await flushRejections();
+
+    expect(warnedAbout("cache:test")).toBe(true);
+    expect(unhandled).toEqual([]);
+    expect(result.current[0]).toEqual(["fallback"]);
+  });
+});
+
+describe("storage failure notice", () => {
+  it("offers a reload the user controls, and does not auto-close", async () => {
+    vi.spyOn(localforage, "getItem").mockResolvedValue(null);
+    vi.spyOn(localforage, "setItem").mockRejectedValue(IDB_LOST());
+
+    const { result } = renderHook(() => usePersistentState("cache:test", []));
+    await act(async () => {
+      result.current[1]([1]);
+    });
+    await flushRejections();
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    const [content, options] = toast.error.mock.calls[0];
+    // Sticky: an announcer must be able to act on this between matches, not
+    // have it disappear on a timer or an accidental click.
+    expect(options).toMatchObject({ autoClose: false, closeOnClick: false });
+
+    // The reload must be user-initiated — never automatic. A dropped Safari
+    // connection recurs after reload, so auto-reloading would loop, and it
+    // would discard in-memory edits that are still recoverable via Settings.
+    const closeToast = vi.fn();
+    render(<>{content({ closeToast })}</>);
+    expect(screen.getByRole("button", { name: /reload now/i })).toBeTruthy();
+    screen.getByRole("button", { name: /not now/i }).click();
+    expect(closeToast).toHaveBeenCalled();
+  });
+
+  it("notifies once per page load no matter how many writes fail", async () => {
+    vi.spyOn(localforage, "getItem").mockResolvedValue(null);
+    vi.spyOn(localforage, "setItem").mockRejectedValue(IDB_LOST());
+
+    const { result } = renderHook(() => usePersistentState("cache:test", []));
+    for (let i = 0; i < 5; i++) {
+      await act(async () => {
+        result.current[1]([i]);
+      });
+      await flushRejections();
+    }
+
+    // ~85 call sites share this hook; a dead connection fails every write.
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls.length).toBeGreaterThan(1);
+  });
+});

--- a/src/pages/TeamDataPage.jsx
+++ b/src/pages/TeamDataPage.jsx
@@ -24,6 +24,19 @@ import { useSettings } from "../contexts/SettingsContext";
 import { useEventData } from "contexts/EventDataContext";
 import { useEventActions } from "contexts/EventActionsContext";
 
+/**
+ * Message for an update that couldn't reach gatool Cloud. Only promise the user
+ * a local copy when the local write actually landed — the browser can refuse or
+ * drop local storage mid-session (Safari drops the IndexedDB connection under
+ * memory pressure), and telling someone their edit is safe when it isn't means
+ * they lose it silently on reload.
+ */
+function cloudSaveFailedMessage(teamNumber, persistedLocally) {
+    return persistedLocally
+        ? `Your update for team ${teamNumber} was not successful. We have saved the change locally, and you can send it later from here or the Settings page.`
+        : `Your update for team ${teamNumber} could not be sent to gatool Cloud, and your browser would not save it on this device either. This change will be lost if you reload — try again, or refresh the page and re-enter it.`;
+}
+
 /** Blue banner stats are a nested object; SheetJS leaves those cells blank unless stringified. */
 const BLUE_BANNER_EXPORT_ROWS = [
     ["regionalWins", "regionalWinsYears", "Regional Win", "Regional Wins"],
@@ -79,6 +92,7 @@ function TeamDataPage({
   putTeamData,
   localUpdates,
   setLocalUpdates,
+  saveLocalUpdates,
   originalAndSustaining,
   user,
   isAuthenticated,
@@ -201,10 +215,9 @@ function TeamDataPage({
                         localUpdatesTemp.splice(failedItemIndex, 1);
                     }
                     localUpdatesTemp.push({ "teamNumber": updateTeam.teamNumber, "update": update.updates });
-                    await setLocalUpdates(localUpdatesTemp);
+                    var persistedFailed = await saveLocalUpdates(localUpdatesTemp);
 
-                    var errorText = `Your update for team ${updateTeam.teamNumber} was not successful. We have saved the change locally, and you can send it later from here or the Settings page.`;
-                    toast.error(errorText);
+                    toast.error(cloudSaveFailedMessage(updateTeam.teamNumber, persistedFailed));
                 } else {
                     // Update succeeded - remove from local updates
                     var successItemIndex = _.findIndex(localUpdatesTemp, { "teamNumber": updateTeam.teamNumber });
@@ -228,10 +241,9 @@ function TeamDataPage({
                     localUpdatesTemp.splice(errorItemIndex, 1);
                 }
                 localUpdatesTemp.push({ "teamNumber": updateTeam.teamNumber, "update": update.updates });
-                await setLocalUpdates(localUpdatesTemp);
+                var persistedError = await saveLocalUpdates(localUpdatesTemp);
 
-                var errorText = `Your update for team ${updateTeam.teamNumber} was not successful. We have saved the change locally, and you can send it later from here or the Settings page.`;
-                toast.error(errorText);
+                toast.error(cloudSaveFailedMessage(updateTeam.teamNumber, persistedError));
                 console.error('Error updating team data:', error);
             });
 
@@ -241,8 +253,12 @@ function TeamDataPage({
                 localUpdatesTemp.splice(itemExists, 1);
             }
             localUpdatesTemp.push({ "teamNumber": updateTeam.teamNumber, "update": update.updates });
-            toast.success(`We have stored your update for team ${updateTeam.teamNumber}. Remember that this update is only visible to you until you save it to gatool Cloud.`)
-            setLocalUpdates(localUpdatesTemp);
+            var persistedLocalOnly = await saveLocalUpdates(localUpdatesTemp);
+            if (persistedLocalOnly) {
+                toast.success(`We have stored your update for team ${updateTeam.teamNumber}. Remember that this update is only visible to you until you save it to gatool Cloud.`)
+            } else {
+                toast.error(`Your browser would not save the update for team ${updateTeam.teamNumber} on this device. It will be lost if you reload — try refreshing the page and entering it again.`)
+            }
         }
 
         await setLastVisit(visits);


### PR DESCRIPTION
## Problem

New Relic showed **493 `Connection to Indexed Database server lost` errors** — the single largest error on the app. They were tightly concentrated:

| Dimension | Value |
|---|---|
| Browser | **Safari 26.2 / Mac — 100%** (zero Chrome, Firefox, Edge) |
| Sessions | **4**, all one machine at one venue |
| Day | July 25 |
| Pages | `/announce` (316), `/playbyplay` (176), `/teamdata` (1) |

The pattern is a sustained drip, not a spike — Safari drops the IndexedDB connection once, early in a long announcer session, and every subsequent write fails for hours:

```
263 errors | 16:05:08 → 19:48:20Z | 223 min | 1.2/min
220 errors | 19:58:12 → 21:51:08Z | 113 min | 1.9/min
```

Safari dropping the connection is a WebKit bug we can't fix. The bug on our side was that **nothing handled the rejection** — `UsePersistentState.jsx` wrote via a floating promise with no `.catch()`, and `load()` had `try/finally` with no `catch`. With ~85 call sites and `cache:` keys updating as match data polls in, one dead connection produced the volume above.

Two real bugs were hiding behind that noise.

**Silent data loss on team updates.** `TeamDataPage` told users *"We have saved the change locally, and you can send it later"* when the local write had failed and the edit was gone on reload. The `await setLocalUpdates(...)` was awaiting a React setter returning `undefined`, so it confirmed nothing.

**Login broke with a misleading message.** `applyTokens` rejected on `setItem`, `LoginModal` caught it and showed **"Network error. Please try again."** on an otherwise successful sign-in — and the one-time OTP had already been consumed, so retrying the same code gave *"That code is invalid or expired."*

## Changes

- **`UsePersistentState.jsx`** — catch rejections on both read and write paths. New third return value `saveNow(value)` resolves to whether the write actually landed, so callers can stop claiming saves that didn't happen. Existing two-element destructuring at ~85 call sites is unaffected. Failures log every time but notify **once per page load**.
- **`AuthProvider.jsx`** — all six localforage calls routed through best-effort `readStored`/`writeStored`/`removeStored`. Sign-in degrades to a memory-only session instead of failing; `logout` and `clearTokens` no longer fail on dead storage.
- **`TeamDataPage.jsx` / `App.jsx`** — the three local-save paths use the confirmed save and branch the message on the real result.

## Why the reload is user-initiated, not automatic

localforage *does* have a `_tryReconnect` path, but `createTransaction` only reaches it when `db.transaction()` throws **synchronously** (`InvalidStateError` / `NotFoundError`). Safari's dropped connection aborts the transaction **asynchronously**, which goes straight to the caller via `transaction.onabort` with no reconnect attempt. Verified in a live browser:

| Simulation | Result |
|---|---|
| Close the IDB handle (sync `InvalidStateError`) | **Self-healed** — write succeeded |
| Async transaction abort (Safari's mode) | `AbortError` ×3, **never reconnected** |

And no public API can force one: `setDriver(INDEXEDDB)` returns in **0ms** (no-op when already selected), and `createInstance()` reuses the cached connection for a given DB name.

Auto-*reloading* would also be wrong. The affected user reloaded **three times** and the error recurred within minutes each time, so it would loop. A reload also discards the in-memory edits that are still recoverable — `SetupPage` pushes `localUpdates` to the cloud over the network, touching no IndexedDB, so the data is fine as long as we *don't* reload. So the notice is sticky (`autoClose: false`) with **Reload now** / **Not now**, and tells users to send pending updates from Settings first.

## Testing

**590 passed / 36 files** (was 580 / 34), lint clean at `--max-warnings=0`, production build green.

8 new regression tests. I verified each one actually fails without the fix — the first version of the storage tests was **vacuous** (it listened for `unhandledrejection` on jsdom's `window`, which never fires there, so it passed against reverted code). Reworked to listen on `process` and assert the failure is reported. Against deliberately reverted code the suite now produces 2 failures in `UsePersistentState` (read + write paths) and 2 in `AuthProvider` (bootstrap auth, `refreshNow` resolution).

## Expected impact

Those 493 errors should go to roughly zero. The underlying Safari drop still happens, but it degrades to one warning toast plus console entries, with the app running from memory.