### PR TITLE
Add manual role assignment interface

### DIFF
--- a/src/components/TeamTimer.jsx
+++ b/src/components/TeamTimer.jsx
@@ -1,6 +1,28 @@
 
 import moment from 'moment/moment';
 
+function getInteractiveProps(editable, handleShow, team) {
+    if (!editable) return {};
+
+    const openTeam = (event) => {
+        if (event.type === "keydown" && event.key !== "Enter" && event.key !== " ") return;
+        if (event.type === "keydown") event.preventDefault();
+        handleShow(team, event);
+    };
+
+    return {
+        onClick: openTeam,
+        onKeyDown: openTeam,
+        role: "button",
+        tabIndex: 0,
+    };
+}
+
+function getVisitStatus(lastVisitAt, stale) {
+    if (lastVisitAt) return moment(lastVisitAt).fromNow();
+    if (stale) return <b><i>Needs review!</i></b>;
+    return "No recent visit.";
+}
 
 const TeamTimer = ({ team, lastVisit, monthsWarning, handleShow, currentTime, editable = true }) => {
 
@@ -18,15 +40,14 @@ const TeamTimer = ({ team, lastVisit, monthsWarning, handleShow, currentTime, ed
         return updateDelay
     }
 
-    const openTeam = (event) => {
-        if (!editable) return;
-        if (event.type === "keydown" && event.key !== "Enter" && event.key !== " ") return;
-        if (event.type === "keydown") event.preventDefault();
-        handleShow(team, event);
-    };
+    const teamNumber = team?.teamNumber;
+    const lastVisitAt = lastVisit[`${teamNumber}`];
+    const stale = updateWarning(team?.updates?.lastUpdate);
+    const interactiveProps = getInteractiveProps(editable, handleShow, team);
+    const className = `${editable ? "teamNumberButton " : ""}${lastVisitAt ? "teamTableButtonHighlight" : ""}${stale ? " staleTeam" : ""}`;
 
     return (
-        <td className={`${editable ? "teamNumberButton " : ""}${lastVisit[`${team?.teamNumber}`] ? "teamTableButtonHighlight" : ""}${updateWarning(team?.updates?.lastUpdate) ? " staleTeam" : ""}`} onClick={editable ? openTeam : undefined} onKeyDown={editable ? openTeam : undefined} role={editable ? "button" : undefined} tabIndex={editable ? 0 : undefined} key={"teamData" + team?.teamNumber}><span className={"teamDataNumber"}>{team?.displayTeamNumber || team?.teamNumber}</span><br />{lastVisit[`${team?.teamNumber}`] ? moment(lastVisit[`${team?.teamNumber}`]).fromNow() : updateWarning(team?.updates?.lastUpdate) ? <b><i>Needs review!</i></b> : "No recent visit."}</td>
+        <td className={className} {...interactiveProps} key={"teamData" + teamNumber}><span className={"teamDataNumber"}>{team?.displayTeamNumber || teamNumber}</span><br />{getVisitStatus(lastVisitAt, stale)}</td>
     );
 };
 

--- a/src/components/TeamTimer.jsx
+++ b/src/components/TeamTimer.jsx
@@ -2,7 +2,7 @@
 import moment from 'moment/moment';
 
 
-const TeamTimer = ({ team, lastVisit, monthsWarning, handleShow, currentTime }) => {
+const TeamTimer = ({ team, lastVisit, monthsWarning, handleShow, currentTime, editable = true }) => {
 
     /**
      * /Display a warning on the Team Data screen if the data is over 6 months old
@@ -18,8 +18,15 @@ const TeamTimer = ({ team, lastVisit, monthsWarning, handleShow, currentTime }) 
         return updateDelay
     }
 
+    const openTeam = (event) => {
+        if (!editable) return;
+        if (event.type === "keydown" && event.key !== "Enter" && event.key !== " ") return;
+        if (event.type === "keydown") event.preventDefault();
+        handleShow(team, event);
+    };
+
     return (
-        <td className={`teamNumberButton ${lastVisit[`${team?.teamNumber}`] ? "teamTableButtonHighlight" : ""}${updateWarning(team?.updates?.lastUpdate) ? " staleTeam" : ""}`} onClick={(e) => handleShow(team, e)} key={"teamData" + team?.teamNumber}><span className={"teamDataNumber"}>{team?.displayTeamNumber || team?.teamNumber}</span><br />{lastVisit[`${team?.teamNumber}`] ? moment(lastVisit[`${team?.teamNumber}`]).fromNow() : updateWarning(team?.updates?.lastUpdate) ? <b><i>Needs review!</i></b> : "No recent visit."}</td>
+        <td className={`${editable ? "teamNumberButton " : ""}${lastVisit[`${team?.teamNumber}`] ? "teamTableButtonHighlight" : ""}${updateWarning(team?.updates?.lastUpdate) ? " staleTeam" : ""}`} onClick={editable ? openTeam : undefined} onKeyDown={editable ? openTeam : undefined} role={editable ? "button" : undefined} tabIndex={editable ? 0 : undefined} key={"teamData" + team?.teamNumber}><span className={"teamDataNumber"}>{team?.displayTeamNumber || team?.teamNumber}</span><br />{lastVisit[`${team?.teamNumber}`] ? moment(lastVisit[`${team?.teamNumber}`]).fromNow() : updateWarning(team?.updates?.lastUpdate) ? <b><i>Needs review!</i></b> : "No recent visit."}</td>
     );
 };
 

--- a/src/pages/Developer.jsx
+++ b/src/pages/Developer.jsx
@@ -1,6 +1,6 @@
 import { useAuth } from "../contextProviders/AuthProvider";
 import { useEffect, useState } from "react";
-import { read, utils } from "xlsx";
+import Select from "react-select";
 import {
   Alert,
   Button,
@@ -15,6 +15,27 @@ import moment from "moment";
 import _ from "lodash";
 import { toast } from "react-toastify";
 import NotificationBanner from "components/NotificationBanner";
+import { UseAuthClient } from "../contextProviders/AuthClientContext";
+
+const BASE_ROLES = [
+  { name: "user", label: "User", description: "Base application access" },
+  { name: "admin", label: "Admin", description: "System administrator access" },
+];
+const MIN_USER_QUERY_LENGTH = 2;
+const USER_SEARCH_DEBOUNCE_MS = 300;
+
+async function fetchUsers(httpClient, query, signal) {
+  const response = await httpClient.get(
+    `system/users?query=${encodeURIComponent(query)}&limit=20`,
+    30000,
+    signal
+  );
+  if (response?._aborted) return null;
+  if (response?.status !== 200 || typeof response.json !== "function") {
+    throw new Error(response?.statusText || "Could not load users");
+  }
+  return response.json();
+}
 
 function Developer({
   putNotifications,
@@ -27,10 +48,20 @@ function Developer({
   getUserPrefs,
 }) {
   const { user, getAccessToken } = useAuth();
+  const [httpClient] = UseAuthClient();
+  const isAdmin = user?.["https://gatool.org/roles"]?.includes("admin");
 
   const [token, setToken] = useState(null);
-  const [formattedUsers, setFormattedUsers] = useState(null);
-  const [loadedUsers, setLoadedUsers] = useState(null);
+  const [availableRoles, setAvailableRoles] = useState([]);
+  const [rolesLoading, setRolesLoading] = useState(false);
+  const [rolesError, setRolesError] = useState("");
+  const [userQuery, setUserQuery] = useState("");
+  const [userOptions, setUserOptions] = useState([]);
+  const [usersLoading, setUsersLoading] = useState(false);
+  const [usersError, setUsersError] = useState("");
+  const [selectedUser, setSelectedUser] = useState(null);
+  const [updatingRole, setUpdatingRole] = useState("");
+  const [roleResult, setRoleResult] = useState(null);
   const [formattedMessage, setFormattedMessage] = useState({
     message: "",
     expiry: moment(),
@@ -87,101 +118,110 @@ function Developer({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  /**
-   * This function clicks the hidden file upload button
-   * @function  clickLoadUsers
-   */
-  function clickLoadUsers() {
-    document.getElementById("userUpload").click();
-  }
-
-  /**
-   * This function clears the file input by removing and recreating the file input button
-   *
-   * @function clearFileInput
-   * @param {string} id - The ID to delete and recreate
-   */
-  function clearFileInput(id) {
-    const oldInput = document.getElementById(id);
-    const newInput = document.createElement("input");
-    newInput.type = "file";
-    newInput.id = oldInput.id;
-    // @ts-ignore
-    newInput.name = oldInput.name;
-    newInput.className = oldInput.className;
-    newInput.style.cssText = oldInput.style.cssText;
-    oldInput.parentNode.replaceChild(newInput, oldInput);
-  }
-
-  /**
-   * This function receives a file from the upload button and parses the user list from the CSV.
-   * It then returns formatted JSON, which is displayed to the user in a Text Area on screen.
-   * It also destroys and recreates the button, and then re-attaches the proper event listener.
-   *
-   * @function handleUserUpload
-   * @param {*} e - The file upload event, which contains a pointer to the file.
-   */
-  function handleUserUpload(e) {
-    let files = e.target.files;
-    let f = files[0];
-    let reader = new FileReader();
-    reader.onload = function (e) {
-      //@ts-ignore
-      const data = new Uint8Array(e.target.result);
-      let workbook;
-      try {
-        workbook = read(data, { type: "array" });
-        const worksheet = workbook.Sheets[workbook.SheetNames[0]];
-        const users = utils.sheet_to_json(worksheet);
-        let formattedUserList = [];
-        try {
-          if (users.length > 0) {
-            formattedUserList = users.map((user) => {
-              return {
-                user_id: user["Email Address"].toLowerCase(),
-                email: user["Email Address"],
-                email_verified: false,
-              };
-            });
-            setFormattedUsers(JSON.stringify(formattedUserList));
-            setLoadedUsers("success");
-          } else {
-            setFormattedUsers("No users in file");
-            setLoadedUsers("danger");
-          }
-        } catch (err) {
-          setFormattedUsers(err.message);
-          setLoadedUsers("danger");
+  useEffect(() => {
+    if (!isAdmin) return;
+    let active = true;
+    setRolesLoading(true);
+    setRolesError("");
+    httpClient
+      .get("system/roles")
+      .then(async (response) => {
+        if (response?.status !== 200 || typeof response.json !== "function") {
+          throw new Error(response?.statusText || "Could not load roles");
         }
-      } catch (err) {
-        setFormattedUsers(err.message);
-        setLoadedUsers("danger");
-      }
-      clearFileInput("userUpload");
-      document
-        .getElementById("userUpload")
-        .addEventListener("change", handleUserUpload);
+        const roles = await response.json();
+        if (active) setAvailableRoles(Array.isArray(roles) ? roles : []);
+      })
+      .catch(() => {
+        if (active) setRolesError("Could not load manageable roles.");
+      })
+      .finally(() => {
+        if (active) setRolesLoading(false);
+      });
+    return () => {
+      active = false;
     };
-    reader.readAsArrayBuffer(f);
-  }
+  }, [httpClient, isAdmin]);
 
-  /**
-   * This function creates a downloadable file from an object
-   * @function downloadObjectAsJson
-   * @param {string} exportName - The name of the file
-   * @param {Object} exportObj - The object you want to include in the file
-   */
-  function downloadObjectAsJson(exportObj, exportName) {
-    const dataStr =
-      "data:text/json;charset=utf-8," +
-      encodeURIComponent(JSON.stringify(exportObj));
-    const downloadAnchorNode = document.createElement("a");
-    downloadAnchorNode.setAttribute("href", dataStr);
-    downloadAnchorNode.setAttribute("download", exportName + ".json");
-    document.body.appendChild(downloadAnchorNode); // required for firefox
-    downloadAnchorNode.click();
-    downloadAnchorNode.remove();
-  }
+  useEffect(() => {
+    const query = userQuery.trim();
+    if (query.length < MIN_USER_QUERY_LENGTH) {
+      setUserOptions([]);
+      setUsersError("");
+      setUsersLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeout = window.setTimeout(async () => {
+      setUsersLoading(true);
+      setUsersError("");
+      try {
+        const users = await fetchUsers(httpClient, query, controller.signal);
+        if (users) {
+          setUserOptions(
+            users.map((entry) => ({
+              value: entry.email,
+              label: entry.email,
+              user: entry,
+            }))
+          );
+        }
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          setUserOptions([]);
+          setUsersError("Could not load users.");
+        }
+      } finally {
+        if (!controller.signal.aborted) setUsersLoading(false);
+      }
+    }, USER_SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(timeout);
+      controller.abort();
+    };
+  }, [httpClient, userQuery]);
+
+  const handleRoleChange = async (role, granted) => {
+    if (!selectedUser) return;
+    const email = selectedUser.email;
+    const path = `system/users/${encodeURIComponent(email)}/roles/${encodeURIComponent(role.name)}`;
+    setUpdatingRole(role.name);
+    setRoleResult(null);
+    try {
+      const response = granted
+        ? await httpClient.put(path)
+        : await httpClient.delete(path);
+      if (response?.status < 200 || response?.status >= 300) {
+        throw new Error(response?.statusText || "Could not update role");
+      }
+
+      const updatedUser = response.status === 200 && typeof response.json === "function"
+        ? await response.json()
+        : (await fetchUsers(httpClient, email))?.find(
+            (entry) => entry.email.toLowerCase() === email.toLowerCase()
+          );
+      if (!updatedUser) throw new Error("Updated user could not be reloaded");
+      setSelectedUser(updatedUser);
+      setUserOptions((options) =>
+        options.map((option) =>
+          option.value === email ? { ...option, user: updatedUser } : option
+        )
+      );
+      setRoleResult({
+        variant: "success",
+        message: `${role.label || role.name} ${granted ? "granted" : "revoked"}.`,
+      });
+    } catch (error) {
+      setRoleResult({
+        variant: "danger",
+        message: error.message || "Could not update role.",
+      });
+    } finally {
+      setUpdatingRole("");
+    }
+  };
 
   /**
    * This function handles setting parts of the form value
@@ -289,7 +329,7 @@ function Developer({
   return (
     <>
       <br />
-      {user?.["https://gatool.org/roles"]?.indexOf("admin") >= 0 ? (
+      {isAdmin ? (
         <Tabs defaultActiveKey="tools" id="dev-tools-tabs" className="mb-3">
           <Tab eventKey="tools" title="Dev Tools">
             <Container>
@@ -395,59 +435,100 @@ function Developer({
                 </div>
               )}
               <br />
-              <div>
-                <input
-                  type="file"
-                  id="userUpload"
-                  onChange={handleUserUpload}
-                  className={"hiddenInput"}
+              <h3>Role Editor</h3>
+              <Form.Group className="mb-3" controlId="user-role-search">
+                <Form.Label>User email</Form.Label>
+                <Select
+                  aria-label="User email"
+                  inputValue={userQuery}
+                  value={
+                    selectedUser
+                      ? {
+                          value: selectedUser.email,
+                          label: selectedUser.email,
+                          user: selectedUser,
+                        }
+                      : null
+                  }
+                  options={userOptions}
+                  isLoading={usersLoading}
+                  isDisabled={Boolean(updatingRole)}
+                  isClearable
+                  filterOption={null}
+                  onInputChange={(value, action) => {
+                    if (action.action === "input-change") {
+                      setUserQuery(value);
+                      setSelectedUser(null);
+                      setRoleResult(null);
+                    }
+                  }}
+                  onChange={(option) => {
+                    setSelectedUser(option?.user || null);
+                    setUserQuery("");
+                    setRoleResult(null);
+                  }}
+                  placeholder="Type at least 2 characters"
+                  noOptionsMessage={() => {
+                    if (usersError) return usersError;
+                    if (userQuery.trim().length < MIN_USER_QUERY_LENGTH) {
+                      return "Type at least 2 characters";
+                    }
+                    return "No users found";
+                  }}
+                  loadingMessage={() => "Searching users..."}
                 />
-              </div>
+              </Form.Group>
 
-              <Button style={{ cursor: "pointer" }} onClick={clickLoadUsers}>
-                <img
-                  style={{ float: "left" }}
-                  width="50"
-                  src="images/excelicon.png"
-                  alt="Excel Logo"
-                />
-                {loadedUsers ? (
-                  <>Load new user list</>
-                ) : (
-                  <>Load user list from Mailchimp</>
-                )}
-              </Button>
-              <div>
-                <Form.Control
-                  as="textarea"
-                  rows={3}
-                  value={formattedUsers ? formattedUsers : ""}
-                  readOnly
-                />
-                {loadedUsers && (
-                  <Button
-                    variant={loadedUsers ? loadedUsers : "primary"}
-                    onClick={() => {
-                      if (loadedUsers !== "danger") {
-                        navigator.clipboard.writeText(formattedUsers);
-                        downloadObjectAsJson(
-                          JSON.parse(formattedUsers),
-                          "GatoolUsers" + moment().format("MMDDYYYY_HHmmss")
-                        );
-                        setLoadedUsers("info");
-                      }
-                    }}
-                  >
-                    {loadedUsers === "info" ? (
-                      <>Users have been downloaded</>
-                    ) : loadedUsers === "danger" ? (
-                      <>Error in file</>
-                    ) : (
-                      <>Download users to JSON file</>
-                    )}
-                  </Button>
-                )}
-              </div>
+              {selectedUser && (
+                <div className="mb-3">
+                  <h4>{selectedUser.email}</h4>
+                  <p className="text-muted mb-2">
+                    Created: {selectedUser.createdAt ? moment(selectedUser.createdAt).format("MMM D, YYYY, h:mm a") : "Unknown"}
+                    {" | "}
+                    Last login: {selectedUser.lastLoginAt ? moment(selectedUser.lastLoginAt).format("MMM D, YYYY, h:mm a") : "Never"}
+                  </p>
+                  <p className="mb-2">
+                    Assigned roles: {selectedUser.roles?.length ? selectedUser.roles.join(", ") : "None"}
+                  </p>
+
+                  {BASE_ROLES.map((role) => (
+                    <Form.Check
+                      key={role.name}
+                      id={`user-role-${role.name}`}
+                      type="checkbox"
+                      className="mb-2"
+                      label={`${role.label} - ${role.description}`}
+                      checked={selectedUser.roles?.includes(role.name) || false}
+                      disabled
+                      readOnly
+                    />
+                  ))}
+
+                  {rolesLoading && <p>Loading manageable roles...</p>}
+                  {rolesError && <Alert variant="danger">{rolesError}</Alert>}
+                  {availableRoles
+                    .filter((role) => !BASE_ROLES.some((baseRole) => baseRole.name === role.name))
+                    .map((role) => (
+                      <Form.Check
+                        key={role.name}
+                        id={`user-role-${role.name}`}
+                        type="checkbox"
+                        className="mb-2"
+                        label={`${role.label || role.name}${role.description ? ` - ${role.description}` : ""}`}
+                        checked={selectedUser.roles?.includes(role.name) || false}
+                        disabled={Boolean(updatingRole)}
+                        onChange={(event) => handleRoleChange(role, event.target.checked)}
+                      />
+                    ))}
+
+                  {updatingRole && <p>Updating role...</p>}
+                  {roleResult && (
+                    <Alert className="mt-3" variant={roleResult.variant}>
+                      {roleResult.message}
+                    </Alert>
+                  )}
+                </div>
+              )}
             </Container>
           </Tab>
           <Tab eventKey="notifications" title="Notifications">

--- a/src/pages/Developer.test.jsx
+++ b/src/pages/Developer.test.jsx
@@ -1,0 +1,171 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Developer from "./Developer";
+
+const { useAuthMock, useAuthClientMock } = vi.hoisted(() => ({
+  useAuthMock: vi.fn(),
+  useAuthClientMock: vi.fn(),
+}));
+
+vi.mock("../contextProviders/AuthProvider", () => ({
+  useAuth: useAuthMock,
+}));
+vi.mock("../contextProviders/AuthClientContext", () => ({
+  UseAuthClient: useAuthClientMock,
+}));
+vi.mock("components/NotificationBanner", () => ({ default: () => null }));
+vi.mock("react-select", () => ({
+  default: ({ options, inputValue, onChange, onInputChange, ...props }) => (
+    <div>
+      <input
+        aria-label={props["aria-label"]}
+        value={inputValue}
+        onChange={(event) =>
+          onInputChange(event.target.value, { action: "input-change" })
+        }
+      />
+      {options.map((option) => (
+        <button key={option.value} onClick={() => onChange(option)}>
+          {option.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+function response(status, data) {
+  return {
+    status,
+    statusText: status === 204 ? "No Content" : "OK",
+    json: vi.fn(async () => data),
+  };
+}
+
+function developerProps(overrides = {}) {
+  return {
+    putNotifications: vi.fn(),
+    getNotifications: vi.fn(),
+    getSyncStatus: vi.fn(async () => ({
+      lastUpdated: "2026-07-26T12:00:00Z",
+      totalEvents: 4,
+      subscribes: 2,
+      unsubscribes: 1,
+      profileUpdates: 1,
+      cleaned: 0,
+      recentEvents: [],
+    })),
+    systemBell: false,
+    setSystemBell: vi.fn(),
+    resetCache: vi.fn(),
+    putUserPrefs: vi.fn(),
+    getUserPrefs: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("Developer user role editor", () => {
+  let httpClient;
+  let eventRoleGranted;
+
+  beforeEach(() => {
+    eventRoleGranted = false;
+    useAuthMock.mockReturnValue({
+      user: { "https://gatool.org/roles": ["admin"] },
+      getAccessToken: vi.fn(async () => "token"),
+    });
+    httpClient = {
+      get: vi.fn(async (path) => {
+        if (path === "system/roles") {
+          return response(200, [
+            {
+              name: "firstglobal-write",
+              label: "FIRST Global Write",
+              description: "Create and update shared FIRST Global team data",
+            },
+          ]);
+        }
+        if (path.startsWith("system/users?")) {
+          return response(200, [
+            {
+              email: "person+test@example.com",
+              roles: eventRoleGranted ? ["user", "firstglobal-write"] : ["user"],
+              createdAt: "2026-01-01T00:00:00Z",
+              lastLoginAt: null,
+            },
+          ]);
+        }
+        throw new Error(`Unexpected GET ${path}`);
+      }),
+      put: vi.fn(async () => {
+        eventRoleGranted = true;
+        return response(200, {
+          email: "person+test@example.com",
+          roles: ["user", "firstglobal-write"],
+          createdAt: "2026-01-01T00:00:00Z",
+          lastLoginAt: null,
+        });
+      }),
+      delete: vi.fn(async () => {
+        eventRoleGranted = false;
+        return response(200, {
+          email: "person+test@example.com",
+          roles: ["user"],
+          createdAt: "2026-01-01T00:00:00Z",
+          lastLoginAt: null,
+        });
+      }),
+    };
+    useAuthClientMock.mockReturnValue([httpClient, 0]);
+  });
+
+  it("searches users and immediately grants only a backend role", async () => {
+    render(<Developer {...developerProps()} />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "User Management" }));
+    expect(await screen.findByText("Total events: 4")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("User email"), {
+      target: { value: "person+test" },
+    });
+
+    const userOption = await screen.findByRole("button", {
+      name: "person+test@example.com",
+    });
+    expect(httpClient.get).toHaveBeenCalledWith(
+      "system/users?query=person%2Btest&limit=20",
+      30000,
+      expect.any(AbortSignal)
+    );
+    fireEvent.click(userOption);
+
+    const userRole = screen.getByLabelText(/User - Base application access/);
+    const adminRole = screen.getByLabelText(/Admin - System administrator access/);
+    const eventRole = screen.getByLabelText(
+      /FIRST Global Write - Create and update shared FIRST Global team data/
+    );
+    expect(userRole).toBeDisabled();
+    expect(userRole).toBeChecked();
+    expect(adminRole).toBeDisabled();
+    expect(eventRole).not.toBeDisabled();
+    expect(eventRole).not.toBeChecked();
+
+    fireEvent.click(eventRole);
+
+    await waitFor(() => {
+      expect(httpClient.put).toHaveBeenCalledWith(
+        "system/users/person%2Btest%40example.com/roles/firstglobal-write"
+      );
+      expect(screen.getByText("FIRST Global Write granted.")).toBeInTheDocument();
+      expect(eventRole).toBeChecked();
+    });
+    fireEvent.click(eventRole);
+
+    await waitFor(() => {
+      expect(httpClient.delete).toHaveBeenCalledWith(
+        "system/users/person%2Btest%40example.com/roles/firstglobal-write"
+      );
+      expect(screen.getByText("FIRST Global Write revoked.")).toBeInTheDocument();
+      expect(eventRole).not.toBeChecked();
+    });
+  });
+});

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -18,6 +18,7 @@ import { ArrowClockwise, Trash, Copy, Plus, BellFill, CaretUpFill, CaretDownFill
 import NotificationBanner from "components/NotificationBanner";
 import { Link } from "react-router-dom";
 import { Range } from "react-range";
+import { canEditTeamData } from "../utils/roleAccess";
 
 
 const filterTime = [
@@ -161,6 +162,8 @@ function SetupPage({
         nonStandardPlayoffs, setNonStandardPlayoffs,
     } = useSettings();
     const isOnline = useOnlineStatus();
+    const firstGlobalMode = ftcMode?.value === "FIRSTGlobal";
+    const canEdit = canEditTeamData({ isAuthenticated, user, firstGlobalMode });
     const PWASupported = (isChrome && Number(browserVersion) >= 76) || (isSafari && Number(browserVersion) >= 15 && Number(fullBrowserVersion.split(".")[1]) >= 4);
 
     const [deleteSavedModal, setDeleteSavedModal] = useState(false);
@@ -231,6 +234,7 @@ function SetupPage({
     }
 
     const uploadLocalUpdates = async () => {
+        if (!canEdit) return;
         const localUpdatesTemp = _.cloneDeep(localUpdates);
         const results = await Promise.allSettled(
             localUpdatesTemp.map(async (update) => {
@@ -616,10 +620,15 @@ function SetupPage({
                         {teamList?.lastUpdate && <p><b>Team List last updated: </b><br />{moment(teamList?.lastUpdate).format("ddd, MMM Do YYYY, " + timeFormat.value)}{selectedEvent?.value?.type === "OffSeason" && <> <span className="data-source-badge">via TBA</span></>}</p>}
                         {rankings?.lastModified && <p><b>Rankings last updated: </b><br />{moment(rankings?.lastModified).format("ddd, MMM Do YYYY, " + timeFormat.value)}{rankings?.dataSource && <> <span className="data-source-badge">via {rankings.dataSource}</span></>}</p>}
                         {alliances?.lastUpdate && <p><b>Alliances last updated: </b><br />{moment(alliances?.lastUpdate).format("ddd, MMM Do YYYY, " + timeFormat.value)}{alliances?.dataSource && <> <span className="data-source-badge">via {alliances.dataSource}</span></>}</p>}
-                        {((isAuthenticated && user["https://gatool.org/roles"] && (user["https://gatool.org/roles"].indexOf("user") >= 0)) && localUpdates.length > 0) &&
+                        {(canEdit && localUpdates.length > 0) &&
                             <Alert>
                                 <p><b>You have {localUpdates.length === 1 ? "an update for team" : "updates for teams"} {_.sortBy(updatedTeamList).join(", ")} that can be uploaded to gatool Cloud.</b></p>
                                 <span><Button disabled={!isOnline} style={{ width: "45%" }} onClick={uploadLocalUpdates}>Upload to gatool Cloud now</Button>  <Button disabled={!isOnline} variant={"warning"} style={{ width: "50%" }} onClick={deleteLocalUpdates}>Delete stored updates</Button></span>
+                            </Alert>
+                        }
+                        {firstGlobalMode && !canEdit &&
+                            <Alert variant="secondary">
+                                <b>FIRST Global team data is read-only for this account.</b>{localUpdates.length > 0 && <> Existing local updates cannot be uploaded without FIRST Global write access.</>}
                             </Alert>
                         }
                         <Alert variant={"warning"}>

--- a/src/pages/SetupPage.test.jsx
+++ b/src/pages/SetupPage.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import SetupPage from "./SetupPage";
 
 vi.mock("contexts/EventDataContext", () => ({ useEventData: vi.fn() }));
@@ -188,6 +189,18 @@ function setupMocks(overrides = {}) {
   });
 }
 
+function setupFirstGlobalEvent() {
+  setupMocks({
+    selectedEvent: {
+      value: { code: "FG2026", name: "FIRST Global", type: "FIRSTGlobal" },
+      label: "FIRST Global",
+    },
+    eventLabel: "FIRST Global",
+    ftcMode: { value: "FIRSTGlobal", label: "FIRST Global" },
+    teamList: { teams: [] },
+  });
+}
+
 describe("SetupPage", () => {
   beforeEach(() => {
     setupMocks();
@@ -217,5 +230,56 @@ describe("SetupPage", () => {
     vi.mocked(useOnlineStatus).mockReturnValue(false);
     render(<SetupPage {...setupProps()} />);
     expect(screen.getByText(/you're offline/i)).toBeInTheDocument();
+  });
+
+  it("blocks queued FIRST Global uploads for a user without write access", () => {
+    setupFirstGlobalEvent();
+    const putTeamData = vi.fn();
+    render(<SetupPage {...setupProps({
+      isAuthenticated: true,
+      user: { "https://gatool.org/roles": ["user"] },
+      localUpdates: [{ teamNumber: 1, update: { robotNameLocal: "Bot" } }],
+      putTeamData,
+    })} />);
+
+    expect(screen.getByText(/FIRST Global team data is read-only/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /upload to gatool Cloud now/i })).not.toBeInTheDocument();
+    expect(putTeamData).not.toHaveBeenCalled();
+  });
+
+  it("uploads queued FIRST Global updates for a write-enabled user", async () => {
+    setupFirstGlobalEvent();
+    const putTeamData = vi.fn().mockResolvedValue({ status: 204 });
+    const setLocalUpdates = vi.fn();
+    render(<SetupPage {...setupProps({
+      isAuthenticated: true,
+      user: { "https://gatool.org/roles": ["user", "firstglobal-write"] },
+      localUpdates: [{ teamNumber: 1, update: { robotNameLocal: "Bot" } }],
+      putTeamData,
+      setLocalUpdates,
+    })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /upload to gatool Cloud now/i }));
+    await waitFor(() => expect(putTeamData).toHaveBeenCalledWith(1, { robotNameLocal: "Bot" }));
+    expect(setLocalUpdates).toHaveBeenCalledWith([]);
+  });
+
+  it("allows an admin to upload queued FIRST Global updates", async () => {
+    setupFirstGlobalEvent();
+    const putTeamData = vi.fn().mockResolvedValue({ status: 204 });
+    render(
+      <MemoryRouter>
+        <SetupPage {...setupProps({
+          isAuthenticated: true,
+          user: { "https://gatool.org/roles": ["admin"] },
+          localUpdates: [{ teamNumber: 1, update: { robotNameLocal: "Bot" } }],
+          putTeamData,
+        })} />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /upload to gatool Cloud now/i }));
+    await waitFor(() => expect(putTeamData).toHaveBeenCalled());
+    expect(screen.queryByText(/FIRST Global team data is read-only/i)).not.toBeInTheDocument();
   });
 });

--- a/src/pages/TeamDataPage.jsx
+++ b/src/pages/TeamDataPage.jsx
@@ -24,6 +24,7 @@ import { useSettings } from "../contexts/SettingsContext";
 import { useEventData } from "contexts/EventDataContext";
 import { useEventActions } from "contexts/EventActionsContext";
 import { getFirstGlobalFlagUrl } from "../utils/countryFlag";
+import { canEditTeamData } from "../utils/roleAccess";
 
 /** Blue banner stats are a nested object; SheetJS leaves those cells blank unless stringified. */
 const BLUE_BANNER_EXPORT_ROWS = [
@@ -92,6 +93,7 @@ function TeamDataPage({
     const [clockRunning, setClockRunning] = useState(true);
     const { disableScope, enableScope } = useHotkeysContext();
     const isOnline = useOnlineStatus();
+    const canEdit = canEditTeamData({ isAuthenticated, user, firstGlobalMode });
 
     // Remember scroll position for Teams page
     useScrollPosition('teams', true, false, useScrollMemory);
@@ -124,6 +126,17 @@ function TeamDataPage({
     const [showSaveToCloud, setShowSaveToCloud] = useState(false);
     const [teamsToReset, setTeamsToReset] = useState([]);
     const [resetNotes, setResetNotes] = useState(false);
+
+    useEffect(() => {
+        if (canEdit || (!show && !showHistory && !showResetConfirm && !showSaveToCloud)) return;
+        setUpdateTeam(null);
+        setShow(false);
+        setShowHistory(false);
+        setShowResetConfirm(false);
+        setShowSaveToCloud(false);
+        enableScope('tabNavigation');
+        setClockRunning(true);
+    }, [canEdit, enableScope, show, showHistory, showResetConfirm, showSaveToCloud]);
 
     const { start, stop } = useInterval(
         () => {
@@ -176,6 +189,7 @@ function TeamDataPage({
      * @param {string} mode - determines whether to send the update to gatool Cloud. "update" = send to cloud
      */
     const handleSubmit = async (mode, formValue) => {
+        if (!canEdit) return;
         var visits = _.cloneDeep(lastVisit);
         visits[`${updateTeam.teamNumber}`] = moment().format();
         var communityUpdatesTemp = _.cloneDeep(communityUpdates);
@@ -254,7 +268,7 @@ function TeamDataPage({
     }
 
     const handleRestoreData = async (data) => {
-        console.log(data);
+        if (!canEdit) return;
         var resp = await putTeamData(data.team.teamNumber, data.update);
         if (resp.status !== 204) {
             var errorText = `Your update for team ${data.team.teamNumber} was not successful.`;
@@ -275,7 +289,7 @@ function TeamDataPage({
      * @param {object} team - The team to display
      */
     const handleShow = (team) => {
-        if (isAuthenticated && user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("user") >= 0) {
+        if (canEdit) {
             setUpdateTeam(team);
             setShow(true);
             disableScope('tabNavigation');
@@ -284,7 +298,7 @@ function TeamDataPage({
     }
 
     const handleHistory = async (team) => {
-        if (isAuthenticated && user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("user") >= 0) {
+        if (canEdit) {
             var history = await getTeamHistory(team.teamNumber);
             setShowHistory(true);
             setTeamHistory(_.orderBy(history, ['modifiedDate'], ['desc']));
@@ -530,6 +544,7 @@ function TeamDataPage({
 
     // This function clicks the hidden file upload button
     function clickRestoreBackup() {
+        if (!canEdit) return;
         document.getElementById("BackupFiles").click();
     }
 
@@ -550,6 +565,7 @@ function TeamDataPage({
     // Excel file's content. The file must have been previously exported from gatool.
     // It will only update data that Game Announcers control in the Team Data page.
     function handleRestoreBackup(e) {
+        if (!canEdit) return;
         var files = e.target.files;
         var i, f, currentUpdate, newUpdate;
         for (i = 0; i !== files.length; ++i) {
@@ -697,6 +713,7 @@ function TeamDataPage({
      * Handles the reset button click - finds teams to reset and shows confirmation dialog
      */
     const handleResetClick = () => {
+        if (!canEdit) return;
         const teamsToResetList = findTeamsToReset();
         setTeamsToReset(teamsToResetList);
         setResetNotes(false); // Reset the checkbox to default
@@ -708,6 +725,7 @@ function TeamDataPage({
      * Handles the confirmation to proceed with reset
      */
     const handleResetProceed = async () => {
+        if (!canEdit) return;
         setShowResetConfirm(false);
 
         // Clone local updates and remove sponsor and robot name fields
@@ -798,6 +816,7 @@ function TeamDataPage({
      * Handles saving changes to gatool Cloud
      */
     const handleSaveToCloud = async () => {
+        if (!canEdit) return;
         setShowSaveToCloud(false);
         enableScope('tabNavigation');
 
@@ -911,7 +930,7 @@ function TeamDataPage({
             </div>}
             {selectedEvent && teamList?.teams.length > 0 && <><div>
                 <h4>{eventLabel || selectedEvent?.label}</h4>
-                <p className={"leftTable"}>This table is {(isAuthenticated && user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("user") >= 0) ? <>editable and sortable. Tap on a team number to change data for a specific team. Edits you make are local to this browser, and they will persist here if you do not clear your browser cache. You can save your changes to the gatool Cloud on the team details page or on the Setup Screen. </> : <>sortable. </>}Cells <span className={"teamTableHighlight"}>highlighted in green</span> have been modified, either by you or by other gatool users.</p>
+                <p className={"leftTable"}>This table is {canEdit ? <>editable and sortable. Tap on a team number to change data for a specific team. Edits you make are local to this browser, and they will persist here if you do not clear your browser cache. You can save your changes to the gatool Cloud on the team details page or on the Setup Screen. </> : <>sortable. </>}Cells <span className={"teamTableHighlight"}>highlighted in green</span> have been modified, either by you or by other gatool users. {firstGlobalMode && !canEdit && <><b>FIRST Global team data is read-only for this account.</b> Editing requires FIRST Global write access.</>}</p>
                 <Table responsive className={"leftTable topBorderLine"}>
                     <thead>
                         <tr>
@@ -921,7 +940,7 @@ function TeamDataPage({
                             <td>
                                 <span className="gatool-tap-link" onClick={downloadTeamInfoSheets}><img style={{ float: "left" }} width="30" src="images/wordicon.png" alt="Word Logo" /> <b>Tap here to download a merged document (docx).</b></span>
                             </td>
-                            {(isAuthenticated && user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("user") >= 0) && <td>
+                            {canEdit && <td>
                                 <span className="gatool-tap-link" onClick={clickRestoreBackup}><input type="file" id="BackupFiles" onChange={handleRestoreBackup} className={"hiddenInput"} /><b><img style={{ float: "left" }} width="30" src="images/excelicon.png" alt="Excel Logo" /> Tap here to restore team data from Excel</b></span>
                             </td>}
                         </tr>
@@ -935,13 +954,13 @@ function TeamDataPage({
                             <td>
                                 <p>This merged doc contains all of the information in your Teams List, merged onto a template you can print and distribute to teams. <i>Note: this will save to Files on iOS 13+</i></p>
                             </td>
-                            {(isAuthenticated && user["https://gatool.org/roles"] && user["https://gatool.org/roles"].indexOf("user") >= 0) && <td>
+                            {canEdit && <td>
                                 <p>You can export your teams data to Excel using the button on the left, and then restore it from backup here. This is handy in low or no network situations, where you may be unable to update changes to gatool Cloud. <i>Note: Be careful if you modify the Excel file and then import it here.</i></p>
                             </td>}
                         </tr>
                     </tbody>
                 </Table>
-                {isAuthenticated && <><Button variant="warning" size="sm" onClick={handleResetClick} style={{ marginRight: "10px" }}>Reset sponsors and robot names</Button>
+                {canEdit && <><Button variant="warning" size="sm" onClick={handleResetClick} style={{ marginRight: "10px" }}>Reset sponsors and robot names</Button>
                     <Button variant="success" size="sm" onClick={() => { clearVisits(false) }}>Reset visit times. Use at the start of each day.</Button><br /><br /></>}
 
                 <Table responsive striped bordered size="sm" className={"teamTable"}>
@@ -970,7 +989,7 @@ function TeamDataPage({
                             var teamName = team?.updates?.nameShortLocal ? team?.updates?.nameShortLocal : team?.nameShort;
 
                             return <tr key={`teamDataRow${team?.teamNumber}`}>
-                                <TeamTimer team={team} lastVisit={lastVisit} monthsWarning={monthsWarning} handleShow={handleShow} currentTime={currentTime} />
+                                <TeamTimer team={team} lastVisit={lastVisit} monthsWarning={monthsWarning} handleShow={handleShow} currentTime={currentTime} editable={canEdit} />
                                 <td style={rankHighlight(team?.rank ? team?.rank : 100, allianceCount || { "count": 8 })}>{team?.rank}</td>
                                 
                                 <td className={updateHighlightClass(team?.updates?.nameShortLocal)} style={updateHighlight(team?.updates?.nameShortLocal)}>
@@ -996,7 +1015,7 @@ function TeamDataPage({
                         })}
                     </tbody>
                 </Table>
-                {isAuthenticated && <Button variant="warning" size="sm" onClick={handleResetClick} style={{ marginRight: "10px" }}>Reset sponsors and robot names</Button>}
+                {canEdit && <Button variant="warning" size="sm" onClick={handleResetClick} style={{ marginRight: "10px" }}>Reset sponsors and robot names</Button>}
                 <Button variant="success" size="sm" onClick={() => { clearVisits(false) }}>Reset visit times. Use at the start of each day.</Button><br /><br /><br />
             </div></>}
             <Modal centered={true} show={showDownload} onHide={handleCloseDownload}>
@@ -1015,7 +1034,7 @@ function TeamDataPage({
             </Modal>
 
             <TeamEditModal
-                show={show}
+                show={show && canEdit}
                 onHide={handleClose}
                 updateTeam={updateTeam}
                 localUpdates={localUpdates}
@@ -1036,7 +1055,7 @@ function TeamDataPage({
             />
 
             <TeamHistoryModal
-                show={showHistory}
+                show={showHistory && canEdit}
                 onHide={handleCloseHistory}
                 updateTeam={updateTeam}
                 teamHistory={teamHistory}
@@ -1046,7 +1065,7 @@ function TeamDataPage({
                 onRestore={handleRestoreData}
             />
 
-            <Modal centered={true} show={showResetConfirm} onHide={handleResetCancel}>
+            <Modal centered={true} show={showResetConfirm && canEdit} onHide={handleResetCancel}>
                 <Modal.Header className={"allianceChoice"} closeVariant={"white"} closeButton>
                     <Modal.Title>Reset Sponsors and Robot Names</Modal.Title>
                 </Modal.Header>
@@ -1087,7 +1106,7 @@ function TeamDataPage({
                 </Modal.Footer>
             </Modal>
 
-            <Modal centered={true} show={showSaveToCloud} onHide={handleSaveToCloudCancel}>
+            <Modal centered={true} show={showSaveToCloud && canEdit} onHide={handleSaveToCloudCancel}>
                 <Modal.Header className={"allianceChoice"} closeVariant={"white"} closeButton>
                     <Modal.Title>Save Changes to gatool Cloud?</Modal.Title>
                 </Modal.Header>

--- a/src/pages/TeamDataPage.test.jsx
+++ b/src/pages/TeamDataPage.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import TeamDataPage from "./TeamDataPage";
 
 vi.mock("contexts/EventDataContext", () => ({ useEventData: vi.fn() }));
@@ -34,10 +34,21 @@ vi.mock("react-interval-hook", () => ({
 }));
 vi.mock("../components/TeamAvatar", () => ({ default: () => null }));
 vi.mock("components/TeamTimer", () => ({
-  default: ({ team }) => <td>{team?.teamNumber}</td>,
+  default: ({ team, handleShow, editable }) => (
+    <td onClick={editable ? () => handleShow(team) : undefined}>{team?.teamNumber}</td>
+  ),
 }));
-vi.mock("components/TeamEditModal", () => ({ default: () => null }));
-vi.mock("components/TeamHistoryModal", () => ({ default: () => null }));
+vi.mock("components/TeamEditModal", () => ({
+  default: ({ show, updateTeam, onHistory }) => show ? (
+    <div>
+      Team edit open
+      <button onClick={() => onHistory(updateTeam)}>Show team history</button>
+    </div>
+  ) : null,
+}));
+vi.mock("components/TeamHistoryModal", () => ({
+  default: ({ show }) => show ? <div>Team history open</div> : null,
+}));
 
 import { useEventData } from "contexts/EventDataContext";
 import { useEventActions } from "contexts/EventActionsContext";
@@ -75,6 +86,23 @@ function setupMocks(overrides = {}) {
     firstGlobalMode: false,
     remapNumberToString: (n) => String(n),
     ...overrides,
+  });
+}
+
+const testTeam = {
+  teamNumber: 254,
+  nameShort: "Poofs",
+  organization: "Bellarmine",
+  city: "San Jose",
+  stateProv: "CA",
+  country: "USA",
+};
+
+function setupFirstGlobal() {
+  setupMocks({
+    firstGlobalMode: true,
+    ftcMode: { value: "FIRSTGlobal", label: "FIRST Global" },
+    teamList: { teams: [testTeam] },
   });
 }
 
@@ -126,5 +154,50 @@ describe("TeamDataPage", () => {
     expect(screen.getByText("254")).toBeInTheDocument();
     expect(screen.getByText("Poofs")).toBeInTheDocument();
     expect(screen.getByText(/tap to download this table as excel/i)).toBeInTheDocument();
+  });
+
+  it("keeps FIRST Global data read-only for a user without write access", () => {
+    setupFirstGlobal();
+    render(<TeamDataPage {...teamDataProps({
+      isAuthenticated: true,
+      user: { "https://gatool.org/roles": ["user"] },
+    })} />);
+
+    expect(screen.getByText(/FIRST Global team data is read-only/i)).toBeInTheDocument();
+    expect(screen.getByText(/tap to download this table as excel/i)).toBeInTheDocument();
+    expect(screen.queryByText(/restore team data from Excel/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /reset sponsors and robot names/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText("254"));
+    expect(screen.queryByText("Team edit open")).not.toBeInTheDocument();
+  });
+
+  it("allows FIRST Global editing and history for a write-enabled user", async () => {
+    setupFirstGlobal();
+    const getTeamHistory = vi.fn().mockResolvedValue([]);
+    render(<TeamDataPage {...teamDataProps({
+      isAuthenticated: true,
+      user: { "https://gatool.org/roles": ["user", "firstglobal-write"] },
+      getTeamHistory,
+    })} />);
+
+    expect(screen.getByText(/restore team data from Excel/i)).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /reset sponsors and robot names/i })).toHaveLength(2);
+    fireEvent.click(screen.getByText("254"));
+    expect(screen.getByText("Team edit open")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /show team history/i }));
+    await waitFor(() => expect(getTeamHistory).toHaveBeenCalledWith(254));
+    expect(screen.getByText("Team history open")).toBeInTheDocument();
+  });
+
+  it("allows an admin to edit FIRST Global data without the write role", () => {
+    setupFirstGlobal();
+    render(<TeamDataPage {...teamDataProps({
+      isAuthenticated: true,
+      user: { "https://gatool.org/roles": ["admin"] },
+    })} />);
+
+    fireEvent.click(screen.getByText("254"));
+    expect(screen.getByText("Team edit open")).toBeInTheDocument();
+    expect(screen.queryByText(/FIRST Global team data is read-only/i)).not.toBeInTheDocument();
   });
 });

--- a/src/utils/roleAccess.js
+++ b/src/utils/roleAccess.js
@@ -1,0 +1,15 @@
+const ROLE_CLAIM = "https://gatool.org/roles";
+
+export function hasRole(user, role) {
+  const roles = user?.[ROLE_CLAIM];
+  return Array.isArray(roles) && roles.includes(role);
+}
+
+export function canEditTeamData({ isAuthenticated, user, firstGlobalMode }) {
+  if (!isAuthenticated) return false;
+  if (firstGlobalMode) {
+    return hasRole(user, "admin") ||
+      (hasRole(user, "user") && hasRole(user, "firstglobal-write"));
+  }
+  return hasRole(user, "user");
+}


### PR DESCRIPTION
## Summary
- replace the obsolete Mailchimp spreadsheet converter with an admin role editor
- add server-backed user autocomplete and backend-governed assignable roles
- enforce FIRST Global write access across editing, restores, imports, bulk updates, and queued uploads
- keep FIRST Global data read-only for users without the new role while allowing admin access

## Testing
- npm test -- --run (671 tests passed)
- npm run lint
- npx vite build