### PR TITLE
Treat New Relic 409 as already-uploaded, not a failure

### DIFF
--- a/scripts/publish-sourcemaps.mjs
+++ b/scripts/publish-sourcemaps.mjs
@@ -171,6 +171,25 @@ const missing = verified.filter((m) => !m.ok);
 const tooBig = verified.filter((m) => m.ok && m.size > MAX_MAP_BYTES);
 const publishable = verified.filter((m) => m.ok && m.size <= MAX_MAP_BYTES);
 
+/** Status code from whichever layer produced the error (superagent sets .status). */
+function errorStatus(err) {
+  return err?.status ?? err?.response?.status ?? err?.response?.statusCode;
+}
+
+function describeError(err) {
+  const status = errorStatus(err);
+  const message = err?.message || "";
+  if (message && status) return `${message} (HTTP ${status})`;
+  if (message) return message;
+  if (status) return `HTTP ${status}`;
+  return String(err);
+}
+
+/** Transient conditions worth a retry. Other 4xx will fail again identically. */
+function isRetryable(status) {
+  return status === 429 || (status >= 500 && status < 600);
+}
+
 async function upload(m) {
   let lastError;
   for (let attempt = 1; attempt <= 3; attempt++) {
@@ -191,18 +210,28 @@ async function upload(m) {
       return { ...m, uploaded: true };
     } catch (err) {
       lastError = err;
+      const status = errorStatus(err);
+      // 409 means New Relic already has a sourcemap for this javascriptUrl.
+      // Asset URLs are content-hashed, so an existing entry was built from
+      // identical bytes and is already correct. Vendor chunks hash off
+      // node_modules alone, so they keep their filename across commits and
+      // conflict on every deploy that doesn't bump a dependency — that is the
+      // normal steady state, not a failure.
+      if (status === 409) return { ...m, alreadyPresent: true };
+      if (status !== undefined && !isRetryable(status)) break;
       if (attempt < 3) await new Promise((resolve) => setTimeout(resolve, 2000 * attempt));
     }
   }
-  return { ...m, uploaded: false, error: lastError?.message || String(lastError) };
+  return { ...m, uploaded: false, error: describeError(lastError) };
 }
 
 const uploaded = dryRun
   ? publishable.map((m) => ({ ...m, uploaded: true }))
   : await pool(publishable, CONCURRENCY, upload);
 
-const failed = uploaded.filter((m) => !m.uploaded);
-const succeeded = uploaded.length - failed.length;
+const alreadyPresent = uploaded.filter((m) => m.alreadyPresent);
+const failed = uploaded.filter((m) => !m.uploaded && !m.alreadyPresent);
+const succeeded = uploaded.filter((m) => m.uploaded).length;
 
 // --- report ---
 const lines = [
@@ -212,6 +241,11 @@ const lines = [
   `- Application ID: \`${applicationId}\``,
   `- Uploaded: **${succeeded}/${maps.length}**`,
 ];
+if (alreadyPresent.length) {
+  lines.push(
+    `- Already in New Relic (unchanged since a previous deploy): **${alreadyPresent.length}**`
+  );
+}
 if (tooBig.length) lines.push(`- Skipped (>50MB): ${tooBig.map((m) => m.rel).join(", ")}`);
 if (missing.length) {
   lines.push(


### PR DESCRIPTION
Fixes the failed run on [#30184691253](https://github.com/arthurlockman/gatool-ui/actions/runs/30184691253/job/89747148995).

## What happened

```
- Uploaded: **1/13**

### ❌ Upload failed
- `assets/vendor-bootstrap-ax7ELrIZ.js.map`: Conflict
- `assets/vendor-dnd-BSV77r5m.js.map`: Conflict
  … 12 total
```

`Conflict` is HTTP 409 — New Relic already has a sourcemap registered for that `javascriptUrl`.

The run history makes the cause exact:

| Run | Commit | Result |
|---|---|---|
| 30182435464 | `a24c00f` | success, all 13 uploaded |
| 30184691253 | #805 merge | **1/13**, twelve conflicts |

Only `src/` changed between the two, so only `assets/index-*.js` got a new content hash and a new URL — that's the single upload that succeeded. The eleven vendor chunks hash off `node_modules` alone, kept their filenames, and conflicted. **Left as-is this would fail every future deploy that doesn't bump a dependency**, which is most of them.

## Why 409 is not an error here

Asset URLs are content-hashed, so an entry already registered for a given URL was produced from identical bytes and already maps that exact file. Re-uploading is a no-op; the existing map is correct. It's the normal steady state, not a failure.

## Changes

- 409 → `alreadyPresent`, reported separately in the job summary, doesn't affect the exit code.
- Stop retrying non-retryable statuses. Each of the twelve conflicts previously burned three attempts with identical results; retries are now limited to 429, 5xx, and network errors with no status. A 401 now fails fast instead of retrying three times.
- Error strings include the status code. superagent builds bare messages from `http.STATUS_CODES` (hence a message of just `"Conflict"`) and puts the code on `err.status`.

Verified the classification against the real error shapes:

```
409 Conflict   status=409        -> ALREADY PRESENT (ok, no retry)
401 Auth       status=401        -> FAIL fast (no retry)
network        status=undefined  -> RETRY
503            status=503        -> RETRY
```

Dry run against live prod: **13/13 verified, exit 0**. Lint clean.

## Note on using the package CLI directly

`@newrelic/publish-sourcemap` is already the dependency doing every upload (`scripts/publish-sourcemaps.mjs:24`). Its bundled CLI isn't a substitute for the wrapper: it takes one file per invocation, and — verified — **exits 0 even on a 401**, because its callback only logs:

```js
publishSourcemap(options, (err) => {
  if (err) { console.log('Status Code', err.status); console.log(err.response.text) }
})   // no process.exit(1)
```

A shell loop over the CLI would make these conflicts stop failing the build only because *nothing* would ever fail it, and it would also drop the check that each `javascriptUrl` actually exists on the deployed site — the safety net for CI rebuilding a commit that Cloudflare built independently.